### PR TITLE
Fix reconnect replay and recover from HID transport failures

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -456,7 +456,7 @@ class Engine:
         summary = ", ".join(f"{key}={mappings.get(key, 'none')}" for key in interesting)
         self._emit_debug(f"{prefix}: {summary}")
 
-    def _replay_saved_settings_once(self):
+    def _run_saved_settings_replay(self):
         hg = self.hook._hid_gesture
         if hg is None:
             return False
@@ -464,7 +464,33 @@ class Engine:
             return False
 
         replay_ok = True
+        retry_dpi = False
+        retry_smart_shift = False
         saved_dpi = self.cfg.get("settings", {}).get("dpi")
+
+        saved_ss = self.cfg.get("settings", {}).get("smart_shift_mode")
+        ss_enabled = self.cfg.get("settings", {}).get("smart_shift_enabled", False)
+        ss_threshold = self.cfg.get("settings", {}).get("smart_shift_threshold", 25)
+
+        # Phase A: apply Smart Shift immediately so the physical wheel mode
+        # converges before the settled replay.
+        if saved_ss and getattr(hg, "smart_shift_supported", False):
+            if not hasattr(hg, "set_smart_shift"):
+                replay_ok = False
+            else:
+                if not hg.set_smart_shift(saved_ss, ss_enabled, ss_threshold):
+                    replay_ok = False
+                if self._smart_shift_read_cb:
+                    try:
+                        self._smart_shift_read_cb(saved_ss)
+                    except Exception:
+                        pass
+
+        time.sleep(3)
+        hg = self.hook._hid_gesture
+        if hg is None or getattr(hg, "connected_device", None) is None:
+            return False
+
         if saved_dpi is not None:
             if not hasattr(hg, "set_dpi"):
                 replay_ok = False
@@ -476,11 +502,9 @@ class Engine:
                         pass
             else:
                 replay_ok = False
+                retry_dpi = True
 
-        saved_ss = self.cfg.get("settings", {}).get("smart_shift_mode")
         if saved_ss and getattr(hg, "smart_shift_supported", False):
-            ss_enabled = self.cfg.get("settings", {}).get("smart_shift_enabled", False)
-            ss_threshold = self.cfg.get("settings", {}).get("smart_shift_threshold", 25)
             if not hasattr(hg, "set_smart_shift"):
                 replay_ok = False
             elif hg.set_smart_shift(saved_ss, ss_enabled, ss_threshold):
@@ -491,22 +515,50 @@ class Engine:
                         pass
             else:
                 replay_ok = False
+                retry_smart_shift = True
+
+        if retry_dpi or retry_smart_shift:
+            time.sleep(5)
+            hg = self.hook._hid_gesture
+            if hg is None or getattr(hg, "connected_device", None) is None:
+                return False
+            if retry_dpi:
+                if not hasattr(hg, "set_dpi") or not hg.set_dpi(saved_dpi):
+                    replay_ok = False
+                elif self._dpi_read_cb:
+                    try:
+                        self._dpi_read_cb(saved_dpi)
+                    except Exception:
+                        pass
+            if retry_smart_shift and getattr(hg, "smart_shift_supported", False):
+                if not hasattr(hg, "set_smart_shift") or not hg.set_smart_shift(
+                    saved_ss, ss_enabled, ss_threshold
+                ):
+                    replay_ok = False
+                elif self._smart_shift_read_cb:
+                    try:
+                        self._smart_shift_read_cb(saved_ss)
+                    except Exception:
+                        pass
+
         return replay_ok
 
     def _replay_saved_settings_worker(self):
         while True:
             with self._replay_lock:
                 self._replay_pending_rerun = False
-            replay_ok = self._replay_saved_settings_once()
+            replay_ok = self._run_saved_settings_replay()
+            should_emit_failure = False
             with self._replay_lock:
                 if self._replay_pending_rerun:
                     continue
                 self._replay_inflight = False
-                if not replay_ok:
-                    self._emit_status(
-                        "Mouse reconnected, but saved device settings could not be restored yet."
-                    )
-                return
+                should_emit_failure = not replay_ok
+            if should_emit_failure:
+                self._emit_status(
+                    "Mouse reconnected, but saved device settings could not be restored yet."
+                )
+            return
 
     def _request_saved_settings_replay(self, *, startup_fallback=False):
         with self._replay_lock:
@@ -681,84 +733,6 @@ class Engine:
 
     def set_enabled(self, enabled):
         self._enabled = bool(enabled)
