### PR TITLE
fix(pyinstaller): include QtSvg in packaged build to prevent Windows startup crash

### DIFF
--- a/Mouser.spec
+++ b/Mouser.spec
@@ -34,6 +34,7 @@ a = Analysis(
         "PySide6.QtQml",
         "PySide6.QtNetwork",
         "PySide6.QtOpenGL",
+        "PySide6.QtSvg",
     ],
     hookspath=[],
     hooksconfig={},
@@ -68,8 +69,6 @@ a = Analysis(
         "PySide6.QtRemoteObjects",
         "PySide6.QtScxml",
         "PySide6.QtSql",
-        "PySide6.QtSvg",
-        "PySide6.QtSvgWidgets",
         "PySide6.QtTextToSpeech",
         "PySide6.QtQuick3D",
         "PySide6.QtVirtualKeyboard",
@@ -123,7 +122,7 @@ _qt_keep = {
     "Qt6QuickTemplates2", "Qt6QuickLayouts", "Qt6QuickEffects",
     "Qt6QuickShapes",
     # Rendering
-    "Qt6ShaderTools",
+    "Qt6ShaderTools", "Qt6Svg",
     # PySide6 runtime
     "pyside6.abi3", "pyside6qml.abi3", "shiboken6.abi3",
     # VC runtime


### PR DESCRIPTION
## Summary
This fixes a packaging issue where the Windows build produced by:

`pyinstaller Mouser.spec --noconfirm`

could crash on startup with:

`ModuleNotFoundError: No module named 'PySide6.QtSvg'`

## Root cause
`main_qml.py` imports `QSvgRenderer` from `PySide6.QtSvg`, but `Mouser.spec` excluded QtSvg during packaging/size trimming.

## Changes
- Added `PySide6.QtSvg` to `hiddenimports`
- Removed `PySide6.QtSvg` and `PySide6.QtSvgWidgets` from `excludes`
- Added `Qt6Svg` to `_qt_keep`

## Why this is safe
- Keeps the existing slimming strategy intact
- Only restores the QtSvg pieces required by current runtime imports
- Does not change app behavior on macOS (which already uses SVG tray icon rendering)

## Related issue
Fixes TomBadash/Mouser#26