### PR TITLE
fix: reduce macos app size

### DIFF
--- a/Mouser-mac.spec
+++ b/Mouser-mac.spec
@@ -82,7 +82,6 @@ a = Analysis(
         "PySide6.QtUiTools",
         "PySide6.QtXml",
         "PySide6.QtConcurrent",
-        "PySide6.QtDBus",
         "PySide6.QtStateMachine",
         "PySide6.QtHttpServer",
         "PySide6.QtSpatialAudio",

--- a/Mouser-mac.spec
+++ b/Mouser-mac.spec
@@ -41,9 +41,130 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=[
+        # ── Aggressively trim unneeded PySide6 modules ──
+        "PySide6.QtWebEngine",
+        "PySide6.QtWebEngineCore",
+        "PySide6.QtWebEngineWidgets",
+        "PySide6.QtWebChannel",
+        "PySide6.QtWebSockets",
+        "PySide6.Qt3DCore",
+        "PySide6.Qt3DRender",
+        "PySide6.Qt3DInput",
+        "PySide6.Qt3DLogic",
+        "PySide6.Qt3DAnimation",
+        "PySide6.Qt3DExtras",
+        "PySide6.QtMultimedia",
+        "PySide6.QtMultimediaWidgets",
+        "PySide6.QtBluetooth",
+        "PySide6.QtNfc",
+        "PySide6.QtPositioning",
+        "PySide6.QtLocation",
+        "PySide6.QtSensors",
+        "PySide6.QtSerialPort",
+        "PySide6.QtSerialBus",
+        "PySide6.QtTest",
+        "PySide6.QtPdf",
+        "PySide6.QtPdfWidgets",
+        "PySide6.QtCharts",
+        "PySide6.QtDataVisualization",
+        "PySide6.QtRemoteObjects",
+        "PySide6.QtScxml",
+        "PySide6.QtSql",
+        "PySide6.QtTextToSpeech",
+        "PySide6.QtQuick3D",
+        "PySide6.QtVirtualKeyboard",
+        "PySide6.QtGraphs",
+        "PySide6.Qt5Compat",
+        # ── PySide6 designer / tools (not needed at runtime) ──
+        "PySide6.QtDesigner",
+        "PySide6.QtHelp",
+        "PySide6.QtUiTools",
+        "PySide6.QtXml",
+        "PySide6.QtConcurrent",
+        "PySide6.QtDBus",
+        "PySide6.QtStateMachine",
+        "PySide6.QtHttpServer",
+        "PySide6.QtSpatialAudio",
+        # ── Other unused stdlib modules ──
+        "unittest",
+        "xmlrpc",
+        "pydoc",
+        "doctest",
+        "tkinter",
+        "test",
+        "distutils",
+        "setuptools",
+        "ensurepip",
+        "lib2to3",
+        "idlelib",
+        "turtledemo",
+        "turtle",
+        "sqlite3",
+        "multiprocessing",
+    ],
     noarchive=False,
 )
