### PR TITLE
feat: add Next Tab and Previous Tab browser actions

### DIFF
--- a/core/key_simulator.py
+++ b/core/key_simulator.py
@@ -244,6 +244,16 @@ if sys.platform == "win32":
             "keys": [VK_CONTROL, VK_S],
             "category": "Editing",
         },
+        "next_tab": {
+            "label": "Next Tab (Ctrl+Tab)",
+            "keys": [VK_CONTROL, VK_TAB],
+            "category": "Browser",
+        },
+        "prev_tab": {
+            "label": "Previous Tab (Ctrl+Shift+Tab)",
+            "keys": [VK_CONTROL, VK_SHIFT, VK_TAB],
+            "category": "Browser",
+        },
         "close_tab": {
             "label": "Close Tab (Ctrl+W)",
             "keys": [VK_CONTROL, VK_W],
@@ -612,6 +622,16 @@ elif sys.platform == "darwin":
             "label": "Save (Cmd+S)",
             "keys": [kVK_Command, kVK_ANSI_S],
             "category": "Editing",
+        },
+        "next_tab": {
+            "label": "Next Tab (Cmd+Shift+])",
+            "keys": [kVK_Command, kVK_Shift, 0x1E],  # kVK_ANSI_RightBracket
+            "category": "Browser",
+        },
+        "prev_tab": {
+            "label": "Previous Tab (Cmd+Shift+[)",
+            "keys": [kVK_Command, kVK_Shift, 0x21],  # kVK_ANSI_LeftBracket
+            "category": "Browser",
         },
         "close_tab": {
             "label": "Close Tab (Cmd+W)",

--- a/tests/test_key_simulator.py
+++ b/tests/test_key_simulator.py
@@ -12,6 +12,15 @@ class KeySimulatorActionTests(unittest.TestCase):
         self.assertEqual(ACTIONS["space_left"]["label"], "Previous Desktop")
         self.assertEqual(ACTIONS["space_right"]["label"], "Next Desktop")
 
+    @unittest.skipUnless(sys.platform in ("darwin", "win32"), "tab switching actions are platform-specific")
+    def test_tab_switch_actions_exist(self):
+        self.assertIn("next_tab", ACTIONS)
+        self.assertIn("prev_tab", ACTIONS)
+        self.assertEqual(ACTIONS["next_tab"]["category"], "Browser")
+        self.assertEqual(ACTIONS["prev_tab"]["category"], "Browser")
+        self.assertTrue(len(ACTIONS["next_tab"]["keys"]) > 0)
+        self.assertTrue(len(ACTIONS["prev_tab"]["keys"]) > 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `next_tab` and `prev_tab` actions to the Browser action category
- **Windows:** Ctrl+Tab / Ctrl+Shift+Tab
- **macOS:** Cmd+Shift+] / Cmd+Shift+[
- Allows users to map mouse buttons to switch between browser tabs
- Includes unit test for the new actions