-
-    def _apply_device_settings(self, source="startup"):
-        """Push persisted DPI and SmartShift settings to the device.
-
-        Called at startup and on every reconnect (e.g. after waking from sleep).
-
-        SmartShift is written immediately (before any delay) so the scroll wheel
-        is in the correct mode as soon as possible — avoiding the window where the
-        device is in its firmware-default SmartShift state (typically enabled with a
-        low threshold).  The UI is also updated immediately with the saved state.
-
-        DPI and a second SmartShift write are sent after a 3 s settling delay.
-        The second write is important for enhanced SmartShift (0x2111) devices:
-        immediately after wake the feature probe can transiently fall back to basic
-        (0x2110) whose function IDs differ, so the first write may fail.  If both
-        writes fail, a final retry happens after another 5 s.
-        """
-        hg = self.hook._hid_gesture
-        if not hg:
-            return
-
-        s = self.cfg.get("settings", {})
-        ss_mode = s.get("smart_shift_mode", "ratchet")
-        ss_enabled = s.get("smart_shift_enabled", False)
-        ss_threshold = s.get("smart_shift_threshold", 25)
-
-        # ── immediate SmartShift write ────────────────────────────────────────
-        # Runs before the settling delay so the physical scroll wheel snaps to
-        # the saved mode within ~1 s of connect/wake (beats the first battery-
-        # poll SmartShift read at T+1 s).  May fail on enhanced-feature devices
-        # right after wake; the settled write below handles that case.
-        if hg.smart_shift_supported:
-            hg.set_smart_shift(ss_mode, ss_enabled, ss_threshold)
-            if self._smart_shift_read_cb:
-                try:
-                    self._smart_shift_read_cb({
-                        "mode": ss_mode,
-                        "enabled": ss_enabled,
-                        "threshold": ss_threshold,
-                    })
-                except Exception:
-                    pass
-
-        time.sleep(3)  # let HID++ settle before sending DPI and settled SS write
-        hg = self.hook._hid_gesture
-        if not hg:
-            return
-
-        saved_dpi = self.cfg.get("settings", {}).get("dpi")
-        if saved_dpi:
-            hg.set_dpi(saved_dpi)
-            if self._dpi_read_cb:
-                try:
-                    self._dpi_read_cb(saved_dpi)
-                except Exception:
-                    pass
-
-        if hg.smart_shift_supported:
-            ok = hg.set_smart_shift(ss_mode, ss_enabled, ss_threshold)
-            if not ok:
-                print(f"[Engine] SmartShift apply failed ({source}) — retrying in 5s")
-                time.sleep(5)
-                hg = self.hook._hid_gesture
-                if hg and hg.smart_shift_supported:
-                    ok = hg.set_smart_shift(ss_mode, ss_enabled, ss_threshold)
-                    print(f"[Engine] SmartShift retry ({source}) -> {'OK' if ok else 'FAILED'}")
-            # Re-push saved state to UI after the settled write in case the
-            # battery-poll loop updated it with stale device state between the
-            # immediate write and now.
-            if self._smart_shift_read_cb:
-                try:
-                    self._smart_shift_read_cb({
-                        "mode": ss_mode,
-                        "enabled": ss_enabled,
-                        "threshold": ss_threshold,
-                    })
-                except Exception:
-                    pass
 
     def start(self):
         self.hook.start()

--- a/core/engine.py
+++ b/core/engine.py
@@ -628,7 +628,11 @@ class Engine:
                         except Exception:
                             pass
 
-                if now - _last_ss >= _ss_poll_interval and hg.smart_shift_supported:
+                if (
+                    not self._replay_inflight
+                    and now - _last_ss >= _ss_poll_interval
+                    and hg.smart_shift_supported
+                ):
                     _last_ss = now
                     ss_mode = hg.read_smart_shift()
                     if stop_event.is_set():

--- a/core/engine.py
+++ b/core/engine.py
@@ -456,6 +456,14 @@ class Engine:
         summary = ", ".join(f"{key}={mappings.get(key, 'none')}" for key in interesting)
         self._emit_debug(f"{prefix}: {summary}")
 
+    def _saved_smart_shift_state(self):
+        settings = self.cfg.get("settings", {})
+        return {
+            "mode": settings.get("smart_shift_mode", "ratchet"),
+            "enabled": settings.get("smart_shift_enabled", False),
+            "threshold": settings.get("smart_shift_threshold", 25),
+        }
+
     def _run_saved_settings_replay(self):
         hg = self.hook._hid_gesture
         if hg is None:
@@ -468,9 +476,10 @@ class Engine:
         retry_smart_shift = False
         saved_dpi = self.cfg.get("settings", {}).get("dpi")
 
-        saved_ss = self.cfg.get("settings", {}).get("smart_shift_mode")
-        ss_enabled = self.cfg.get("settings", {}).get("smart_shift_enabled", False)
-        ss_threshold = self.cfg.get("settings", {}).get("smart_shift_threshold", 25)
+        saved_ss_state = self._saved_smart_shift_state()
+        saved_ss = saved_ss_state["mode"]
+        ss_enabled = saved_ss_state["enabled"]
+        ss_threshold = saved_ss_state["threshold"]
 
         # Phase A: apply Smart Shift immediately so the physical wheel mode
         # converges before the settled replay.
@@ -482,7 +491,7 @@ class Engine:
                     replay_ok = False
                 if self._smart_shift_read_cb:
                     try:
-                        self._smart_shift_read_cb(saved_ss)
+                        self._smart_shift_read_cb(saved_ss_state)
                     except Exception:
                         pass
 
@@ -510,7 +519,7 @@ class Engine:
             elif hg.set_smart_shift(saved_ss, ss_enabled, ss_threshold):
                 if self._smart_shift_read_cb:
                     try:
-                        self._smart_shift_read_cb(saved_ss)
+                        self._smart_shift_read_cb(saved_ss_state)
                     except Exception:
                         pass
             else:
@@ -537,7 +546,7 @@ class Engine:
                     replay_ok = False
                 elif self._smart_shift_read_cb:
                     try:
-                        self._smart_shift_read_cb(saved_ss)
+                        self._smart_shift_read_cb(saved_ss_state)
                     except Exception:
                         pass
 
@@ -755,7 +764,7 @@ class Engine:
         self._dpi_read_cb = cb
 
     def set_smart_shift_read_callback(self, cb):
-        """Register a callback ``cb(mode)`` invoked when Smart Shift is read."""
+        """Register a callback ``cb(state)`` invoked when Smart Shift is read."""
         self._smart_shift_read_cb = cb
 
     def stop(self):

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -601,6 +601,9 @@ class HidGestureListener:
         self._smart_shift_enhanced = False  # True → use fn 1/2; False → fn 0/1
         self._pending_smart_shift = None
         self._smart_shift_result = None
+        self._smart_shift_call_lock = threading.Lock()
+        self._smart_shift_slot_lock = threading.Lock()
+        self._smart_shift_event = threading.Event()
         self._reconnect_requested = False
         self._pending_battery = None
         self._battery_result = None