+
+# ── Filter collected Qt shared libs / plugins that PyInstaller hooks may have pulled in ──
+UNWANTED_PATTERNS = [
+    "QtWebEngine",
+    "QtWebChannel",
+    "QtWebSockets",
+    "Qt3D",
+    "QtMultimedia",
+    "QtMultimediaWidgets",
+    "QtBluetooth",
+    "QtLocation",
+    "QtPositioning",
+    "QtSensors",
+    "QtSerialPort",
+    "QtPdf",
+    "QtCharts",
+    "QtDataVisualization",
+    "QtRemoteObjects",
+    "QtTextToSpeech",
+    "QtQuick3D",
+    "QtVirtualKeyboard",
+    "QtGraphs",
+    "Qt5Compat",
+    "QtWebView",
+    "QtTest",
+    "QtLabsAnimation",
+    "QtLabsFolderListModel",
+    "QtLabsPlatform",
+    "QtLabsQmlModels",
+    "QtLabsSettings",
+    "QtLabsSharedImage",
+    "QtLabsWavefrontMesh",
+    "QtQuickTest",
+    "QtScxml",
+    "QtScxmlQml",
+    "QtSpatialAudio",
+    "QtSql",
+]
+
+def is_unwanted(path_or_toc_entry):
+    # entry can be a (src, dest) tuple (TOC) or a string path
+    src = ""
+    if isinstance(path_or_toc_entry, (list, tuple)) and len(path_or_toc_entry) >= 1:
+        src = path_or_toc_entry[0] or ""
+    elif isinstance(path_or_toc_entry, str):
+        src = path_or_toc_entry
+    src_lower = src.lower()
+    for pat in UNWANTED_PATTERNS:
+        if pat.lower() in src_lower:
+            return True
+    # also drop plugin subdirectories commonly unused (webengine, multimedia, printsupport, etc.)
+    if "/plugins/" in src_lower:
+        for pat in ("webengine", "multimedia", "printsupport", "qmltooling", "sensorgestures"):
+            if pat in src_lower:
+                return True
+    return False
+
+# Filter Analysis.toc lists (binaries and datas)
+a.binaries = [b for b in a.binaries if not is_unwanted(b)]
+a.datas = [d for d in a.datas if not is_unwanted(d)]
 
 pyz = PYZ(a.pure)
 

--- a/Mouser-mac.spec
+++ b/Mouser-mac.spec
@@ -143,6 +143,29 @@ UNWANTED_PATTERNS = [
     "QtSql",
 ]
 
+# QtQuick.Controls.Material imports QtQuick.Controls.Basic, so keep the
+# Material and Basic stacks but drop the other optional style families.
+UNUSED_QUICK_CONTROLS_PATTERNS = [
+    "QtQuickControls2Fusion",
+    "QtQuickControls2FusionStyleImpl",
+    "QtQuickControls2Imagine",
+    "QtQuickControls2ImagineStyleImpl",
+    "QtQuickControls2Universal",
+    "QtQuickControls2UniversalStyleImpl",
+    "QtQuickControls2FluentWinUI3StyleImpl",
+    "QtQuickControls2IOSStyleImpl",
+    "QtQuickControls2MacOSStyleImpl",
+]
+
+UNUSED_QUICK_CONTROLS_QML_DIRS = [
+    "/qtquick/controls/fusion/",
+    "/qtquick/controls/fluentwinui3/",
+    "/qtquick/controls/imagine/",
+    "/qtquick/controls/universal/",
+    "/qtquick/controls/ios/",
+    "/qtquick/controls/macos/",
+]
+
 def is_unwanted(path_or_toc_entry):
     # entry can be a (src, dest) tuple (TOC) or a string path
     src = ""
@@ -153,6 +176,12 @@ def is_unwanted(path_or_toc_entry):
     src_lower = src.lower()
     for pat in UNWANTED_PATTERNS:
         if pat.lower() in src_lower:
+            return True
+    for pat in UNUSED_QUICK_CONTROLS_PATTERNS:
+        if pat.lower() in src_lower:
+            return True
+    for qml_dir in UNUSED_QUICK_CONTROLS_QML_DIRS:
+        if qml_dir in src_lower:
             return True
     # also drop plugin subdirectories commonly unused (webengine, multimedia, printsupport, etc.)
     if "/plugins/" in src_lower:


### PR DESCRIPTION
Reduce the macOS bundle by trimming unused Qt payloads while keeping the packaged dependency graph consistent.

## What Changed
- trims unused Qt frameworks/plugins from the macOS bundle
- keeps `QtDBus` bundled instead of excluding it, matching PyInstaller dependency discovery
- trims unused optional Qt Quick Controls styles while keeping `Material` + `Basic`

## Size Comparison
| Build | `.app` size | Release zip size |
| --- | ---: | ---: |
| Before (`master` @ `8948524`) | 438 MB (`448,808K`) | 161.7 MB (`163,900K`) |
| After (this PR @ `1b10e40`) | 146 MB (`149,336K`) | 54.6 MB (`54,260K`) |
| Delta | `-66.7%` | `-66.9%` |

Quick smoke test: `Mouser.app/Contents/MacOS/Mouser --start-hidden` launched cleanly after each change.
