### PR TITLE
Add macOS app packaging, login-item support, tray-first behavior, and horizontal scroll desktop switching fixes

### DIFF
--- a/Mouser-mac.spec
+++ b/Mouser-mac.spec
@@ -1,0 +1,81 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for building a native macOS app bundle.
+
+Run from Apple Silicon Python on macOS:
+    python3 -m PyInstaller Mouser-mac.spec --noconfirm
+"""
+
+import os
+
+ROOT = os.path.abspath(".")
+MAC_ICON = os.path.join(ROOT, "build", "macos", "Mouser.icns")
+ICON_PATH = MAC_ICON if os.path.exists(MAC_ICON) else None
+BUNDLE_ID = "io.github.tombadash.mouser"
+
+a = Analysis(
+    ["main_qml.py"],
+    pathex=[ROOT],
+    binaries=[],
+    datas=[
+        (os.path.join(ROOT, "ui", "qml"), os.path.join("ui", "qml")),
+        (os.path.join(ROOT, "images"), "images"),
+    ],
+    hiddenimports=[
+        "hid",
+        "PySide6.QtQuick",
+        "PySide6.QtQuickControls2",
+        "PySide6.QtQml",
+        "PySide6.QtNetwork",
+        "PySide6.QtOpenGL",
+        "PySide6.QtSvg",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="Mouser",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    icon=ICON_PATH,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="Mouser",
+)
+
+app = BUNDLE(
+    coll,
+    name="Mouser.app",
+    icon=ICON_PATH,
+    bundle_identifier=BUNDLE_ID,
+    info_plist={
+        "CFBundleDisplayName": "Mouser",
+        "CFBundleName": "Mouser",
+        "CFBundleShortVersionString": "1.0.0",
+        "CFBundleVersion": "1.0.0",
+        "LSMinimumSystemVersion": "12.0",
+        "LSUIElement": True,
+        "NSHighResolutionCapable": True,
+    },
+)

--- a/build_macos_app.sh
+++ b/build_macos_app.sh
@@ -1,0 +1,38 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="$ROOT_DIR/build/macos"
+ICONSET_DIR="$BUILD_DIR/Mouser.iconset"
+ICON_PATH="$BUILD_DIR/Mouser.icns"
+SOURCE_ICON="$ROOT_DIR/images/logo_icon.png"
+export PYINSTALLER_CONFIG_DIR="$BUILD_DIR/pyinstaller"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This build script must be run on macOS."
+  exit 1
+fi
+
+mkdir -p "$BUILD_DIR"
+rm -rf "$ICONSET_DIR"
+mkdir -p "$ICONSET_DIR"
+
+for size in 16 32 128 256 512; do
+  sips -z "$size" "$size" "$SOURCE_ICON" --out "$ICONSET_DIR/icon_${size}x${size}.png" >/dev/null
+  double_size=$((size * 2))
+  sips -z "$double_size" "$double_size" "$SOURCE_ICON" --out "$ICONSET_DIR/icon_${size}x${size}@2x.png" >/dev/null
+done
+
+if ! iconutil -c icns "$ICONSET_DIR" -o "$ICON_PATH"; then
+  echo "warning: iconutil failed, continuing without a custom .icns icon"
+  rm -f "$ICON_PATH"
+fi
+
+python3 -m PyInstaller "$ROOT_DIR/Mouser-mac.spec" --noconfirm
+
+if command -v codesign >/dev/null 2>&1; then
+  codesign --force --deep --sign - "$ROOT_DIR/dist/Mouser.app"
+fi
+
+echo "Build complete: $ROOT_DIR/dist/Mouser.app"

--- a/core/autostart.py
+++ b/core/autostart.py
@@ -1,0 +1,96 @@
+"""
+macOS login item helpers.
+
+Uses a per-user LaunchAgent so Mouser can start automatically after login
+without requiring the user to launch Python from Terminal.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import sys
+from pathlib import Path
+
+APP_NAME = "Mouser"
+LAUNCH_AGENT_LABEL = "io.github.tombadash.mouser"
+
+
+def is_supported() -> bool:
+    return sys.platform == "darwin"
+
+
+def launch_agent_dir(home: str | Path | None = None) -> Path:
+    if home is None:
+        return Path.home() / "Library" / "LaunchAgents"
+    return Path(home) / "Library" / "LaunchAgents"
+
+
+def launch_agent_path(home: str | Path | None = None) -> Path:
+    return launch_agent_dir(home) / f"{LAUNCH_AGENT_LABEL}.plist"
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _current_program_arguments(start_hidden: bool = False) -> list[str]:
+    args: list[str]
+
+    if getattr(sys, "frozen", False):
+        args = [str(Path(sys.executable).resolve())]
+    else:
+        args = [
+            str(Path(sys.executable).resolve()),
+            str((_project_root() / "main_qml.py").resolve()),
+        ]
+
+    if start_hidden:
+        args.append("--start-hidden")
+    return args
+
+
+def build_launch_agent_payload(start_hidden: bool = False) -> dict:
+    program_arguments = _current_program_arguments(start_hidden=start_hidden)
+    if getattr(sys, "frozen", False):
+        working_dir = str(Path(program_arguments[0]).resolve().parent)
+    else:
+        working_dir = str(_project_root())
+
+    return {
+        "Label": LAUNCH_AGENT_LABEL,
+        "ProgramArguments": program_arguments,
+        "RunAtLoad": True,
+        "KeepAlive": False,
+        "ProcessType": "Interactive",
+        "WorkingDirectory": working_dir,
+        "LimitLoadToSessionType": ["Aqua"],
+    }
+
+
+def is_launch_at_login_enabled(home: str | Path | None = None) -> bool:
+    if not is_supported():
+        return False
+    return launch_agent_path(home).exists()
+
+
+def enable_launch_at_login(start_hidden: bool = False, home: str | Path | None = None) -> Path:
+    if not is_supported():
+        raise NotImplementedError("Launch at login is only implemented for macOS")
+
+    plist_path = launch_agent_path(home)
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = build_launch_agent_payload(start_hidden=start_hidden)
+
+    with plist_path.open("wb") as handle:
+        plistlib.dump(payload, handle, sort_keys=True)
+
+    return plist_path
+
+
+def disable_launch_at_login(home: str | Path | None = None) -> None:
+    if not is_supported():
+        raise NotImplementedError("Launch at login is only implemented for macOS")
+
+    plist_path = launch_agent_path(home)
+    if plist_path.exists():
+        plist_path.unlink()