@@ -1112,23 +1115,31 @@ class HidGestureListener:
         smart_shift_enabled: True to enable auto SmartShift (auto-switching)
         threshold: 1-50 sensitivity when SmartShift is enabled
         Can be called from any thread.  Returns True on success."""
-        self._smart_shift_result = None
-        self._pending_smart_shift = (mode, smart_shift_enabled, threshold)
-        for _ in range(30):
-            if self._pending_smart_shift is None:
+        pending = (mode, smart_shift_enabled, threshold)
+        with self._smart_shift_call_lock:
+            with self._smart_shift_slot_lock:
+                self._smart_shift_result = None
+                self._pending_smart_shift = pending
+                self._smart_shift_event.clear()
+            if not self._smart_shift_event.wait(3):
+                with self._smart_shift_slot_lock:
+                    if self._pending_smart_shift == pending:
+                        self._smart_shift_result = False
+                        self._pending_smart_shift = None
+                        self._smart_shift_event.set()
+                print("[HidGesture] Smart Shift set timed out")
+                return False
+            with self._smart_shift_slot_lock:
                 return self._smart_shift_result is True
-            time.sleep(0.1)
-        print("[HidGesture] Smart Shift set timed out")
-        return False
 
     def _apply_pending_smart_shift(self):
-        pending = self._pending_smart_shift
+        with self._smart_shift_slot_lock:
+            pending = self._pending_smart_shift
         if pending is None:
             return
         if self._smart_shift_idx is None or self._dev is None:
             print("[HidGesture] Cannot set Smart Shift — not connected")
-            self._smart_shift_result = None if pending == "read" else False
-            self._pending_smart_shift = None
+            self._finish_pending_smart_shift(None if pending == "read" else False)
             return
         if pending == "read":
             self._apply_pending_read_smart_shift()
@@ -1158,11 +1169,11 @@ class HidGestureListener:
             label = "fixed ratchet (SmartShift disabled)"
         if resp:
             print(f"[HidGesture] Smart Shift set to {label}")
-            self._smart_shift_result = True
+            result = True
         else:
             print("[HidGesture] Smart Shift set FAILED")
-            self._smart_shift_result = False
-        self._pending_smart_shift = None
+            result = False
+        self._finish_pending_smart_shift(result)
 
     def force_reconnect(self):
         """Request the listener thread to drop and re-establish the HID++ connection.
@@ -1176,20 +1187,41 @@ class HidGestureListener:
     def read_smart_shift(self):
         """Queue a Smart Shift read.
         Returns dict {'mode': str, 'enabled': bool, 'threshold': int} or None."""
-        self._smart_shift_result = None
-        self._pending_smart_shift = "read"
-        for _ in range(30):
-            if self._pending_smart_shift is None:
+        with self._smart_shift_call_lock:
+            with self._smart_shift_slot_lock:
+                self._smart_shift_result = None
+                self._pending_smart_shift = "read"
+                self._smart_shift_event.clear()
+            if not self._smart_shift_event.wait(3):
+                with self._smart_shift_slot_lock:
+                    if self._pending_smart_shift == "read":
+                        self._smart_shift_result = None
+                        self._pending_smart_shift = None
+                        self._smart_shift_event.set()
+                print("[HidGesture] Smart Shift read timed out")
+                return None
+            with self._smart_shift_slot_lock:
                 return self._smart_shift_result
-            time.sleep(0.1)
-        print("[HidGesture] Smart Shift read timed out")
-        self._pending_smart_shift = None   # prevent stale processing
-        return None
+
+    def _finish_pending_smart_shift(self, result):
+        with self._smart_shift_slot_lock:
+            self._smart_shift_result = result
+            self._pending_smart_shift = None
+            self._smart_shift_event.set()
+
+    def _abort_pending_smart_shift(self):
+        with self._smart_shift_slot_lock:
+            pending = self._pending_smart_shift
+            if pending is None:
+                self._smart_shift_result = None
+                return
+            self._smart_shift_result = None if pending == "read" else False
+            self._pending_smart_shift = None
+            self._smart_shift_event.set()
 
     def _apply_pending_read_smart_shift(self):
         if self._smart_shift_idx is None or self._dev is None:
-            self._smart_shift_result = None
-            self._pending_smart_shift = None
+            self._finish_pending_smart_shift(None)
             return
         # enhanced (0x2111): read fn=1; basic (0x2110): read fn=0
         read_fn = 1 if self._smart_shift_enhanced else 0
@@ -1212,11 +1244,10 @@ class HidGestureListener:
             else:
                 result = {"mode": "ratchet", "enabled": False, "threshold": 25}
             print(f"[HidGesture] Smart Shift state = {result}")
-            self._smart_shift_result = result
+            self._finish_pending_smart_shift(result)
         else:
             print("[HidGesture] Smart Shift read FAILED")
-            self._smart_shift_result = None
-        self._pending_smart_shift = None
+            self._finish_pending_smart_shift(None)
 
     def read_battery(self):
         """Queue a battery read and wait for the listener thread result."""
@@ -1639,7 +1670,8 @@ class HidGestureListener:
             self._battery_feature_id = None
             self._pending_battery = None
             self._pending_dpi = None
-            self._pending_smart_shift = None
+            self._dpi_result = None
+            self._abort_pending_smart_shift()
             self._last_logged_battery = None
             self._consecutive_request_timeouts = 0
             if self._held:

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -767,6 +767,11 @@ class HidGestureListener:
         except Exception as exc:
             print(f"[HidGesture] request tx failed feat=0x{feat:02X} func=0x{func:X} "
                   f"params=[{_hex_bytes(req_params)}]: {exc}")
+            # Discovery probes should skip bad candidates, but an active session
+            # transport failure means the live handle has died and the main loop
+            # must run its existing cleanup/reconnect path.
+            if self._connected:
+                raise IOError(str(exc)) from exc
             return None
         deadline = time.time() + timeout_ms / 1000
         while time.time() < deadline:
