### PR TITLE
Ignore trackpad setting for macos

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -65,7 +65,7 @@ BUTTON_TO_EVENTS = {
 }
 
 DEFAULT_CONFIG = {
-    "version": 8,
+    "version": 9,
     "active_profile": "default",
     "profiles": {
         "default": {
@@ -104,6 +104,7 @@ DEFAULT_CONFIG = {
         "debug_mode": False,
         "device_layout_overrides": {},
         "language": "en",
+        "ignore_trackpad": True,
     },
 }
 
@@ -318,6 +319,11 @@ def _migrate(cfg):
             if mappings.get("mode_shift") == "toggle_smart_shift":
                 mappings["mode_shift"] = "switch_scroll_mode"
         cfg["version"] = 8
+
+    if version < 9:
+        settings = cfg.setdefault("settings", {})
+        settings.setdefault("ignore_trackpad", True)
+        cfg["version"] = 9
 
     cfg.setdefault("settings", {})
     cfg["settings"].setdefault("appearance_mode", "system")

--- a/core/engine.py
+++ b/core/engine.py
@@ -72,6 +72,8 @@ class Engine:
         settings = self.cfg.get("settings", {})
         self.hook.invert_vscroll = settings.get("invert_vscroll", False)
         self.hook.invert_hscroll = settings.get("invert_hscroll", False)
+        if hasattr(self.hook, "ignore_trackpad"):
+            self.hook.ignore_trackpad = settings.get("ignore_trackpad", True)
         self.hook.debug_mode = self._debug_events_enabled
         self.hook.configure_gestures(
             enabled=any(mappings.get(key, "none") != "none"

--- a/core/mouse_hook.py
+++ b/core/mouse_hook.py
@@ -934,6 +934,10 @@ elif sys.platform == "darwin":
     _BTN_BACK = 3
     _BTN_FORWARD = 4
     _SCROLL_INVERT_MARKER = 0x4D4F5553
+    # kCGScrollWheelEventIsContinuous (field 88) distinguishes input source:
+    # 0 = line-based / discrete (physical mouse scroll wheel)
+    # 1 = pixel-based / continuous (trackpad / Magic Mouse)
+    _SCROLL_IS_CONTINUOUS = Quartz.kCGScrollWheelEventIsContinuous
 
     class MouseHook:
         """
@@ -953,6 +957,7 @@ elif sys.platform == "darwin":
             self.debug_mode = False
             self.invert_vscroll = False
             self.invert_hscroll = False
+            self.ignore_trackpad = True
             self._gesture_active = False
             self._hid_gesture = None
             self._wake_observer = None
@@ -1298,12 +1303,57 @@ elif sys.platform == "darwin":
                 except queue.Empty:
                     continue
 
+        def _is_trackpad_event(self, cg_event, event_type):
+            """Return True if the event originated from a trackpad rather than a mouse.
+
+            For scroll events we inspect kCGScrollWheelEventScrollType
+            (raw field 1):
+              0 = line-based / discrete  (physical scroll wheel)
+              1 = pixel-based / continuous (trackpad / Magic Mouse)
+            For non-scroll events (mouse moved, dragged) we check the
+            mouse sub-type field (field 109). Trackpad touch events set
+            this to NX_SUBTYPE_MOUSE_TOUCH (non-zero).
+            """
+            if event_type == Quartz.kCGEventScrollWheel:
+                scroll_type = Quartz.CGEventGetIntegerValueField(
+                    cg_event, _SCROLL_IS_CONTINUOUS
+                )
+                return scroll_type == 1
+            # For move / drag events during gesture tracking, check the
+            # mouse sub-type field (field 109). Trackpad touch events set
+            # this to NX_SUBTYPE_MOUSE_TOUCH (non-zero).
+            try:
+                subtype = Quartz.CGEventGetIntegerValueField(cg_event, 109)
+                return subtype != 0
+            except Exception:
+                return False
+
         def _event_tap_callback(self, proxy, event_type, cg_event, refcon):
             """CGEventTap callback.  Return the event to pass through, or None to suppress."""
             try:
                 if not self._first_event_logged:
                     self._first_event_logged = True
                     print("[MouseHook] CGEventTap: first event received", flush=True)
+
+                # ── Trackpad filter ──────────────────────────────────
+                # When enabled, pass trackpad / Magic Mouse events
+                # through unmodified so Mouser only acts on real mouse
+                # input.  Skip our own synthetic scroll-inversion events
+                # (they use pixel units and would look like trackpad).
+                if self.ignore_trackpad:
+                    if event_type == Quartz.kCGEventScrollWheel:
+                        is_own_event = (
+                            Quartz.CGEventGetIntegerValueField(
+                                cg_event, Quartz.kCGEventSourceUserData
+                            )
+                            == _SCROLL_INVERT_MARKER
+                        )
+                        if not is_own_event and self._is_trackpad_event(
+                            cg_event, event_type
+                        ):
+                            return cg_event
+                    elif self._is_trackpad_event(cg_event, event_type):
+                        return cg_event
 
                 mouse_event = None
                 should_block = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,7 @@ class ConfigMigrationTests(unittest.TestCase):
 
         migrated = config._migrate(legacy)
 
-        self.assertEqual(migrated["version"], 8)
+        self.assertEqual(migrated["version"], 9)
         self.assertEqual(migrated["profiles"]["default"]["apps"], [])
         self.assertFalse(migrated["settings"]["invert_hscroll"])
         self.assertFalse(migrated["settings"]["invert_vscroll"])
@@ -45,6 +45,7 @@ class ConfigMigrationTests(unittest.TestCase):
         self.assertEqual(migrated["settings"]["device_layout_overrides"], {})
         self.assertFalse(migrated["settings"]["start_at_login"])
         self.assertNotIn("start_with_windows", migrated["settings"])
+        self.assertTrue(migrated["settings"]["ignore_trackpad"])
         self.assertEqual(
             migrated["profiles"]["default"]["mappings"]["gesture"], "none"
         )
@@ -73,7 +74,7 @@ class ConfigMigrationTests(unittest.TestCase):
 
         migrated = config._migrate(cfg)
 
-        self.assertEqual(migrated["version"], 8)
+        self.assertEqual(migrated["version"], 9)
         self.assertEqual(
             migrated["profiles"]["media"]["apps"],
             ["Microsoft.Media.Player.exe", "VLC.exe"],
@@ -112,7 +113,7 @@ class ConfigMigrationTests(unittest.TestCase):
             ):
                 loaded = config.load_config()
 
-        self.assertEqual(loaded["version"], 8)
+        self.assertEqual(loaded["version"], 9)
         self.assertEqual(loaded["settings"]["dpi"], 800)
         self.assertFalse(loaded["settings"]["start_at_login"])
         self.assertEqual(loaded["settings"]["gesture_threshold"], 50)
@@ -136,7 +137,7 @@ class ConfigMigrationTests(unittest.TestCase):
 
         migrated = config._migrate(legacy)
 
-        self.assertEqual(migrated["version"], 8)
+        self.assertEqual(migrated["version"], 9)
         self.assertTrue(migrated["settings"]["start_at_login"])
         self.assertEqual(
             migrated["profiles"]["default"]["mappings"]["mode_shift"],

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -152,6 +152,7 @@ class Backend(QObject):
     def actionCategories(self):
         """Actions grouped by category — for the action picker chips."""
         from collections import OrderedDict
+
         cats = OrderedDict()
         for aid in sorted(
             ACTIONS,
@@ -234,6 +235,14 @@ class Backend(QObject):
     @Property(bool, notify=settingsChanged)
     def invertHScroll(self):
         return self._cfg.get("settings", {}).get("invert_hscroll", False)
+
+    @Property(bool, notify=settingsChanged)
+    def ignoreTrackpad(self):
+        return self._cfg.get("settings", {}).get("ignore_trackpad", True)
+
+    @Property(bool, constant=True)
+    def isMacOS(self):
+        return sys.platform == "darwin"
 
     @Property(int, notify=settingsChanged)
     def gestureThreshold(self):
@@ -547,6 +556,14 @@ class Backend(QObject):
     @Slot(bool)
     def setInvertHScroll(self, value):
         self._cfg.setdefault("settings", {})["invert_hscroll"] = value
+        save_config(self._cfg)
+        if self._engine:
+            self._engine.reload_mappings()
+        self.settingsChanged.emit()
+
+    @Slot(bool)
+    def setIgnoreTrackpad(self, value):
+        self._cfg.setdefault("settings", {})["ignore_trackpad"] = value
         save_config(self._cfg)
         if self._engine:
             self._engine.reload_mappings()

--- a/ui/qml/ScrollPage.qml
+++ b/ui/qml/ScrollPage.qml
@@ -866,6 +866,53 @@ Item {
                             }
                         }
                     }
+
+                    Rectangle {
+                        width: parent.width
+                        height: 52
+                        radius: 10
+                        color: scrollPage.theme.bgSubtle
+                        visible: backend.isMacOS
+
+                        RowLayout {
+                            anchors {
+                                fill: parent
+                                leftMargin: 16
+                                rightMargin: 16
+                            }
+
+                            Column {
+                                Layout.fillWidth: true
+                                spacing: 2
+
+                                Text {
+                                    text: "Ignore trackpad"
+                                    font {
+                                        family: uiState.fontFamily
+                                        pixelSize: 13
+                                    }
+                                    color: scrollPage.theme.textPrimary
+                                }
+
+                                Text {
+                                    text: "Only respond to mouse events, not trackpad or Magic Mouse"
+                                    font {
+                                        family: uiState.fontFamily
+                                        pixelSize: 11
+                                    }
+                                    color: scrollPage.theme.textSecondary
+                                }
+                            }
+
+                            Switch {
+                                id: ignoreTrackpadSwitch
+                                checked: backend.ignoreTrackpad
+                                Material.accent: scrollPage.theme.accent
+                                Accessible.name: "Ignore trackpad"
+                                onToggled: backend.setIgnoreTrackpad(checked)
+                            }
+                        }
+                    }
                 }
             }
 
@@ -933,6 +980,7 @@ Item {
             }
             vscrollSwitch.checked = backend.invertVScroll
             hscrollSwitch.checked = backend.invertHScroll
+            ignoreTrackpadSwitch.checked = backend.ignoreTrackpad
         }
     }
 }


### PR DESCRIPTION
Fixes #35 
Hint: I created the code with the help of AI (Human in the loop)

## Why

On macOS, Mouser's CGEventTap intercepts **all** mouse and scroll events regardless of input device. When using a MacBook with both a Logitech mouse and the built-in trackpad, two-finger trackpad gestures (horizontal scrolls) get captured by Mouser and mapped to browser back/forward actions -- making normal trackpad navigation unusable while Mouser is running.

Windows and Linux already have device-level filtering (Raw Input vendor ID filtering and evdev device grabbing respectively), but macOS had no equivalent.

## How

The key technical mechanism is the `kCGScrollWheelEventIsContinuous` CGEvent field:
- Physical mouse scroll wheels produce **discrete/line-based** events (field value `0`)
- Trackpads and Magic Mouse produce **continuous/pixel-based** events (field value `1`)

The filter runs at the very top of the CGEventTap callback, before any mapping or blocking logic, so trackpad events pass through the system completely untouched by Mouser.

**Edge case handled**: Mouser's own scroll-inversion feature posts synthetic events using `kCGScrollEventUnitPixel` (which would look like trackpad events). These are identified by the existing `_SCROLL_INVERT_MARKER` in `kCGEventSourceUserData` and exempted from filtering.

**Trade-off**: Magic Mouse users who want Mouser to intercept their scroll events will need to disable this setting, since Magic Mouse also uses continuous scrolling. This is acceptable given Mouser targets Logitech mice.

## What

Adds an "Ignore trackpad" setting (enabled by default) that filters out trackpad and Magic Mouse events on macOS so Mouser only processes input from discrete mouse scroll wheels.

**Config** (`core/config.py`):
- New `ignore_trackpad: true` setting in `DEFAULT_CONFIG`
- Config version bumped to 6 with migration that defaults existing users to enabled

**Event filtering** (`core/mouse_hook.py`):
- New `_is_trackpad_event()` helper that uses `kCGScrollWheelEventIsContinuous` (field 88) to distinguish discrete scroll wheel events (value 0) from continuous trackpad/Magic Mouse events (value 1)
- For non-scroll events, checks CGEvent field 109 (mouse subtype) which is non-zero for trackpad touch events
- Early return in `_event_tap_callback` passes trackpad events through unmodified before any mapping/blocking logic runs
- Correctly exempts Mouser's own synthetic scroll-inversion events (which use pixel units) by checking the `_SCROLL_INVERT_MARKER` first

**Engine** (`core/engine.py`):
- Wires the setting to the hook in `_setup_hooks()`, guarded by `hasattr` for cross-platform safety

**UI** (`ui/backend.py`, `ui/qml/ScrollPage.qml`):
- `ignoreTrackpad` property + `setIgnoreTrackpad` slot on the backend
- `isMacOS` constant property for platform-conditional UI
- Toggle in the Scroll Direction section, only visible on macOS, with subtitle explaining it also affects Magic Mouse