### PR TITLE
feat: add persistent rotating log file storage

### DIFF
--- a/Mouser-mac.spec
+++ b/Mouser-mac.spec
@@ -29,6 +29,7 @@ a = Analysis(
     ],
     hiddenimports=[
         "hid",
+        "logging.handlers",
         "PySide6.QtQuick",
         "PySide6.QtQuickControls2",
         "PySide6.QtQml",

--- a/Mouser.spec
+++ b/Mouser.spec
@@ -27,6 +27,7 @@ a = Analysis(
     hiddenimports=[
         # conditional / lazy imports PyInstaller may miss
         "hid",
+        "logging.handlers",
         "ctypes.wintypes",
         # PySide6 QML runtime
         "PySide6.QtQuick",

--- a/core/log_setup.py
+++ b/core/log_setup.py
@@ -1,0 +1,117 @@
+"""
+log_setup.py — Redirect all print() output to a rotating log file.
+
+Call setup_logging() once, early in main_qml.py, before Qt and core imports.
+"""
+import io
+import logging
+import logging.handlers
+import os
+import sys
+import threading
+
+
+def _get_log_dir() -> str:
+    if sys.platform == "darwin":
+        return os.path.join(os.path.expanduser("~"), "Library", "Logs", "Mouser")
+    elif sys.platform == "linux":
+        xdg_state = os.environ.get(
+            "XDG_STATE_HOME",
+            os.path.join(os.path.expanduser("~"), ".local", "state"),
+        )
+        return os.path.join(xdg_state, "Mouser", "logs")
+    else:  # Windows
+        appdata = os.environ.get("APPDATA", os.path.expanduser("~"))
+        return os.path.join(appdata, "Mouser", "logs")
+
+
+class _StreamToLogger:
+    """Forward writes to a Logger. Thread-safe via threading.local buffer."""
+
+    def __init__(self, logger: logging.Logger, level: int = logging.INFO):
+        self._logger = logger
+        self._level = level
+        self._local = threading.local()
+
+    def write(self, msg: str) -> int:
+        if not hasattr(self._local, "buf"):
+            self._local.buf = ""
+        self._local.buf += msg
+        while "\n" in self._local.buf:
+            line, self._local.buf = self._local.buf.split("\n", 1)
+            if line:
+                self._logger.log(self._level, line)
+        return len(msg)
+
+    def flush(self) -> None:
+        if hasattr(self._local, "buf") and self._local.buf:
+            self._logger.log(self._level, self._local.buf)
+            self._local.buf = ""
+
+    def fileno(self):
+        raise io.UnsupportedOperation("fileno")
+
+    @property
+    def encoding(self):
+        return "utf-8"
+
+    @property
+    def errors(self):
+        return "replace"
+
+    def isatty(self):
+        return False
+
+
+def setup_logging() -> str:
+    """
+    Configure rotating file log and redirect stdout to it.
+    Returns the log file path. Idempotent (safe to call multiple times).
+
+    Only sys.stdout is redirected (all app output uses print()). sys.stderr
+    is left untouched to avoid a recursion: logging handler errors call
+    handleError() which writes to sys.stderr — redirecting it through the
+    logger would create an infinite loop.
+    """
+    root = logging.getLogger()
+    if root.handlers:
+        return ""  # already configured
+
+    log_dir = _get_log_dir()
+    fmt = logging.Formatter(fmt="%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+
+    log_path = ""
+    try:
+        os.makedirs(log_dir, mode=0o700, exist_ok=True)
+        log_path = os.path.join(log_dir, "mouser.log")
+        file_handler = logging.handlers.RotatingFileHandler(
+            log_path,
+            maxBytes=5 * 1024 * 1024,  # 5 MB per file
+            backupCount=5,              # 25 MB total ceiling
+            encoding="utf-8",
+            delay=False,                # create file immediately on startup
+        )
+        file_handler.setFormatter(fmt)
+        root.addHandler(file_handler)
+    except OSError as exc:
+        log_path = ""
+        # Fall back to console-only — app must not crash due to logging failure
+        print(f"[Logging] Cannot create log dir {log_dir}: {exc}", file=sys.__stderr__)
+
+    # Terminal output: only when NOT running as a frozen bundle.
+    # getattr(sys, "frozen", False) is set by PyInstaller (same pattern used
+    # in main_qml.py for ROOT path resolution). When frozen with console=False,
+    # sys.stdout is /dev/null, so we skip the StreamHandler.
+    if not getattr(sys, "frozen", False):
+        console_handler = logging.StreamHandler(sys.__stdout__)
+        console_handler.setFormatter(fmt)
+        root.addHandler(console_handler)
+
+    root.setLevel(logging.DEBUG)
+
+    # Redirect stdout — must come AFTER StreamHandler setup above.
+    # StreamHandler uses sys.__stdout__ (original), not sys.stdout, so
+    # redirecting sys.stdout here does not create a circular loop.
+    sys.stdout = _StreamToLogger(root, logging.INFO)
+
+    return log_path

--- a/main_qml.py
+++ b/main_qml.py
@@ -24,6 +24,9 @@ else:
     ROOT = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, ROOT)
 
+from core.log_setup import setup_logging
+setup_logging()
+
 # Set Material theme before any Qt imports
 os.environ["QT_QUICK_CONTROLS_STYLE"] = "Material"
 os.environ["QT_QUICK_CONTROLS_MATERIAL_ACCENT"] = "#00d4aa"

--- a/tests/test_key_simulator.py
+++ b/tests/test_key_simulator.py
@@ -15,6 +15,14 @@ class KeySimulatorActionTests(unittest.TestCase):
         self.assertEqual(key_simulator.ACTIONS["space_left"]["label"], "Previous Desktop")
         self.assertEqual(key_simulator.ACTIONS["space_right"]["label"], "Next Desktop")
 
+    @unittest.skipUnless(sys.platform in ("darwin", "win32"), "tab switching actions are platform-specific")
+    def test_tab_switch_actions_exist(self):
+        self.assertIn("next_tab", key_simulator.ACTIONS)
+        self.assertIn("prev_tab", key_simulator.ACTIONS)
+        self.assertEqual(key_simulator.ACTIONS["next_tab"]["category"], "Browser")
+        self.assertEqual(key_simulator.ACTIONS["prev_tab"]["category"], "Browser")
+        self.assertTrue(len(key_simulator.ACTIONS["next_tab"]["keys"]) > 0)
+        self.assertTrue(len(key_simulator.ACTIONS["prev_tab"]["keys"]) > 0)
 
 class LinuxDesktopShortcutTests(unittest.TestCase):
     def _reload_for_linux(self, desktop: str):
@@ -49,16 +57,6 @@ class LinuxDesktopShortcutTests(unittest.TestCase):
             module.ACTIONS["space_right"]["keys"],
             [module.KEY_LEFTCTRL, module.KEY_LEFTMETA, module.KEY_RIGHT],
         )
-
-    @unittest.skipUnless(sys.platform in ("darwin", "win32"), "tab switching actions are platform-specific")
-    def test_tab_switch_actions_exist(self):
-        self.assertIn("next_tab", ACTIONS)
-        self.assertIn("prev_tab", ACTIONS)
-        self.assertEqual(ACTIONS["next_tab"]["category"], "Browser")
-        self.assertEqual(ACTIONS["prev_tab"]["category"], "Browser")
-        self.assertTrue(len(ACTIONS["next_tab"]["keys"]) > 0)
-        self.assertTrue(len(ACTIONS["prev_tab"]["keys"]) > 0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -1,0 +1,211 @@
+import logging
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from core import log_setup
+
+
+class GetLogDirTests(unittest.TestCase):
+    def test_darwin_returns_library_logs_mouser(self):
+        with patch.object(sys, "platform", "darwin"):
+            result = log_setup._get_log_dir()
+        self.assertTrue(result.endswith(os.path.join("Library", "Logs", "Mouser")))
+
+    def test_linux_uses_xdg_state_home(self):
+        with (
+            patch.object(sys, "platform", "linux"),
+            patch.dict(os.environ, {"XDG_STATE_HOME": "/custom/state"}, clear=False),
+        ):
+            result = log_setup._get_log_dir()
+        self.assertEqual(result, os.path.join("/custom/state", "Mouser", "logs"))
+
+    def test_linux_defaults_to_dot_local_state(self):
+        env = {k: v for k, v in os.environ.items() if k != "XDG_STATE_HOME"}
+        with (
+            patch.object(sys, "platform", "linux"),
+            patch.dict(os.environ, env, clear=True),
+        ):
+            result = log_setup._get_log_dir()
+        expected = os.path.join(
+            os.path.expanduser("~"), ".local", "state", "Mouser", "logs"
+        )
+        self.assertEqual(result, expected)
+
+    def test_windows_uses_appdata(self):
+        fake_appdata = os.path.join("C:", "Users", "test", "AppData", "Roaming")
+        with (
+            patch.object(sys, "platform", "win32"),
+            patch.dict(os.environ, {"APPDATA": fake_appdata}, clear=False),
+        ):
+            result = log_setup._get_log_dir()
+        self.assertEqual(result, os.path.join(fake_appdata, "Mouser", "logs"))
+
+
+class SetupLoggingTests(unittest.TestCase):
+    def setUp(self):
+        self._orig_stdout = sys.stdout
+        self._orig_handlers = logging.root.handlers[:]
+        self._orig_level = logging.root.level
+        logging.root.handlers.clear()
+
+    def tearDown(self):
+        # Restore stdout first so handler.close() can safely write errors to stderr
+        sys.stdout = self._orig_stdout
+        for h in logging.root.handlers[:]:
+            h.close()
+        logging.root.handlers.clear()
+        logging.root.handlers.extend(self._orig_handlers)
+        logging.root.setLevel(self._orig_level)
+
+    def test_creates_log_file_on_startup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(log_setup, "_get_log_dir", return_value=tmp):
+                path = log_setup.setup_logging()
+            self.assertTrue(os.path.exists(path))
+            self.assertEqual(path, os.path.join(tmp, "mouser.log"))
+
+    def test_returns_empty_string_when_already_configured(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(log_setup, "_get_log_dir", return_value=tmp):
+                log_setup.setup_logging()
+                result = log_setup.setup_logging()
+        self.assertEqual(result, "")
+
+    def test_redirects_stdout_to_stream_to_logger(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(log_setup, "_get_log_dir", return_value=tmp):
+                log_setup.setup_logging()
+        self.assertIsInstance(sys.stdout, log_setup._StreamToLogger)
+
+    def test_stderr_not_redirected(self):
+        orig_stderr = sys.stderr
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(log_setup, "_get_log_dir", return_value=tmp):
+                log_setup.setup_logging()
+        self.assertIs(sys.stderr, orig_stderr)
+
+    def test_print_output_written_to_log_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(log_setup, "_get_log_dir", return_value=tmp):
+                log_setup.setup_logging()
+            print("[Test] hello from print")
+            for h in logging.root.handlers:
+                h.flush()
+            log_path = os.path.join(tmp, "mouser.log")
+            with open(log_path, encoding="utf-8") as f:
+                content = f.read()
+        self.assertIn("[Test] hello from print", content)
+
+    def test_log_entries_include_timestamp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(log_setup, "_get_log_dir", return_value=tmp):
+                log_setup.setup_logging()
+            print("[Test] timestamped line")
+            for h in logging.root.handlers:
+                h.flush()
+            log_path = os.path.join(tmp, "mouser.log")
+            with open(log_path, encoding="utf-8") as f:
+                content = f.read()
+        # Timestamp format: "YYYY-MM-DD HH:MM:SS"
+        import re
+        self.assertRegex(content, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
+
+    def test_graceful_fallback_on_oserror(self):
+        with patch.object(log_setup, "_get_log_dir", return_value="/nonexistent/xyz"):
+            with patch("core.log_setup.os.makedirs", side_effect=OSError("denied")):
+                path = log_setup.setup_logging()  # must not raise
+        self.assertEqual(path, "")
+
+    def test_no_console_handler_when_frozen(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with (
+                patch.object(log_setup, "_get_log_dir", return_value=tmp),
+                patch.object(sys, "frozen", True, create=True),
+            ):
+                log_setup.setup_logging()
+        handler_types = [type(h) for h in logging.root.handlers]
+        self.assertNotIn(logging.StreamHandler, handler_types)
+
+    def test_rotating_handler_configured_with_correct_size(self):
+        import logging.handlers
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(log_setup, "_get_log_dir", return_value=tmp):
+                log_setup.setup_logging()
+        rotating = next(
+            h for h in logging.root.handlers
+            if isinstance(h, logging.handlers.RotatingFileHandler)
+        )
+        self.assertEqual(rotating.maxBytes, 5 * 1024 * 1024)
+        self.assertEqual(rotating.backupCount, 5)
+
+
+class StreamToLoggerTests(unittest.TestCase):
+    def _make_stream(self, level=logging.INFO):
+        logger = logging.getLogger(f"test_stream_{id(self)}")
+        logger.handlers.clear()
+        logger.propagate = False
+        records = []
+
+        class Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        logger.addHandler(Capture())
+        logger.setLevel(logging.DEBUG)
+        return log_setup._StreamToLogger(logger, level), records
+
+    def test_complete_line_is_logged_immediately(self):
+        stream, records = self._make_stream()
+        stream.write("[Engine] DPI changed\n")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].getMessage(), "[Engine] DPI changed")
+
+    def test_partial_line_is_buffered_until_newline(self):
+        stream, records = self._make_stream()
+        stream.write("[Engine]")
+        self.assertEqual(len(records), 0)
+        stream.write(" DPI changed\n")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].getMessage(), "[Engine] DPI changed")
+
+    def test_multiple_lines_in_single_write(self):
+        stream, records = self._make_stream()
+        stream.write("line one\nline two\nline three\n")
+        self.assertEqual(len(records), 3)
+        self.assertEqual(records[0].getMessage(), "line one")
+        self.assertEqual(records[1].getMessage(), "line two")
+        self.assertEqual(records[2].getMessage(), "line three")
+
+    def test_flush_emits_partial_buffer(self):
+        stream, records = self._make_stream()
+        stream.write("no newline")
+        self.assertEqual(len(records), 0)
+        stream.flush()
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].getMessage(), "no newline")
+
+    def test_blank_lines_not_logged(self):
+        stream, records = self._make_stream()
+        stream.write("\n\n\n")
+        self.assertEqual(len(records), 0)
+
+    def test_write_returns_length_of_message(self):
+        stream, _ = self._make_stream()
+        msg = "hello\n"
+        result = stream.write(msg)
+        self.assertEqual(result, len(msg))
+
+    def test_isatty_returns_false(self):
+        stream, _ = self._make_stream()
+        self.assertFalse(stream.isatty())
+
+    def test_encoding_is_utf8(self):
+        stream, _ = self._make_stream()
+        self.assertEqual(stream.encoding, "utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `core/log_setup.py` that redirects all `print()` output to a rotating log file via Python's `logging` module — zero changes to existing 138 print calls across the codebase
- Log location follows macOS/Linux/Windows conventions: `~/Library/Logs/Mouser/mouser.log` on macOS, `~/.local/state/Mouser/logs/mouser.log` on Linux, `%APPDATA%\Mouser\logs\mouser.log` on Windows
- Uses `RotatingFileHandler` (5 MB × 5 files = 25 MB ceiling) to handle high-frequency mouse events without filling the disk
- When running from terminal, output still appears in the terminal AND is written to the log file; when running as a built `.app` bundle, output goes to the log file only
- On macOS, logs are stored in `~/Library/Logs/` which means they are natively viewable in the **Console.app** — just open Console and filter by process name `Mouser`
- Adds 18 tests covering log dir resolution per platform, rotation config, stdout redirect, idempotency, and graceful fallback on permission errors