@@ -775,6 +780,8 @@ class HidGestureListener:
             except Exception as exc:
                 print(f"[HidGesture] request rx failed feat=0x{feat:02X} func=0x{func:X} "
                       f"params=[{_hex_bytes(req_params)}]: {exc}")
+                if self._connected:
+                    raise IOError(str(exc)) from exc
                 return None
             if raw is None:
                 continue

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -214,6 +214,15 @@ class BackendDeviceLayoutTests(unittest.TestCase):
 
         self.assertEqual(notifications, [])
 
+    def test_non_dict_smart_shift_payload_does_not_mutate_config(self):
+        backend = self._make_backend()
+        original = copy.deepcopy(backend._cfg["settings"])
+
+        backend._pending_smart_shift_state = "freespin"
+        backend._handleSmartShiftRead()
+
+        self.assertEqual(backend._cfg["settings"], original)
+
     def test_linux_reports_gesture_direction_support(self):
         backend = self._make_backend()
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -204,6 +204,16 @@ class BackendDeviceLayoutTests(unittest.TestCase):
             ["Failed to replay HID++ settings after reconnect"],
         )
 
+    def test_non_dict_smart_shift_payload_does_not_emit_change_signal(self):
+        backend = self._make_backend()
+        notifications = []
+        backend.smartShiftChanged.connect(lambda: notifications.append(True))
+
+        backend._pending_smart_shift_state = "freespin"
+        backend._handleSmartShiftRead()
+
+        self.assertEqual(notifications, [])
+
     def test_linux_reports_gesture_direction_support(self):
         backend = self._make_backend()
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -300,6 +300,34 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
             expected_ss_mode, expected_ss_enabled, expected_ss_threshold
         )
 
+    def test_live_reconnect_replay_restores_saved_values_through_worker(self):
+        engine = self._make_engine()
+        engine.hook._hid_gesture = self._make_hid(connected_device=None)
+        threads = []
+        seen_dpi = []
+        seen_smart_shift = []
+        engine.set_dpi_read_callback(seen_dpi.append)
+        engine.set_smart_shift_read_callback(seen_smart_shift.append)
+
+        with patch("core.engine.threading.Thread", side_effect=self._thread_factory(threads)):
+            engine._on_connection_change(True)
+            engine.hook._hid_gesture.connected_device = SimpleNamespace(name="MX Master 3S")
+            engine._on_connection_change(True)
+
+        replay_threads = self._non_battery_threads(threads)
+        self.assertEqual(len(replay_threads), 1)
+        replay_threads[0].run_target()
+
+        self.assertEqual(seen_dpi, [engine.cfg["settings"]["dpi"]])
+        self.assertEqual(
+            seen_smart_shift,
+            [{
+                "mode": engine.cfg["settings"]["smart_shift_mode"],
+                "enabled": engine.cfg["settings"]["smart_shift_enabled"],
+                "threshold": engine.cfg["settings"]["smart_shift_threshold"],
+            }],
+        )
+
     def test_evdev_only_connected_true_does_not_request_replay_worker(self):
         engine = self._make_engine()
         engine.hook.connected_device = SimpleNamespace(name="MX Master 3S", source="evdev")
@@ -331,6 +359,28 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
 
         self.assertEqual(len(first_replay_threads), 1)
         self.assertEqual(self._non_battery_threads(threads), first_replay_threads)
+
+    def test_hid_disconnect_while_evdev_connected_allows_next_hid_replay(self):
+        engine = self._make_engine()
+        engine.hook.connected_device = SimpleNamespace(name="MX Master 3S", source="evdev")
+        engine.hook._hid_gesture = self._make_hid(
+            connected_device=SimpleNamespace(name="MX Master 3S")
+        )
+        threads = []
+
+        with patch("core.engine.threading.Thread", side_effect=self._thread_factory(threads)):
+            engine._on_connection_change(True)
+            self.assertEqual(len(self._non_battery_threads(threads)), 1)
+            self._non_battery_threads(threads)[0].run_target()
+
+            engine.hook._hid_gesture.connected_device = None
+            engine._on_connection_change(True)
+            self.assertEqual(len(self._non_battery_threads(threads)), 1)
+
+            engine.hook._hid_gesture.connected_device = SimpleNamespace(name="MX Master 3S")
+            engine._on_connection_change(True)
+
+        self.assertEqual(len(self._non_battery_threads(threads)), 2)
 
     def test_startup_fallback_does_not_queue_replay_after_hid_ready_replay_requested(self):
         engine = self._make_engine()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -296,7 +296,8 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
         self.assertEqual(len(replay_threads), 1)
         replay_threads[0].run_target()
         engine.hook._hid_gesture.set_dpi.assert_called_once_with(expected_dpi)
