### PR TITLE
fix: re-enable CGEventTap after macOS wake from sleep

### DIFF
--- a/core/mouse_hook.py
+++ b/core/mouse_hook.py
@@ -975,6 +975,7 @@ elif sys.platform == "darwin":
             self._gesture_cooldown_until = 0.0
             self._gesture_input_source = None
             self._connected_device = None
+            self._wake_observer = None
 
         def register(self, event_type, callback):
             self._callbacks.setdefault(event_type, []).append(callback)
@@ -1298,6 +1299,19 @@ elif sys.platform == "darwin":
         def _event_tap_callback(self, proxy, event_type, cg_event, refcon):
             """CGEventTap callback.  Return the event to pass through, or None to suppress."""
             try:
+                # Re-enable tap if macOS disabled it (e.g. after sleep)
+                if event_type in (
+                    Quartz.kCGEventTapDisabledByTimeout,
+                    Quartz.kCGEventTapDisabledByUserInput,
+                ):
+                    print(
+                        f"[MouseHook] CGEventTap was disabled "
+                        f"(type={event_type:#x}), re-enabling",
+                        flush=True,
+                    )
+                    Quartz.CGEventTapEnable(self._tap, True)
+                    return cg_event
+
                 if not self._first_event_logged:
                     self._first_event_logged = True
                     print("[MouseHook] CGEventTap: first event received", flush=True)
@@ -1474,6 +1488,43 @@ elif sys.platform == "darwin":
             self._connected_device = None
             self._set_device_connected(False)
 
+        def _register_wake_observer(self):
+            """Register for system wake notifications to re-enable the event tap."""
+            try:
+                from AppKit import NSWorkspace
+
+                ws = NSWorkspace.sharedWorkspace()
+                nc = ws.notificationCenter()
+
+                def _on_wake(notification):
+                    print("[MouseHook] System wake detected, checking event tap", flush=True)
+                    if self._tap and self._running:
+                        Quartz.CGEventTapEnable(self._tap, True)
+                        print("[MouseHook] Event tap re-enabled after wake", flush=True)
+
+                self._wake_observer = nc.addObserverForName_object_queue_usingBlock_(
+                    "NSWorkspaceDidWakeNotification",
+                    None,
+                    None,
+                    _on_wake,
+                )
+            except Exception as e:
+                print(f"[MouseHook] Failed to register wake observer: {e}", flush=True)
+                self._wake_observer = None
+
+        def _unregister_wake_observer(self):
+            """Remove the wake notification observer."""
+            if self._wake_observer is not None:
+                try:
+                    from AppKit import NSWorkspace
+
+                    ws = NSWorkspace.sharedWorkspace()
+                    nc = ws.notificationCenter()
+                    nc.removeObserver_(self._wake_observer)
+                except Exception as e:
+                    print(f"[MouseHook] Failed to remove wake observer: {e}", flush=True)
+                self._wake_observer = None
+
         def start(self):
             if not _QUARTZ_OK:
                 print("[MouseHook] Quartz not available — hook not installed")
@@ -1538,10 +1589,13 @@ elif sys.platform == "darwin":
                 self._hid_gesture = listener
                 if not listener.start():
                     self._hid_gesture = None
+
+            self._register_wake_observer()
             return True
 
         def stop(self):
             self._running = False
+            self._unregister_wake_observer()
             if self._hid_gesture:
                 self._hid_gesture.stop()
                 self._hid_gesture = None

