### PR TITLE
fix: handle macOS gesture button in event tap

### DIFF
--- a/core/mouse_hook.py
+++ b/core/mouse_hook.py
@@ -915,6 +915,7 @@ elif sys.platform == "darwin":
     _BTN_MIDDLE = 2
     _BTN_BACK = 3
     _BTN_FORWARD = 4
+    _BTN_GESTURE = 6
     _SCROLL_INVERT_MARKER = 0x4D4F5553
 
     class MouseHook:
@@ -1333,6 +1334,9 @@ elif sys.platform == "darwin":
                     elif btn == _BTN_FORWARD:
                         mouse_event = MouseEvent(MouseEvent.XBUTTON2_DOWN)
                         should_block = MouseEvent.XBUTTON2_DOWN in self._blocked_events
+                    elif btn == _BTN_GESTURE:
+                        self._on_hid_gesture_down()
+                        should_block = True
 
                 elif event_type == Quartz.kCGEventOtherMouseUp:
                     btn = Quartz.CGEventGetIntegerValueField(
@@ -1351,6 +1355,9 @@ elif sys.platform == "darwin":
                     elif btn == _BTN_FORWARD:
                         mouse_event = MouseEvent(MouseEvent.XBUTTON2_UP)
                         should_block = MouseEvent.XBUTTON2_UP in self._blocked_events
+                    elif btn == _BTN_GESTURE:
+                        self._on_hid_gesture_up()
+                        should_block = True
 
                 elif event_type == Quartz.kCGEventScrollWheel:
                     if (

--- a/tests/test_mouse_hook.py
+++ b/tests/test_mouse_hook.py
@@ -40,5 +40,69 @@ class LinuxMouseHookReconnectTests(unittest.TestCase):
         self.assertFalse(hook._rescan_requested.is_set())
 
 
+class _FakeQuartz:
+    kCGEventMouseMoved = 1
+    kCGEventOtherMouseDragged = 2
+    kCGEventOtherMouseDown = 3
+    kCGEventOtherMouseUp = 4
+    kCGEventScrollWheel = 5
+    kCGMouseEventButtonNumber = 10
+    kCGMouseEventDeltaX = 11
+    kCGMouseEventDeltaY = 12
+    kCGEventSourceUserData = 13
+    kCGScrollWheelEventFixedPtDeltaAxis1 = 14
+    kCGScrollWheelEventFixedPtDeltaAxis2 = 15
+
+    @staticmethod
+    def CGEventGetIntegerValueField(event, field):
+        return event.get(field, 0)
+
+
+class MacMouseHookGestureButtonTests(unittest.TestCase):
+    def _reload_for_darwin(self):
+        fake_quartz = _FakeQuartz()
+        with (
+            patch.object(sys, "platform", "darwin"),
+            patch.dict(sys.modules, {"Quartz": fake_quartz}),
+        ):
+            importlib.reload(mouse_hook)
+        self.addCleanup(importlib.reload, mouse_hook)
+        return mouse_hook, fake_quartz
+
+    def test_gesture_button_is_blocked_and_dispatches_click(self):
+        module, quartz = self._reload_for_darwin()
+        hook = module.MouseHook()
+        dispatched = []
+        hook.register(
+            module.MouseEvent.GESTURE_CLICK,
+            lambda event: dispatched.append(event.event_type),
+        )
+
+        down_event = {quartz.kCGMouseEventButtonNumber: module._BTN_GESTURE}
+        up_event = {quartz.kCGMouseEventButtonNumber: module._BTN_GESTURE}
+
+        self.assertIsNone(
+            hook._event_tap_callback(None, quartz.kCGEventOtherMouseDown, down_event, None)
+        )
+        self.assertTrue(hook._gesture_active)
+
+        self.assertIsNone(
+            hook._event_tap_callback(None, quartz.kCGEventOtherMouseUp, up_event, None)
+        )
+        self.assertFalse(hook._gesture_active)
+        self.assertEqual(dispatched, [module.MouseEvent.GESTURE_CLICK])
+
+    def test_non_gesture_button_still_passes_through(self):
+        module, quartz = self._reload_for_darwin()
+        hook = module.MouseHook()
+        event = {quartz.kCGMouseEventButtonNumber: 99}
+
+        self.assertIs(
+            hook._event_tap_callback(None, quartz.kCGEventOtherMouseDown, event, None),
+            event,
+        )
+        self.assertFalse(hook._gesture_active)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Handle the MX gesture/action button on macOS when it comes through the CGEvent tap as button `6`.

## Changes

- add a macOS `_BTN_GESTURE = 6` mapping in `core/mouse_hook.py`
- route button 6 down/up events into the existing gesture handlers
- block the raw OS event so the button does not fall through unhandled
- add regression coverage for the darwin event-tap path in `tests/test_mouse_hook.py`

## Validation

- `python3 -m unittest tests.test_mouse_hook`
- `python3 -m unittest discover -s tests`

## Context

This is a follow-up to the MX Master 4 detection work merged in #38, but it is scoped to the macOS mouse-hook path only.