-        engine.hook._hid_gesture.set_smart_shift.assert_called_once_with(
+        self.assertEqual(engine.hook._hid_gesture.set_smart_shift.call_count, 2)
+        engine.hook._hid_gesture.set_smart_shift.assert_called_with(
             expected_ss_mode, expected_ss_enabled, expected_ss_threshold
         )
 
@@ -319,13 +320,14 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
         replay_threads[0].run_target()
 
         self.assertEqual(seen_dpi, [engine.cfg["settings"]["dpi"]])
+        self.assertGreaterEqual(len(seen_smart_shift), 2)
         self.assertEqual(
-            seen_smart_shift,
-            [{
+            seen_smart_shift[-1],
+            {
                 "mode": engine.cfg["settings"]["smart_shift_mode"],
                 "enabled": engine.cfg["settings"]["smart_shift_enabled"],
                 "threshold": engine.cfg["settings"]["smart_shift_threshold"],
-            }],
+            },
         )
 
     def test_evdev_only_connected_true_does_not_request_replay_worker(self):
@@ -409,7 +411,7 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
         replay_threads[0].run_target()
 
         self.assertEqual(engine.hook._hid_gesture.set_dpi.call_count, 1)
-        self.assertEqual(engine.hook._hid_gesture.set_smart_shift.call_count, 1)
+        self.assertEqual(engine.hook._hid_gesture.set_smart_shift.call_count, 2)
 
         startup_threads[0].run_target()
 
@@ -418,7 +420,8 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
         expected_ss_enabled = engine.cfg["settings"]["smart_shift_enabled"]
         expected_ss_threshold = engine.cfg["settings"]["smart_shift_threshold"]
         engine.hook._hid_gesture.set_dpi.assert_called_once_with(expected_dpi)
-        engine.hook._hid_gesture.set_smart_shift.assert_called_once_with(
+        self.assertEqual(engine.hook._hid_gesture.set_smart_shift.call_count, 2)
+        engine.hook._hid_gesture.set_smart_shift.assert_called_with(
             expected_ss_mode, expected_ss_enabled, expected_ss_threshold
         )
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -384,6 +384,22 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
 
         self.assertEqual(len(self._non_battery_threads(threads)), 2)
 
+    def test_hid_disconnect_updates_last_hid_ready_without_connection_edge(self):
+        engine = self._make_engine()
+        engine.hook.connected_device = SimpleNamespace(name="MX Master 3S", source="evdev")
+        engine.hook._hid_gesture = self._make_hid(
+            connected_device=SimpleNamespace(name="MX Master 3S")
+        )
+
+        with patch("core.engine.threading.Thread", side_effect=self._thread_factory([])):
+            engine._on_connection_change(True)
+        self.assertTrue(engine._last_hid_features_ready)
+
+        engine.hook._hid_gesture.connected_device = None
+        engine._on_connection_change(True)
+
+        self.assertFalse(engine._last_hid_features_ready)
+
     def test_startup_fallback_does_not_queue_replay_after_hid_ready_replay_requested(self):
         engine = self._make_engine()
         engine.hook._hid_gesture = self._make_hid(connected_device=None)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -451,6 +451,24 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
             status_messages,
         )
 
+    def test_battery_poll_skips_smart_shift_reads_while_replay_is_inflight(self):
+        engine = self._make_engine()
+        stop_event = Mock()
+        stop_event.is_set.return_value = False
+        stop_event.wait.return_value = True
+        engine._replay_inflight = True
+        engine.hook._hid_gesture = SimpleNamespace(
+            connected_device=SimpleNamespace(name="MX Master 3S"),
+            smart_shift_supported=True,
+            read_battery=Mock(return_value=None),
+            read_smart_shift=Mock(return_value={"mode": "ratchet", "enabled": False, "threshold": 25}),
+        )
+
+        engine._battery_poll_loop(stop_event)
+
+        engine.hook._hid_gesture.read_battery.assert_called_once_with()
+        engine.hook._hid_gesture.read_smart_shift.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -201,6 +201,53 @@ class HidDiscoveryDiagnosticsTests(unittest.TestCase):
         self.assertFalse(listener._extra_diverts[0x00C4]["held"])
 
 
+class HidRequestTransportFailureTests(unittest.TestCase):
+    def test_request_raises_ioerror_on_tx_failure_during_active_session(self):
+        listener = hid_gesture.HidGestureListener()
+        listener._connected = True
+
+        with patch.object(listener, "_tx", side_effect=OSError("tx boom")):
+            with self.assertRaises(IOError):
+                listener._request(0x0E, 0, [])
+
+    def test_request_raises_ioerror_on_rx_failure_during_active_session(self):
+        listener = hid_gesture.HidGestureListener()
+        listener._connected = True
+
+        with (
+            patch.object(listener, "_tx"),
+            patch.object(listener, "_rx", side_effect=OSError("rx boom")),
+        ):
+            with self.assertRaises(IOError):
+                listener._request(0x0E, 0, [])
+
+    def test_request_returns_none_on_tx_failure_during_discovery(self):
+        listener = hid_gesture.HidGestureListener()
+
+        with patch.object(listener, "_tx", side_effect=OSError("tx boom")):
+            self.assertIsNone(listener._request(0x0E, 0, []))
+
+    def test_request_returns_none_on_rx_failure_during_discovery(self):
+        listener = hid_gesture.HidGestureListener()
+
+        with (
+            patch.object(listener, "_tx"),
+            patch.object(listener, "_rx", side_effect=OSError("rx boom")),
+        ):
+            self.assertIsNone(listener._request(0x0E, 0, []))
+
+    def test_request_timeout_still_increments_timeout_counter(self):
+        listener = hid_gesture.HidGestureListener()
+
+        with (
+            patch.object(listener, "_tx"),
+            patch.object(listener, "_rx", return_value=None),
+        ):
+            self.assertIsNone(listener._request(0x0E, 0, [], timeout_ms=0))
+
+        self.assertEqual(listener._consecutive_request_timeouts, 1)
+
+
 class HidReconnectInvariantTests(unittest.TestCase):
     def test_force_release_stale_holds_clears_gesture_and_extra_buttons(self):
         gesture_up = Mock()

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -99,6 +99,7 @@ class HidDiscoveryDiagnosticsTests(unittest.TestCase):
                 hid_gesture,
                 "_hid",
                 SimpleNamespace(device=lambda: fake_dev),
+                create=True,
             ),
             patch("builtins.print") as print_mock,
         ):
@@ -135,6 +136,7 @@ class HidDiscoveryDiagnosticsTests(unittest.TestCase):
                 hid_gesture,
                 "_hid",
                 SimpleNamespace(device=lambda: fake_dev),
+                create=True,
             ),
             patch("builtins.print") as print_mock,
         ):
@@ -151,6 +153,52 @@ class HidDiscoveryDiagnosticsTests(unittest.TestCase):
             any(self._is_missing_reprog_diag(message) for message in messages)
         )
         fake_dev.close.assert_not_called()