--- a/tests/test_mouse_hook.py
+++ b/tests/test_mouse_hook.py
@@ -2,9 +2,161 @@ import importlib
 import sys
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 from core import mouse_hook
+
+
+class MacOSCGEventTapWakeTests(unittest.TestCase):
+    """Tests for CGEventTap re-enable logic after macOS sleep/wake."""
+
+    _DISABLED_BY_TIMEOUT = 0xFFFFFFFE
+    _DISABLED_BY_USER_INPUT = 0xFFFFFFFD
+
+    def _make_quartz_mock(self):
+        q = MagicMock()
+        q.kCGEventTapDisabledByTimeout = self._DISABLED_BY_TIMEOUT
+        q.kCGEventTapDisabledByUserInput = self._DISABLED_BY_USER_INPUT
+        return q
+
+    def _reload_with_quartz(self, quartz_mock=None):
+        if quartz_mock is None:
+            quartz_mock = self._make_quartz_mock()
+        with patch.dict(sys.modules, {"Quartz": quartz_mock}):
+            with patch.object(sys, "platform", "darwin"):
+                importlib.reload(mouse_hook)
+        self.addCleanup(importlib.reload, mouse_hook)
+        return mouse_hook, quartz_mock
+
+    # -- _event_tap_callback: disabled events --------------------------------
+
+    def test_callback_reenables_tap_on_timeout_disabled(self):
+        mod, q = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        fake_tap = object()
+        hook._tap = fake_tap
+        fake_event = object()
+
+        result = hook._event_tap_callback(None, q.kCGEventTapDisabledByTimeout, fake_event, None)
+
+        q.CGEventTapEnable.assert_called_once_with(fake_tap, True)
+        self.assertIs(result, fake_event)
+
+    def test_callback_reenables_tap_on_user_input_disabled(self):
+        mod, q = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        fake_tap = object()
+        hook._tap = fake_tap
+        fake_event = object()
+
+        result = hook._event_tap_callback(None, q.kCGEventTapDisabledByUserInput, fake_event, None)
+
+        q.CGEventTapEnable.assert_called_once_with(fake_tap, True)
+        self.assertIs(result, fake_event)
+
+    def test_callback_does_not_reenable_for_normal_events(self):
+        mod, q = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        hook._tap = object()
+        # Use a plain integer that is not a disabled-event constant
+        normal_event_type = 22  # kCGEventScrollWheel
+
+        hook._event_tap_callback(None, normal_event_type, MagicMock(), None)
+
+        q.CGEventTapEnable.assert_not_called()
+
+    # -- _register_wake_observer / _on_wake callback -------------------------
+
+    def _make_appkit_mock(self):
+        appkit = MagicMock()
+        nc = appkit.NSWorkspace.sharedWorkspace.return_value.notificationCenter.return_value
+        return appkit, nc
+
+    def _register_and_get_wake_cb(self, hook):
+        appkit_mock, nc = self._make_appkit_mock()
+        with patch.dict(sys.modules, {"AppKit": appkit_mock}):
+            hook._register_wake_observer()
+        wake_cb = nc.addObserverForName_object_queue_usingBlock_.call_args[0][3]
+        return wake_cb, nc, appkit_mock
+
+    def test_register_wake_observer_subscribes_to_did_wake(self):
+        mod, q = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        _, nc, _ = self._register_and_get_wake_cb(hook)
+
+        name_arg = nc.addObserverForName_object_queue_usingBlock_.call_args[0][0]
+        self.assertEqual(name_arg, "NSWorkspaceDidWakeNotification")
+
+    def test_on_wake_reenables_tap_when_running(self):
+        mod, q = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        fake_tap = object()
+        hook._tap = fake_tap
+        hook._running = True
+        wake_cb, _, _ = self._register_and_get_wake_cb(hook)
+
+        wake_cb(None)
+
+        q.CGEventTapEnable.assert_called_once_with(fake_tap, True)
+
+    def test_on_wake_skips_reenable_when_not_running(self):
+        mod, q = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        hook._tap = object()
+        hook._running = False
+        wake_cb, _, _ = self._register_and_get_wake_cb(hook)
+
+        wake_cb(None)
+
+        q.CGEventTapEnable.assert_not_called()
+
+    def test_on_wake_skips_reenable_when_tap_is_none(self):
+        mod, q = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        hook._tap = None
+        hook._running = True
+        wake_cb, _, _ = self._register_and_get_wake_cb(hook)
+
+        wake_cb(None)
+
+        q.CGEventTapEnable.assert_not_called()
+
+    # -- _unregister_wake_observer -------------------------------------------
+
+    def test_unregister_removes_observer_and_clears_field(self):
+        mod, _ = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        sentinel = object()
+        hook._wake_observer = sentinel
+        appkit_mock, nc = self._make_appkit_mock()
+
+        with patch.dict(sys.modules, {"AppKit": appkit_mock}):
+            hook._unregister_wake_observer()
+
+        nc.removeObserver_.assert_called_once_with(sentinel)
+        self.assertIsNone(hook._wake_observer)
+
+    def test_unregister_is_noop_when_no_observer(self):
+        mod, _ = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        hook._wake_observer = None
+        appkit_mock, nc = self._make_appkit_mock()
+
+        with patch.dict(sys.modules, {"AppKit": appkit_mock}):
+            hook._unregister_wake_observer()  # must not raise
+
+        nc.removeObserver_.assert_not_called()
+
+    def test_register_failure_sets_observer_to_none(self):
+        mod, _ = self._reload_with_quartz()
+        hook = mod.MouseHook()
+        appkit_mock = MagicMock()
+        appkit_mock.NSWorkspace.sharedWorkspace.side_effect = RuntimeError("no workspace")
+
+        with patch.dict(sys.modules, {"AppKit": appkit_mock}):
+            hook._register_wake_observer()  # must not raise
+
+        self.assertIsNone(hook._wake_observer)
 
 
 class LinuxMouseHookReconnectTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

After a long sleep on macOS, scroll inversion and horizontal scroll remapping stop working. Restarting the app restores them.

**Root cause:** macOS disables `CGEventTap` during extended sleep (and also during fast user switching). When disabled, the tap stops intercepting scroll events and Mouser's overrides fall back to system defaults.

## Fix

Two complementary mechanisms to automatically re-enable the tap:

1. **Callback handler** — handles `kCGEventTapDisabledByTimeout` / `kCGEventTapDisabledByUserInput` events sent to the tap callback before macOS fully disables it, calling `CGEventTapEnable` immediately. This is the Apple-recommended pattern.

2. **Wake notification observer** — registers for `NSWorkspaceDidWakeNotification` to proactively re-enable the tap on system wake, as a belt-and-suspenders measure.

## Also fixed

`test_key_simulator.py::test_tab_switch_actions_exist` was broken due to two bugs: bare `ACTIONS` reference (missing `key_simulator.` prefix) and the test being placed in the wrong class (`LinuxDesktopShortcutTests` with a macOS/Windows-only skip guard).

## Tests

10 new tests covering the wake re-enable logic (callback path, wake observer, register/unregister lifecycle).