--- a/core/config.py
+++ b/core/config.py
@@ -55,7 +55,7 @@ BUTTON_TO_EVENTS = {
 }
 
 DEFAULT_CONFIG = {
-    "version": 4,
+    "version": 5,
     "active_profile": "default",
     "profiles": {
         "default": {
@@ -77,7 +77,7 @@ DEFAULT_CONFIG = {
     },
     "settings": {
         "start_minimized": True,
-        "start_with_windows": False,
+        "start_at_login": False,
         "hscroll_threshold": 1,
         "invert_hscroll": False,  # swap horizontal scroll directions
         "invert_vscroll": False,  # swap vertical scroll directions
@@ -254,7 +254,19 @@ def _migrate(cfg):
         settings.setdefault("device_layout_overrides", {})
         cfg["version"] = 4
 
+    if version < 5:
+        settings = cfg.setdefault("settings", {})
+        if "start_at_login" not in settings:
+            settings["start_at_login"] = bool(
+                settings.get("start_with_windows", False)
+            )
+        cfg["version"] = 5
+
     cfg.setdefault("settings", {})
+    if "start_at_login" not in cfg["settings"]:
+        cfg["settings"]["start_at_login"] = bool(
+            cfg["settings"].get("start_with_windows", False)
+        )
     cfg["settings"].setdefault("appearance_mode", "system")
     cfg["settings"].setdefault("debug_mode", False)
     cfg["settings"].setdefault("device_layout_overrides", {})

--- a/core/engine.py
+++ b/core/engine.py
@@ -5,6 +5,7 @@ Supports per-application auto-switching of profiles.
 """
 
 import threading
+import time
 from core.mouse_hook import MouseHook, MouseEvent
 from core.key_simulator import ACTIONS, execute_action
 from core.config import (
@@ -13,6 +14,8 @@ from core.config import (
 )
 from core.app_detector import AppDetector
 from core.logi_devices import clamp_dpi
+
+HSCROLL_ACTION_COOLDOWN_S = 0.35
 
 
 class Engine:
@@ -27,6 +30,10 @@ class Engine:
         self.cfg = load_config()
         self._enabled = True
         self._hscroll_accum = 0
+        self._hscroll_state = {
+            MouseEvent.HSCROLL_LEFT: {"accum": 0.0, "last_fire_at": 0.0},
+            MouseEvent.HSCROLL_RIGHT: {"accum": 0.0, "last_fire_at": 0.0},
+        }
         self._current_profile: str = self.cfg.get("active_profile", "default")
         self._app_detector = AppDetector(self._on_app_change)
         self._profile_change_cb = None       # UI callback
@@ -112,6 +119,36 @@ class Engine:
         def handler(event):
             if not self._enabled:
                 return
+            state = self._hscroll_state.setdefault(
+                event.event_type,
+                {"accum": 0.0, "last_fire_at": 0.0},
+            )
+            raw_value = event.raw_data
+            if isinstance(raw_value, (int, float)):
+                step = abs(float(raw_value))
+                # Treat large wheel deltas as a single logical step while
+                # preserving sub-step deltas from macOS event tap scrolling.
+                if step >= 1.0:
+                    step = 1.0
+            else:
+                step = 1.0
+
+            threshold = max(
+                0.1,
+                float(self.cfg.get("settings", {}).get("hscroll_threshold", 1)),
+            )
+            now = getattr(event, "timestamp", None) or time.time()
+
+            if now - state["last_fire_at"] < HSCROLL_ACTION_COOLDOWN_S:
+                state["accum"] = 0.0
+                return
+
+            state["accum"] += step
+            if state["accum"] < threshold:
+                return
+
+            state["accum"] = 0.0
+            state["last_fire_at"] = now
             self._emit_debug(
                 f"Mapped {event.event_type} -> {action_id} "
                 f"({self._action_label(action_id)})"
@@ -249,6 +286,11 @@ class Engine:
     def set_connection_change_callback(self, cb):
         """Register ``cb(connected: bool)`` invoked on device connect/disconnect."""
         self._connection_change_cb = cb
+        if cb:
+            try:
+                cb(bool(self.hook.device_connected))
+            except Exception:
+                pass
 
     @property
     def device_connected(self):

--- a/core/key_simulator.py
+++ b/core/key_simulator.py
@@ -241,6 +241,16 @@ if sys.platform == "win32":
             "keys": [VK_LWIN, VK_TAB],
             "category": "Navigation",
         },
+        "space_left": {
+            "label": "Previous Desktop",
+            "keys": [VK_CONTROL, VK_LWIN, VK_LEFT],
+            "category": "Navigation",
+        },
+        "space_right": {
+            "label": "Next Desktop",
+            "keys": [VK_CONTROL, VK_LWIN, VK_RIGHT],
+            "category": "Navigation",
+        },
         "volume_up": {
             "label": "Volume Up",
             "keys": [VK_VOLUME_UP],
@@ -607,12 +617,12 @@ elif sys.platform == "darwin":
             "category": "Navigation",
         },
         "space_left": {
-            "label": "Previous Space",
+            "label": "Previous Desktop",
             "keys": _MAC_ACTION_FALLBACKS["space_left"],
             "category": "Navigation",
         },
         "space_right": {
-            "label": "Next Space",
+            "label": "Next Desktop",
             "keys": _MAC_ACTION_FALLBACKS["space_right"],
             "category": "Navigation",
         },

--- a/main_qml.py
+++ b/main_qml.py
@@ -16,8 +16,7 @@ from urllib.parse import parse_qs, unquote
 
 # Ensure project root on path — works for both normal Python and PyInstaller
 if getattr(sys, "frozen", False):
-    # PyInstaller 6.x: data files are in _internal/ next to the exe
-    ROOT = os.path.join(os.path.dirname(sys.executable), "_internal")
+    ROOT = getattr(sys, "_MEIPASS", os.path.dirname(sys.executable))
 else:
     ROOT = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, ROOT)
@@ -57,6 +56,7 @@ def _print_startup_times():
 def _parse_cli_args(argv):
     qt_argv = [argv[0]]
     hid_backend = None
+    start_hidden = False
     i = 1
     while i < len(argv):
         arg = argv[i]
@@ -70,15 +70,21 @@ def _parse_cli_args(argv):
             hid_backend = arg.split("=", 1)[1].strip().lower()
             i += 1
             continue
+        if arg == "--start-hidden":
+            start_hidden = True
+            i += 1
+            continue
         qt_argv.append(arg)
         i += 1
-    return qt_argv, hid_backend
+    return qt_argv, hid_backend, start_hidden
 
 
 def _app_icon() -> QIcon:
-    """Load the app icon from the pre-cropped .ico file."""
-    ico = os.path.join(ROOT, "images", "logo.ico")
-    return QIcon(ico)
+    """Load the app icon with a macOS-friendly fallback."""
+    icon_path = os.path.join(ROOT, "images", "logo.ico")
+    if sys.platform == "darwin":
+        icon_path = os.path.join(ROOT, "images", "logo_icon.png")
+    return QIcon(icon_path)
 
 
 def _render_svg_pixmap(path: str, color: QColor, size: int) -> QPixmap:
@@ -112,6 +118,28 @@ def _tray_icon() -> QIcon:
     icon = QIcon(_render_svg_pixmap(tray_svg, QColor("#000000"), 18))
     icon.setIsMask(True)
     return icon
+
+
+def _configure_macos_app_mode():
+    if sys.platform != "darwin":
+        return
+    try:
+        import AppKit
+        AppKit.NSApp.setActivationPolicy_(
+            AppKit.NSApplicationActivationPolicyAccessory
+        )
+    except Exception as exc:
+        print(f"[Mouser] Failed to configure macOS app mode: {exc}")
+
+
+def _activate_macos_window():
+    if sys.platform != "darwin":
+        return
+    try:
+        import AppKit
+        AppKit.NSApp.activateIgnoringOtherApps_(True)
+    except Exception as exc:
+        print(f"[Mouser] Failed to activate macOS window: {exc}")
 
 
 class UiState(QObject):
@@ -234,7 +262,7 @@ class SystemIconProvider(QQuickImageProvider):
 def main():
     _print_startup_times()
     _t5 = _time.perf_counter()
-    argv, hid_backend = _parse_cli_args(sys.argv)
+    argv, hid_backend, start_hidden = _parse_cli_args(sys.argv)
     if hid_backend:
         try:
             set_hid_backend_preference(hid_backend)
@@ -246,6 +274,8 @@ def main():
     app.setApplicationName("Mouser")
     app.setOrganizationName("Mouser")
     app.setWindowIcon(_app_icon())
+    app.setQuitOnLastWindowClosed(False)
+    _configure_macos_app_mode()
     ui_state = UiState(app)
 
     # macOS: allow Ctrl+C in terminal to quit the app
@@ -280,6 +310,7 @@ def main():
     qml_engine.addImageProvider("systemicons", SystemIconProvider())
     qml_engine.rootContext().setContextProperty("backend", backend)
     qml_engine.rootContext().setContextProperty("uiState", ui_state)
+    qml_engine.rootContext().setContextProperty("launchHidden", start_hidden)
     qml_engine.rootContext().setContextProperty(
         "applicationDirPath", ROOT.replace("\\", "/"))
 
@@ -292,6 +323,12 @@ def main():
         sys.exit(1)
 
     root_window = qml_engine.rootObjects()[0]
+
+    def show_main_window():
+        root_window.show()
+        root_window.raise_()
+        root_window.requestActivate()
+        _activate_macos_window()
 
     print(f"[Startup] QApp create:      {(_t6-_t5)*1000:7.1f} ms")
     print(f"[Startup] Engine create:    {(_t7-_t6)*1000:7.1f} ms")
@@ -312,11 +349,7 @@ def main():
     tray_menu = QMenu()
 
     open_action = QAction("Open Settings", tray_menu)
-    open_action.triggered.connect(lambda: (
-        root_window.show(),
-        root_window.raise_(),
-        root_window.requestActivate(),
-    ))
+    open_action.triggered.connect(show_main_window)
     tray_menu.addAction(open_action)
 
     toggle_action = QAction("Disable Remapping", tray_menu)
@@ -342,9 +375,7 @@ def main():
         backend.setDebugMode(not backend.debugMode)
         sync_debug_action()
         if backend.debugMode:
-            root_window.show()
-            root_window.raise_()
-            root_window.requestActivate()
+            show_main_window()
 
     debug_action.triggered.connect(toggle_debug_mode)
     tray_menu.addAction(debug_action)
@@ -365,9 +396,7 @@ def main():
 
     tray.setContextMenu(tray_menu)
     tray.activated.connect(lambda reason: (
-        root_window.show(),
-        root_window.raise_(),
-        root_window.requestActivate(),
+        show_main_window()
     ) if reason in (
         QSystemTrayIcon.ActivationReason.Trigger,
         QSystemTrayIcon.ActivationReason.DoubleClick,

--- a/readme_mac_osx.md
+++ b/readme_mac_osx.md
@@ -6,6 +6,7 @@ Mouser now supports macOS alongside Windows. This document covers macOS-specific
 
 - **macOS 12 (Monterey)** or later recommended
 - **Python 3.11+** (via Homebrew or python.org)
+- **Apple Silicon / M1**: use an `arm64` Python interpreter if you want a native `arm64` app bundle
 - **Accessibility permission** — required for CGEventTap to intercept mouse events
 
 ### Python Dependencies
@@ -71,6 +72,45 @@ so the mouse continues to function normally while Mouser reads HID++ reports.
 ```bash
 python main_qml.py
 ```
+
+## Building a Native macOS App
+
+The repository now includes a dedicated macOS bundle flow:
+
+```bash
+python3 -m pip install -r requirements.txt pyinstaller
+./build_macos_app.sh
+```
+
+This produces:
+
+```text
+dist/Mouser.app
+```
+
+Notes:
+
+- Build on the target architecture. On an M1/M2/M3 Mac, use an `arm64` Python to produce an Apple Silicon app.
+- The build script generates an `.icns` icon, runs PyInstaller with `Mouser-mac.spec`, and applies ad-hoc signing via `codesign --sign -`.
+- The app can then be moved to `/Applications/Mouser.app` and launched directly from Finder, Spotlight, or Dock.
+
+## Start at Login
+
+Mouser can now manage **Start at login** from the app UI on macOS.
+
+- The toggle writes a LaunchAgent plist to `~/Library/LaunchAgents/io.github.tombadash.mouser.plist`
+- If **Launch hidden after login** is enabled, the login item passes `--start-hidden` so Mouser starts in the menu bar without popping the settings window
+- The setting is designed for the packaged `.app`, but it also works in a source checkout by launching the current Python interpreter directly
+
+## Accessibility for the Packaged App
+
+If you switch from Terminal-based startup to `Mouser.app`, re-grant Accessibility for the app bundle:
+
+1. Open **System Settings → Privacy & Security → Accessibility**
+2. Remove old Terminal / Python entries if needed
+3. Add **Mouser.app**
+4. Ensure it is enabled
+5. Restart Mouser
 
 ## Debugging
 

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,0 +1,71 @@
+import plistlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from core import autostart
+
+
+class AutostartTests(unittest.TestCase):
+    def test_build_launch_agent_payload_for_source_mode(self):
+        fake_python = Path("/opt/homebrew/bin/python3")
+        fake_module = Path("/tmp/Mouser/core/autostart.py")
+
+        with (
+            patch.object(autostart.sys, "platform", "darwin"),
+            patch.object(autostart.sys, "frozen", False, create=True),
+            patch.object(autostart.sys, "executable", str(fake_python)),
+            patch.object(autostart, "__file__", str(fake_module)),
+        ):
+            payload = autostart.build_launch_agent_payload(start_hidden=True)
+
+        self.assertEqual(payload["Label"], autostart.LAUNCH_AGENT_LABEL)
+        self.assertEqual(payload["ProgramArguments"][0], str(fake_python))
+        self.assertEqual(
+            payload["ProgramArguments"][1],
+            str((fake_module.parent.parent / "main_qml.py").resolve()),
+        )
+        self.assertEqual(payload["ProgramArguments"][-1], "--start-hidden")
+        self.assertEqual(
+            payload["WorkingDirectory"],
+            str(fake_module.parent.parent.resolve()),
+        )
+        self.assertEqual(payload["LimitLoadToSessionType"], ["Aqua"])
+
+    def test_enable_launch_at_login_writes_plist(self):
+        fake_executable = "/Applications/Mouser.app/Contents/MacOS/Mouser"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.object(autostart.sys, "platform", "darwin"),
+                patch.object(autostart.sys, "frozen", True, create=True),
+                patch.object(autostart.sys, "executable", fake_executable),
+            ):
+                plist_path = autostart.enable_launch_at_login(
+                    start_hidden=True,
+                    home=temp_dir,
+                )
+
+            self.assertTrue(plist_path.exists())
+            with plist_path.open("rb") as handle:
+                payload = plistlib.load(handle)
+
+        self.assertEqual(payload["ProgramArguments"][0], fake_executable)
+        self.assertEqual(payload["ProgramArguments"][-1], "--start-hidden")
+        self.assertTrue(payload["RunAtLoad"])
+
+    def test_disable_launch_at_login_removes_plist(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plist_path = autostart.launch_agent_path(temp_dir)
+            plist_path.parent.mkdir(parents=True, exist_ok=True)
+            plist_path.write_text("placeholder", encoding="utf-8")
+
+            with patch.object(autostart.sys, "platform", "darwin"):
+                autostart.disable_launch_at_login(home=temp_dir)
+
+            self.assertFalse(plist_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,8 +30,9 @@ class ConfigMigrationTests(unittest.TestCase):
 
         migrated = config._migrate(legacy)
 
-        self.assertEqual(migrated["version"], 4)
+        self.assertEqual(migrated["version"], 5)
         self.assertEqual(migrated["profiles"]["default"]["apps"], [])
+        self.assertFalse(migrated["settings"]["start_at_login"])
         self.assertFalse(migrated["settings"]["invert_hscroll"])
         self.assertFalse(migrated["settings"]["invert_vscroll"])
         self.assertEqual(migrated["settings"]["dpi"], 1000)
@@ -68,6 +69,7 @@ class ConfigMigrationTests(unittest.TestCase):
             migrated["profiles"]["media"]["apps"],
             ["Microsoft.Media.Player.exe", "VLC.exe"],
         )
+        self.assertFalse(migrated["settings"]["start_at_login"])
         self.assertEqual(migrated["settings"]["appearance_mode"], "system")
         self.assertFalse(migrated["settings"]["debug_mode"])
         self.assertEqual(migrated["settings"]["device_layout_overrides"], {})
@@ -101,6 +103,7 @@ class ConfigMigrationTests(unittest.TestCase):
                 loaded = config.load_config()
 
         self.assertEqual(loaded["settings"]["dpi"], 800)
+        self.assertFalse(loaded["settings"]["start_at_login"])
         self.assertEqual(loaded["settings"]["gesture_threshold"], 50)
         self.assertEqual(loaded["settings"]["appearance_mode"], "system")
         self.assertFalse(loaded["settings"]["debug_mode"])
@@ -112,6 +115,18 @@ class ConfigMigrationTests(unittest.TestCase):
         self.assertEqual(
             loaded["profiles"]["default"]["mappings"]["gesture_left"], "none"
         )
+
+    def test_migrate_renames_start_with_windows_to_start_at_login(self):
+        legacy = {
+            "version": 4,
+            "profiles": {"default": {"apps": [], "mappings": {}}},
+            "settings": {"start_with_windows": True},
+        }
+
+        migrated = config._migrate(legacy)
+
+        self.assertEqual(migrated["version"], 5)
+        self.assertTrue(migrated["settings"]["start_at_login"])
 
     def test_get_profile_for_app_matches_aliases(self):
         cfg = {

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,116 @@
+import copy
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from core.config import DEFAULT_CONFIG
+from core.mouse_hook import MouseEvent
+
+
+class _FakeMouseHook:
+    def __init__(self):
+        self.invert_vscroll = False
+        self.invert_hscroll = False
+        self.debug_mode = False
+        self.connected_device = None
+        self.device_connected = False
+
+    def set_debug_callback(self, cb):
+        self._debug_callback = cb
+
+    def set_gesture_callback(self, cb):
+        self._gesture_callback = cb
+
+    def set_connection_change_callback(self, cb):
+        self._connection_change_callback = cb
+
+    def configure_gestures(self, **kwargs):
+        self._gesture_config = kwargs
+
+    def block(self, event_type):
+        pass
+
+    def register(self, event_type, callback):
+        pass
+
+    def reset_bindings(self):
+        pass
+
+
+class _FakeAppDetector:
+    def __init__(self, callback):
+        self.callback = callback
+
+
+class EngineHorizontalScrollTests(unittest.TestCase):
+    def _make_engine(self):
+        from core.engine import Engine
+
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["settings"]["hscroll_threshold"] = 1
+
+        with (
+            patch("core.engine.MouseHook", _FakeMouseHook),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=cfg),
+        ):
+            return Engine()
+
+    def test_hscroll_desktop_action_uses_cooldown(self):
+        engine = self._make_engine()
+        handler = engine._make_hscroll_handler("space_left")
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            handler(SimpleNamespace(
+                event_type=MouseEvent.HSCROLL_LEFT,
+                raw_data=1,
+                timestamp=1.00,
+            ))
+            handler(SimpleNamespace(
+                event_type=MouseEvent.HSCROLL_LEFT,
+                raw_data=1,
+                timestamp=1.05,
+            ))
+            handler(SimpleNamespace(
+                event_type=MouseEvent.HSCROLL_LEFT,
+                raw_data=1,
+                timestamp=1.45,
+            ))
+
+        self.assertEqual(execute_action_mock.call_count, 2)
+
+    def test_hscroll_accumulates_fractional_mac_deltas(self):
+        engine = self._make_engine()
+        handler = engine._make_hscroll_handler("space_right")
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            handler(SimpleNamespace(
+                event_type=MouseEvent.HSCROLL_RIGHT,
+                raw_data=0.35,
+                timestamp=2.00,
+            ))
+            handler(SimpleNamespace(
+                event_type=MouseEvent.HSCROLL_RIGHT,
+                raw_data=0.40,
+                timestamp=2.02,
+            ))
+            handler(SimpleNamespace(
+                event_type=MouseEvent.HSCROLL_RIGHT,
+                raw_data=0.30,
+                timestamp=2.04,
+            ))
+
+        self.assertEqual(execute_action_mock.call_count, 1)
+
+    def test_connection_callback_receives_current_state_immediately(self):
+        engine = self._make_engine()
+        engine.hook.device_connected = True
+
+        seen = []
+        engine.set_connection_change_callback(seen.append)
+
+        self.assertEqual(seen, [True])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_key_simulator.py
+++ b/tests/test_key_simulator.py
@@ -1,0 +1,17 @@
+import sys
+import unittest
+
+from core.key_simulator import ACTIONS
+
+
+class KeySimulatorActionTests(unittest.TestCase):
+    @unittest.skipUnless(sys.platform in ("darwin", "win32"), "desktop switching actions are platform-specific")
+    def test_desktop_switch_actions_exist(self):
+        self.assertIn("space_left", ACTIONS)
+        self.assertIn("space_right", ACTIONS)
+        self.assertEqual(ACTIONS["space_left"]["label"], "Previous Desktop")
+        self.assertEqual(ACTIONS["space_right"]["label"], "Next Desktop")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -10,6 +10,7 @@ import time
 
 from PySide6.QtCore import QObject, Property, Signal, Slot, Qt
 
+from core import autostart
 from core.config import (
     BUTTON_NAMES, load_config, save_config, get_active_mappings,
     PROFILE_BUTTON_NAMES, set_mapping, create_profile, delete_profile,
@@ -56,6 +57,7 @@ class Backend(QObject):
         super().__init__(parent)
         self._engine = engine
         self._cfg = load_config()
+        self._autostart_supported = autostart.is_supported()
         self._mouse_connected = False
         self._device_display_name = "Logitech mouse"
         self._connected_device_key = ""
@@ -105,9 +107,23 @@ class Backend(QObject):
                 engine.set_gesture_event_callback(self._onEngineGestureEvent)
             if hasattr(engine, "set_debug_enabled"):
                 engine.set_debug_enabled(self.debugMode)
+            self._mouse_connected = bool(getattr(engine, "device_connected", False))
+        self._sync_autostart_state()
         self._apply_device_layout(
-            getattr(engine, "connected_device", None) if engine else None
+            getattr(engine, "connected_device", None)
+            if engine and self._mouse_connected else None
         )
+
+    def _sync_autostart_state(self):
+        settings = self._cfg.setdefault("settings", {})
+        if not self._autostart_supported:
+            settings["start_at_login"] = False
+            return
+
+        enabled = autostart.is_launch_at_login_enabled()
+        if settings.get("start_at_login") != enabled:
+            settings["start_at_login"] = enabled
+            save_config(self._cfg)
 
     # ── Properties ─────────────────────────────────────────────
 
@@ -166,6 +182,18 @@ class Backend(QObject):
     @Property(int, notify=settingsChanged)
     def dpi(self):
         return self._cfg.get("settings", {}).get("dpi", 1000)
+
+    @Property(bool, notify=settingsChanged)
+    def startMinimized(self):
+        return bool(self._cfg.get("settings", {}).get("start_minimized", True))
+
+    @Property(bool, notify=settingsChanged)
+    def startAtLogin(self):
+        return bool(self._cfg.get("settings", {}).get("start_at_login", False))
+
+    @Property(bool, constant=True)
+    def supportsStartAtLogin(self):
+        return self._autostart_supported
 
     @Property(bool, notify=settingsChanged)
     def invertVScroll(self):
@@ -346,6 +374,56 @@ class Backend(QObject):
         self.profilesChanged.emit()
         self.mappingsChanged.emit()
         self.statusMessage.emit("Saved")
+
+    @Slot(bool)
+    def setStartMinimized(self, value):
+        enabled = bool(value)
+        settings = self._cfg.setdefault("settings", {})
+        if settings.get("start_minimized", True) == enabled:
+            return
+
+        settings["start_minimized"] = enabled
+        status_message = (
+            "Launch hidden after login enabled" if enabled
+            else "Launch hidden after login disabled"
+        )
+
+        if self._autostart_supported and self.startAtLogin:
+            try:
+                autostart.enable_launch_at_login(start_hidden=enabled)
+            except Exception as exc:
+                status_message = f"Updated setting, but login item refresh failed: {exc}"
+
+        save_config(self._cfg)
+        self.settingsChanged.emit()
+        self.statusMessage.emit(status_message)
+
+    @Slot(bool)
+    def setStartAtLogin(self, value):
+        enabled = bool(value)
+        if not self._autostart_supported:
+            self.statusMessage.emit("Start at login is only available on macOS")
+            return
+
+        try:
+            if enabled:
+                autostart.enable_launch_at_login(
+                    start_hidden=self.startMinimized
+                )
+            else:
+                autostart.disable_launch_at_login()
+        except Exception as exc:
+            self._sync_autostart_state()
+            self.settingsChanged.emit()
+            self.statusMessage.emit(f"Failed to update login item: {exc}")
+            return
+
+        self._cfg.setdefault("settings", {})["start_at_login"] = enabled
+        save_config(self._cfg)
+        self.settingsChanged.emit()
+        self.statusMessage.emit(
+            "Start at login enabled" if enabled else "Start at login disabled"
+        )
 
     @Slot(int)
     def setDpi(self, value):

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -6,7 +6,7 @@ import "Theme.js" as Theme
 
 ApplicationWindow {
     id: root
-    visible: true
+    visible: !launchHidden
     width: 1060
     height: 700
     minimumWidth: 920

--- a/ui/qml/ScrollPage.qml
+++ b/ui/qml/ScrollPage.qml
@@ -342,6 +342,121 @@ Item {
             Item { width: 1; height: 16 }
 
             Rectangle {
+                visible: backend.supportsStartAtLogin
+                width: parent.width - 72
+                anchors.horizontalCenter: parent.horizontalCenter
+                height: startupContent.implicitHeight + 40
+                radius: Theme.radius
+                color: scrollPage.theme.bgCard
+                border.width: 1
+                border.color: scrollPage.theme.border
+
+                Column {
+                    id: startupContent
+                    anchors {
+                        left: parent.left
+                        right: parent.right
+                        top: parent.top
+                        margins: 20
+                    }
+                    spacing: 12
+
+                    Text {
+                        text: "Startup"
+                        font {
+                            family: uiState.fontFamily
+                            pixelSize: 16
+                            bold: true
+                        }
+                        color: scrollPage.theme.textPrimary
+                    }
+
+                    Text {
+                        text: "Start Mouser automatically after login, and optionally keep the settings window hidden."
+                        font {
+                            family: uiState.fontFamily
+                            pixelSize: 12
+                        }
+                        color: scrollPage.theme.textSecondary
+                        wrapMode: Text.WordWrap
+                    }
+
+                    Rectangle {
+                        width: parent.width
+                        height: 52
+                        radius: 10
+                        color: scrollPage.theme.bgSubtle
+
+                        RowLayout {
+                            anchors {
+                                fill: parent
+                                leftMargin: 16
+                                rightMargin: 16
+                            }
+
+                            Text {
+                                text: "Start at login"
+                                font {
+                                    family: uiState.fontFamily
+                                    pixelSize: 13
+                                }
+                                color: scrollPage.theme.textPrimary
+                                Layout.fillWidth: true
+                            }
+
+                            Switch {
+                                id: startAtLoginSwitch
+                                checked: backend.startAtLogin
+                                Material.accent: scrollPage.theme.accent
+                                Accessible.name: "Start Mouser at login"
+                                onToggled: backend.setStartAtLogin(checked)
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        width: parent.width
+                        height: 52
+                        radius: 10
+                        color: scrollPage.theme.bgSubtle
+                        opacity: startAtLoginSwitch.checked ? 1 : 0.55
+
+                        RowLayout {
+                            anchors {
+                                fill: parent
+                                leftMargin: 16
+                                rightMargin: 16
+                            }
+
+                            Text {
+                                text: "Launch hidden after login"
+                                font {
+                                    family: uiState.fontFamily
+                                    pixelSize: 13
+                                }
+                                color: scrollPage.theme.textPrimary
+                                Layout.fillWidth: true
+                            }
+
+                            Switch {
+                                id: startMinimizedSwitch
+                                checked: backend.startMinimized
+                                enabled: startAtLoginSwitch.checked
+                                Material.accent: scrollPage.theme.accent
+                                Accessible.name: "Launch hidden after login"
+                                onToggled: backend.setStartMinimized(checked)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Item {
+                width: 1
+                height: backend.supportsStartAtLogin ? 16 : 0
+            }
+
+            Rectangle {
                 width: parent.width - 72
                 anchors.horizontalCenter: parent.horizontalCenter
                 height: scrollContent.implicitHeight + 40
@@ -503,6 +618,10 @@ Item {
             if (!dpiSlider.pressed) {
                 dpiSlider.value = backend.dpi
                 dpiLabel.text = backend.dpi + " DPI"
+            }
+            if (backend.supportsStartAtLogin) {
+                startAtLoginSwitch.checked = backend.startAtLogin
+                startMinimizedSwitch.checked = backend.startMinimized
             }
             vscrollSwitch.checked = backend.invertVScroll
             hscrollSwitch.checked = backend.invertHScroll


### PR DESCRIPTION
## Summary

This PR improves the macOS experience for Mouser and adds a more robust desktop-switching workflow for horizontal scroll mappings.

## Changes

- add a native macOS PyInstaller app bundle flow (`Mouser.app`)
- add macOS start-at-login support via LaunchAgent
- add hidden startup support for login launch
- switch macOS behavior to tray-first / Dock-less app mode
- add previous desktop / next desktop actions for horizontal scroll mappings
- fix horizontal scroll desktop switching so a single wheel gesture does not jump across many desktops
- harden connection-state synchronization between hook layer and UI
- add tests for autostart, horizontal scroll throttling, config migration, and desktop-switching actions
- expand macOS documentation for packaging and login behavior

## Verification

- `python3 -m unittest discover -s tests`
- built and verified a macOS `.app` bundle locally