+
+    def test_try_connect_rearms_extra_diverts_on_reconnect(self):
+        listener = hid_gesture.HidGestureListener(
+            extra_diverts={
+                0x00C4: {"on_down": Mock(), "on_up": Mock()},
+            }
+        )
+        info = {
+            "product_id": 0xB023,
+            "usage_page": 0xFF00,
+            "usage": 0x0001,
+            "transport": "Bluetooth Low Energy",
+            "source": "hidapi-enumerate",
+            "product_string": "MX Master 3",
+            "path": b"/dev/hidraw-test",
+        }
+        fake_devs = [_FakeHidDevice(), _FakeHidDevice()]
+
+        def fake_find_feature(feature_id):
+            if feature_id == hid_gesture.FEAT_REPROG_V4:
+                return 0x10
+            return None
+
+        with (
+            patch.object(listener, "_vendor_hid_infos", return_value=[info]),
+            patch.object(listener, "_find_feature", side_effect=fake_find_feature),
+            patch.object(listener, "_discover_reprog_controls", return_value=[]),
+            patch.object(listener, "_divert", return_value=True),
+            patch.object(listener, "_divert_extras") as divert_extras_mock,
+            patch.object(hid_gesture, "HIDAPI_OK", True),
+            patch.object(hid_gesture, "_BACKEND_PREFERENCE", "hidapi"),
+            patch.object(hid_gesture, "_HID_API_STYLE", "hidapi"),
+            patch.object(
+                hid_gesture,
+                "_hid",
+                SimpleNamespace(device=lambda: fake_devs.pop(0)),
+                create=True,
+            ),
+        ):
+            self.assertTrue(listener._try_connect())
+            listener._dev = None
+            self.assertTrue(listener._try_connect())
+
+        self.assertEqual(divert_extras_mock.call_count, 2)
+        self.assertIn(0x00C4, listener._extra_diverts)
+        self.assertFalse(listener._extra_diverts[0x00C4]["held"])
 
 
 if __name__ == "__main__":

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -201,5 +201,24 @@ class HidDiscoveryDiagnosticsTests(unittest.TestCase):
         self.assertFalse(listener._extra_diverts[0x00C4]["held"])
 
 
+class HidReconnectInvariantTests(unittest.TestCase):
+    def test_force_release_stale_holds_clears_gesture_and_extra_buttons(self):
+        gesture_up = Mock()
+        extra_up = Mock()
+        listener = hid_gesture.HidGestureListener(
+            on_up=gesture_up,
+            extra_diverts={0x00C4: {"on_up": extra_up}},
+        )
+        listener._held = True
+        listener._extra_diverts[0x00C4]["held"] = True
+
+        listener._force_release_stale_holds()
+
+        self.assertFalse(listener._held)
+        self.assertFalse(listener._extra_diverts[0x00C4]["held"])
+        gesture_up.assert_called_once_with()
+        extra_up.assert_called_once_with()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mouse_hook.py
+++ b/tests/test_mouse_hook.py
@@ -23,6 +23,27 @@ class _FakeEvdevDevice:
         return self._capabilities
 
 
+class _CapturingListener:
+    def __init__(self, on_down=None, on_up=None, on_move=None,
+                 on_connect=None, on_disconnect=None, extra_diverts=None):
+        self.on_down = on_down
+        self.on_up = on_up
+        self.on_move = on_move
+        self.on_connect = on_connect
+        self.on_disconnect = on_disconnect
+        self.extra_diverts = extra_diverts or {}
+        self.connected_device = None
+        self.started = False
+        self.stopped = False
+
+    def start(self):
+        self.started = True
+        return True
+
+    def stop(self):
+        self.stopped = True
+
+
 class LinuxMouseHookReconnectTests(unittest.TestCase):
     def _reload_for_linux(self):
         with patch.object(sys, "platform", "linux"):
@@ -245,6 +266,63 @@ class LinuxMouseHookReconnectTests(unittest.TestCase):
         self.assertEqual(len(setup_calls), 2)
         self.assertEqual(seen_rescan_state, [False])
         self.assertEqual(len(cleanup_calls), 1)
+
+    def test_gesture_click_callback_fires_again_after_reconnect(self):
+        module = self._reload_for_linux()
+        seen = []
+
+        with (
+            patch.object(module, "HidGestureListener", _CapturingListener),
+            patch.object(module, "_EVDEV_OK", False),
+        ):
+            hook = module.MouseHook()
+            hook.register(module.MouseEvent.GESTURE_CLICK, lambda event: seen.append(event.event_type))
+            hook.start()
+            listener = hook._hid_gesture
+
+            listener.on_down()
+            listener.on_up()
+            hook._on_hid_disconnect()
+            hook._on_hid_connect()
+            listener.on_down()
+            listener.on_up()
+
+        self.assertEqual(
+            seen,
+            [module.MouseEvent.GESTURE_CLICK, module.MouseEvent.GESTURE_CLICK],
+        )
+
+    def test_mode_shift_callbacks_fire_again_after_reconnect(self):
+        module = self._reload_for_linux()
+        seen = []
+
+        with (
+            patch.object(module, "HidGestureListener", _CapturingListener),
+            patch.object(module, "_EVDEV_OK", False),
+        ):
+            hook = module.MouseHook()
+            hook.divert_mode_shift = True
+            hook.register(module.MouseEvent.MODE_SHIFT_DOWN, lambda event: seen.append(event.event_type))
+            hook.register(module.MouseEvent.MODE_SHIFT_UP, lambda event: seen.append(event.event_type))
+            hook.start()
+            listener = hook._hid_gesture
+
+            listener.extra_diverts[0x00C4]["on_down"]()
+            listener.extra_diverts[0x00C4]["on_up"]()
+            hook._on_hid_disconnect()
+            hook._on_hid_connect()
+            listener.extra_diverts[0x00C4]["on_down"]()
+            listener.extra_diverts[0x00C4]["on_up"]()
+
+        self.assertEqual(
+            seen,
+            [
+                module.MouseEvent.MODE_SHIFT_DOWN,
+                module.MouseEvent.MODE_SHIFT_UP,
+                module.MouseEvent.MODE_SHIFT_DOWN,
+                module.MouseEvent.MODE_SHIFT_UP,
+            ],
+        )
 
 
 @unittest.skipUnless(sys.platform == "darwin", "macOS-only tests")

