### PR TITLE
fix: add MX Master 4 device to known logi devices

### DIFF
--- a/core/logi_devices.py
+++ b/core/logi_devices.py
@@ -72,6 +72,18 @@ class ConnectedDeviceInfo:
 # Solaar/logiops for the major MX-family mice we want to grow into first.
 KNOWN_LOGI_DEVICES = (
     LogiDeviceSpec(
+        key="mx_master_4",
+        display_name="MX Master 4",
+        product_ids=(0xB042,),
+        aliases=(
+            "Logitech MX Master 4",
+            "MX Master 4 for Mac",
+            "MX_Master_4",
+            "MX Master 4 for Business",
+        ),
+        ui_layout="mx_master",
+    ),
+    LogiDeviceSpec(
         key="mx_master_3s",
         display_name="MX Master 3S",
         product_ids=(0xB034,),

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -9,6 +9,19 @@ from core.logi_devices import (
 
 
 class LogiDeviceRegistryTests(unittest.TestCase):
+    def test_resolve_mx_master_4_by_product_id(self):
+        device = resolve_device(product_id=0xB042)
+
+        self.assertIsNotNone(device)
+        self.assertEqual(device.key, "mx_master_4")
+        self.assertEqual(device.ui_layout, "mx_master")
+
+    def test_resolve_mx_master_4_by_hid_product_string(self):
+        device = resolve_device(product_name="MX_Master_4")
+
+        self.assertIsNotNone(device)
+        self.assertEqual(device.key, "mx_master_4")
+
     def test_resolve_device_by_product_id(self):
         device = resolve_device(product_id=0xB034)
 


### PR DESCRIPTION
## Summary

Registers the Logitech MX Master 4 in the known-device catalog so Mouser can resolve it by USB product ID and by common HID product strings, using the existing `mx_master` UI layout.

## Changes

- **`core/logi_devices.py`**: Add a `LogiDeviceSpec` for `mx_master_4` with product ID `0xB042`, aliases (including “MX Master 4 for Mac”, `MX_Master_4`, and “for Business”), and `ui_layout="mx_master"`.
- **`tests/test_logi_devices.py`**: Add unit tests that assert resolution by product ID and by HID-style product name.