--- a/tests/test_mouse_hook.py
+++ b/tests/test_mouse_hook.py
@@ -44,9 +44,35 @@ class _CapturingListener:
         self.stopped = True
 
 
+class _FakeLinuxEcodes:
+    EV_REL = 0x02
+    EV_KEY = 0x01
+    REL_X = 0x00
+    REL_Y = 0x01
+    BTN_LEFT = 0x110
+    BTN_RIGHT = 0x111
+    BTN_MIDDLE = 0x112
+    BTN_SIDE = 0x113
+    BTN_EXTRA = 0x114
+
+
+class _FakeLinuxUInput:
+    @staticmethod
+    def from_device(*_args, **_kwargs):
+        return Mock()
+
+
 class LinuxMouseHookReconnectTests(unittest.TestCase):
     def _reload_for_linux(self):
-        with patch.object(sys, "platform", "linux"):
+        fake_evdev = SimpleNamespace(
+            ecodes=_FakeLinuxEcodes,
+            UInput=_FakeLinuxUInput,
+            InputDevice=Mock(name="InputDevice"),
+        )
+        with (
+            patch.object(sys, "platform", "linux"),
+            patch.dict(sys.modules, {"evdev": fake_evdev}),
+        ):
             importlib.reload(mouse_hook)
         self.addCleanup(importlib.reload, mouse_hook)
         return mouse_hook

--- a/tests/test_smart_shift.py
+++ b/tests/test_smart_shift.py
@@ -1,6 +1,8 @@
 """Tests for SmartShift (HID++ 0x2110/0x2111) across hid_gesture, engine, and backend."""
 
 import copy
+import threading
+import time
 import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -190,6 +192,52 @@ class SmartShiftReadTests(unittest.TestCase):
         listener._request = Mock(return_value=None)
         listener._apply_pending_read_smart_shift()
         self.assertIsNone(listener._smart_shift_result)
+
+
+class SmartShiftPendingRequestAbortTests(unittest.TestCase):
+    def test_read_abort_returns_none_instead_of_stale_result(self):
+        listener = hid_gesture.HidGestureListener()
+        listener._smart_shift_result = {"mode": "ratchet", "enabled": True, "threshold": 30}
+        seen = []
+        done = threading.Event()
+
+        def worker():
+            seen.append(listener.read_smart_shift())
+            done.set()
+
+        thread = threading.Thread(target=worker, daemon=True)
+        thread.start()
+        for _ in range(50):
+            if listener._pending_smart_shift == "read":
+                break
+            time.sleep(0.01)
+        listener._abort_pending_smart_shift()
+        done.wait(1)
+        thread.join(timeout=1)
+
+        self.assertEqual(seen, [None])
+
+    def test_write_abort_returns_false_instead_of_stale_success(self):
+        listener = hid_gesture.HidGestureListener()
+        listener._smart_shift_result = True
+        seen = []
+        done = threading.Event()
+
+        def worker():
+            seen.append(listener.set_smart_shift("ratchet", False, 25))
+            done.set()
+
+        thread = threading.Thread(target=worker, daemon=True)
+        thread.start()
+        for _ in range(50):
+            if listener._pending_smart_shift == ("ratchet", False, 25):
+                break
+            time.sleep(0.01)
+        listener._abort_pending_smart_shift()
+        done.wait(1)
+        thread.join(timeout=1)
+
+        self.assertEqual(seen, [False])
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/test_smart_shift.py
+++ b/tests/test_smart_shift.py
@@ -301,17 +301,18 @@ class EngineSmartShiftTests(unittest.TestCase):
             engine.start()
         hg.set_smart_shift.assert_not_called()
 
-    def test_reconnect_reapplies_saved_smart_shift(self):
-        """_apply_device_settings pushes saved SmartShift to device (reconnect path)."""
+    def test_run_saved_settings_replay_reapplies_saved_smart_shift(self):
+        """Live replay pushes saved SmartShift to the device after reconnect."""
         engine = self._make_engine({
             "smart_shift_mode": "ratchet",
             "smart_shift_enabled": False,
             "smart_shift_threshold": 30,
         })
         hg = Mock(smart_shift_supported=True)
+        hg.connected_device = SimpleNamespace(name="MX Master 3S")
         engine.hook._hid_gesture = hg
         with patch("time.sleep"):
-            engine._apply_device_settings("reconnect")
+            engine._run_saved_settings_replay()
         hg.set_smart_shift.assert_called_with("ratchet", False, 30)
 
     def test_on_connection_change_spawns_battery_poll_thread(self):
@@ -336,21 +337,22 @@ class EngineSmartShiftTests(unittest.TestCase):
         thread_names = [c.kwargs.get("name") for c in thread_cls.call_args_list]
         self.assertIn("SavedSettingsReplay", thread_names)
 
-    def test_apply_device_settings_retries_on_failure(self):
+    def test_run_saved_settings_replay_retries_on_failure(self):
         """On write failure (e.g. IOReturnBadArgument right after wake), retry once."""
         engine = self._make_engine({
             "smart_shift_enabled": True,
             "smart_shift_threshold": 25,
         })
         hg = Mock(smart_shift_supported=True)
-        # First call fails (device not ready), second succeeds
+        hg.connected_device = SimpleNamespace(name="MX Master 3S")
+        # First call fails (immediate write), second succeeds (settled replay)
         hg.set_smart_shift.side_effect = [False, True]
         engine.hook._hid_gesture = hg
         with patch("time.sleep"):
-            engine._apply_device_settings("reconnect")
+            engine._run_saved_settings_replay()
         self.assertEqual(hg.set_smart_shift.call_count, 2)
 
-    def test_apply_device_settings_notifies_ui_with_saved_state(self):
+    def test_run_saved_settings_replay_notifies_ui_with_saved_state(self):
         """UI must show the saved config, not stale hardware state read by the poll."""
         engine = self._make_engine({
             "smart_shift_mode": "ratchet",
@@ -358,11 +360,12 @@ class EngineSmartShiftTests(unittest.TestCase):
             "smart_shift_threshold": 30,
         })
         hg = Mock(smart_shift_supported=True)
+        hg.connected_device = SimpleNamespace(name="MX Master 3S")
         engine.hook._hid_gesture = hg
         received = []
         engine.set_smart_shift_read_callback(received.append)
         with patch("time.sleep"):
-            engine._apply_device_settings("startup")
+            engine._run_saved_settings_replay()
         # UI is notified twice: once immediately, once after the settled 3 s delay.
         self.assertGreaterEqual(len(received), 2)
         self.assertEqual(received[-1], {

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -879,16 +879,17 @@ class Backend(QObject):
     def _handleSmartShiftRead(self):
         """Runs on Qt main thread — updates config and notifies QML."""
         state = self._pending_smart_shift_state
-        if isinstance(state, dict):
-            settings = self._cfg.setdefault("settings", {})
-            settings["smart_shift_mode"] = state.get("mode", "ratchet")
-            settings["smart_shift_enabled"] = state.get("enabled", False)
-            # Only accept the device-reported threshold when SmartShift is
-            # enabled (device returns the real value 1-50).  When disabled the
-            # device returns 0xFF which the read code maps to a hardcoded 25,
-            # overwriting whatever the user chose in the UI.
-            if state.get("enabled", False):
-                settings["smart_shift_threshold"] = state.get("threshold", 25)
+        if not isinstance(state, dict):
+            return
+        settings = self._cfg.setdefault("settings", {})
+        settings["smart_shift_mode"] = state.get("mode", "ratchet")
+        settings["smart_shift_enabled"] = state.get("enabled", False)
+        # Only accept the device-reported threshold when SmartShift is
+        # enabled (device returns the real value 1-50).  When disabled the
+        # device returns 0xFF which the read code maps to a hardcoded 25,
+        # overwriting whatever the user chose in the UI.
+        if state.get("enabled", False):
+            settings["smart_shift_threshold"] = state.get("threshold", 25)
         self.smartShiftChanged.emit()
 
     def _onEngineStatusMessage(self, message):


### PR DESCRIPTION
## Problem

After sleep, reconnect, or cold start, Mouser could get stuck in a half-recovered state:

- **Settings lost** (#81, #48): saved DPI and Smart Shift were not reliably restored because the production replay path had no settle/retry. That logic only existed in dead code (`_apply_device_settings()`, which had zero callers).
- **Gesture/mode_shift recovery gaps** (#56): diverted button callbacks could stop firing after reconnect, and there were no regressions locking this behavior down.
- **Silent transport death**: if the HID device handle went stale (for example `IOHIDDeviceSetReport failed: 0xE00002C2` on macOS), the app stayed "connected" and kept polling Smart Shift every 15 seconds instead of reconnecting.
- **Stale UI updates**: replay sent Smart Shift state as a bare string instead of the dict the backend expected, so `smartShiftChanged` could fire without actually updating config.

## Fix

### Phased replay
Deleted the dead `_apply_device_settings()` helper and moved its settle/retry semantics into the live replay worker:
- **Phase A** (immediate): write saved Smart Shift so the wheel converges quickly
- **Phase B** (+3 s): re-fetch the HID handle, then write saved DPI and Smart Shift again
- **Phase C** (+5 s, only on failure): one final retry

Also moved `_emit_status()` outside `_replay_lock` to avoid callback-under-lock.

### Smart Shift serialization
Replaced the unsynchronized `_pending_smart_shift` busy-wait path with `threading.Event` plus separate call/slot locks. Reconnect cleanup now aborts pending Smart Shift requests so waiters never read stale state. Smart Shift polling is also suppressed while replay is in flight.

### Payload normalization
All engine-to-backend Smart Shift callbacks now use:
`{"mode": str, "enabled": bool, "threshold": int}`

Backend now returns early on non-dict payloads, and `smartShiftChanged` only fires after a valid update.

### Transport failure recovery
In `_request()`, active-session tx/rx exceptions now raise `IOError`, which drives the existing cleanup/reconnect path through `_main_loop()`. Discovery-time probe failures still return `None`.

This is intentionally error-code-agnostic and does not depend on any specific IOKit error code.

### Regression coverage
Added regressions for:
- replay restoring DPI and Smart Shift through the real worker path
- gesture and mode_shift callbacks firing again after reconnect
- `_divert_extras()` re-arming on reconnect and held state clearing before disconnect callbacks
- backend ignoring non-dict Smart Shift payloads without config mutation or signal emission
- Smart Shift polling being skipped during replay
- active-session transport failures raising reconnect-driving errors while discovery failures remain non-fatal

## Scope

- No config migration, no schema bump, and no new user-facing settings
- DPI still has the same pending-slot race shape, but it is deferred here because it has lower concurrency pressure
- `engine.set_smart_shift()` and `set_dpi()` remain synchronous; async dispatch is follow-up work
- `IOHIDManagerRegisterDeviceRemovalCallback` would be a more complete disconnect signal on macOS, but that is also follow-up work

## Tested on

- **macOS 15.5** (MX Master 3S over Bluetooth): full local test suite passed (`222` tests)
- **Nobara 43 KDE Wayland** (MX Master 3S over Bluetooth): full local test suite passed (`217` tests)