### PR TITLE
Fix/logi bolt macos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ No telemetry. No cloud. No Logitech account required.
 - **Single instance guard** — launching a second copy brings the existing window to the front
 
 ### 🔌 Smart Connectivity
+- **Bluetooth and Logi Bolt** — works with both Bluetooth and Logi Bolt USB receivers; connection type shown in the UI
 - **Auto-reconnection** — detects power-off/on and restores full functionality without restarting
 - **Live connection status** — real-time "Connected" / "Not Connected" badge in the UI
 - **Device-aware UI** — interactive MX Master diagram with clickable hotspots; generic fallback for other models
@@ -376,7 +377,7 @@ mouser/
 │   ├── accessibility.py     # macOS Accessibility trust checks
 │   ├── engine.py            # Core engine — wires hook ↔ simulator ↔ config
 │   ├── mouse_hook.py        # Low-level mouse hook + HID++ gesture listener
-│   ├── hid_gesture.py       # HID++ 2.0 gesture button divert (Bluetooth)
+│   ├── hid_gesture.py       # HID++ 2.0 gesture button divert (Bluetooth + Logi Bolt)
 │   ├── logi_devices.py      # Known Logitech device catalog + connected-device metadata
 │   ├── device_layouts.py    # Device-family layout registry for QML overlays
 │   ├── key_simulator.py     # Platform-specific action simulator
@@ -430,7 +431,7 @@ The app has two pages accessible from a slim sidebar:
 
 - **Early multi-device support** — only the MX Master family currently has a dedicated interactive overlay; MX Anywhere, MX Vertical, and unknown Logitech mice still use the generic fallback card
 - **Per-device mappings are not fully separated yet** — layout overrides are stored per detected device, but profile mappings are still global rather than truly device-specific
-- **Bluetooth recommended** — HID++ gesture button divert works best over Bluetooth; USB receiver has partial support
+- **Bluetooth and Logi Bolt supported** — HID++ gesture button divert works over both Bluetooth and Logi Bolt USB receivers
 - **Conflicts with Logitech Options+** — both apps fight over HID++ access; quit Options+ before running Mouser
 - **Scroll inversion is experimental** — uses coalesced `PostMessage` injection to avoid LL hook deadlocks; may not work perfectly in all apps
 - **Admin not required** — but some games or elevated windows may not receive injected keystrokes

--- a/README_CN.md
+++ b/README_CN.md
@@ -34,8 +34,9 @@
 - **单实例**：重复启动会将已运行窗口置前
 
 ### 🔌 智能连接
+- **蓝牙和 Logi Bolt**：同时支持蓝牙和 Logi Bolt USB 接收器；连接方式显示在 UI 中
 - **自动重连**：检测鼠标断电/重连，无需重启即可恢复完整功能
-- **实时连接状态**：UI 中显示“Connected / Not Connected”
+- **实时连接状态**：UI 中显示”Connected / Not Connected”
 - **设备感知 UI**：MX Master 提供可点击热区的交互示意图；其他型号使用通用回退卡片
 
 ### 🌐 多语言 UI
@@ -396,7 +397,7 @@ mouser/
 │   ├── accessibility.py     # macOS Accessibility trust checks
 │   ├── engine.py            # Core engine — wires hook ↔ simulator ↔ config
 │   ├── mouse_hook.py        # Low-level mouse hook + HID++ gesture listener
-│   ├── hid_gesture.py       # HID++ 2.0 gesture button divert (Bluetooth)
+│   ├── hid_gesture.py       # HID++ 2.0 gesture button divert (Bluetooth + Logi Bolt)
 │   ├── logi_devices.py      # Known Logitech device catalog + connected-device metadata
 │   ├── device_layouts.py    # Device-family layout registry for QML overlays
 │   ├── key_simulator.py     # Platform-specific action simulator
@@ -452,7 +453,7 @@ mouser/
 
 - **Early multi-device support** — only the MX Master family currently has a dedicated interactive overlay; MX Anywhere, MX Vertical, and unknown Logitech mice still use the generic fallback card
 - **Per-device mappings are not fully separated yet** — layout overrides are stored per detected device, but profile mappings are still global rather than truly device-specific
-- **Bluetooth recommended** — HID++ gesture button divert works best over Bluetooth; USB receiver has partial support
+- **Bluetooth and Logi Bolt supported** — HID++ gesture button divert works over both Bluetooth and Logi Bolt USB receivers
 - **Conflicts with Logitech Options+** — both apps fight over HID++ access; quit Options+ before running Mouser
 - **Scroll inversion is experimental** — uses coalesced `PostMessage` injection to avoid LL hook deadlocks; may not work perfectly in all apps
 - **Admin not required** — but some games or elevated windows may not receive injected keystrokes

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -1426,6 +1426,14 @@ class HidGestureListener:
         if not infos:
             return False
 
+        # Try direct devices (Bluetooth) before USB receivers, which
+        # require scanning multiple slots with slow timeouts.
+        def _direct_device_first(info):
+            name = (info.get("product_string") or "").lower()
+            return (1 if "receiver" in name else 0, name)
+
+        infos.sort(key=_direct_device_first)
+
         print(f"[HidGesture] Backend preference: {_BACKEND_PREFERENCE}")
         print(f"[HidGesture] Candidate HID interfaces: {len(infos)}")
         for info in infos:
@@ -1460,8 +1468,8 @@ class HidGestureListener:
             opened_up = int(up or 0)
             opened_usage = int(usage or 0)
             open_attempts = []
-            if _BACKEND_PREFERENCE in ("auto", "hidapi") and info.get("path"):
-                open_attempts.append(("hidapi", info))
+            # On macOS, prefer IOKit (non-exclusive access) over hidapi
+            # which may lock the device and freeze the cursor.
             if (
                 sys.platform == "darwin"
                 and _MAC_NATIVE_OK
@@ -1476,6 +1484,8 @@ class HidGestureListener:
                         "transport": "Bluetooth Low Energy",
                     }),
                 ])
+            if _BACKEND_PREFERENCE in ("auto", "hidapi") and info.get("path"):
+                open_attempts.append(("hidapi", info))
 
             for transport, open_info in open_attempts:
                 try:
@@ -1573,10 +1583,15 @@ class HidGestureListener:
                             print(f"[HidGesture] Found BATTERY_STATUS @0x{batt_fi:02X}")
                     if self._divert():
                         self._divert_extras()
+                        actual_transport = (
+                            "Bluetooth"
+                            if idx == BT_DEV_IDX
+                            else "Logi Bolt"
+                        )
                         self._connected_device_info = build_connected_device_info(
                             product_id=pid,
                             product_name=hidpp_name or product,
-                            transport=open_info.get("transport") or transport,
+                            transport=actual_transport,
                             source=source,
                             gesture_cids=self._gesture_candidates,
                         )

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -468,6 +468,9 @@ SHORT_LEN      = 7
 LONG_LEN       = 20
 
 BT_DEV_IDX     = 0xFF        # device-index for direct Bluetooth
+# Known Logi Bolt receiver PID.
+# Source: https://github.com/pwr-Solaar/Solaar/blob/master/lib/logitech_receiver/base_usb.py
+BOLT_RECEIVER_PID = 0xC548
 FEAT_IROOT     = 0x0000
 FEAT_REPROG_V4 = 0x1B04      # Reprogrammable Controls V4
 FEAT_ADJ_DPI   = 0x2201      # Adjustable DPI
@@ -1583,11 +1586,12 @@ class HidGestureListener:
                             print(f"[HidGesture] Found BATTERY_STATUS @0x{batt_fi:02X}")
                     if self._divert():
                         self._divert_extras()
-                        actual_transport = (
-                            "Bluetooth"
-                            if idx == BT_DEV_IDX
-                            else "Logi Bolt"
-                        )
+                        if idx == BT_DEV_IDX:
+                            actual_transport = "Bluetooth"
+                        elif pid == BOLT_RECEIVER_PID:
+                            actual_transport = "Logi Bolt"
+                        else:
+                            actual_transport = "USB Receiver"
                         self._connected_device_info = build_connected_device_info(
                             product_id=pid,
                             product_name=hidpp_name or product,

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -147,8 +147,6 @@ if sys.platform == "darwin":
 
 def _default_backend_preference(platform_name=None):
     platform_name = sys.platform if platform_name is None else platform_name
-    if platform_name == "darwin":
-        return "iokit"
     return "auto"
 
 
@@ -1583,7 +1581,7 @@ class HidGestureListener:
                             gesture_cids=self._gesture_candidates,
                         )
                         return True
-                    break        # right device but divert failed
+                    continue     # divert failed — try next receiver slot
             if not reprog_found:
                 print(
                     "[HidGesture] Opened candidate but REPROG_V4 was not found "

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -359,8 +359,8 @@ class HidBoltReceiverTests(unittest.TestCase):
         # devIdx 0xFF (first tried) = Bluetooth
         self.assertEqual(listener.connected_device.transport, "Bluetooth")
 
-    def test_transport_label_logi_bolt_for_receiver_slot(self):
-        """devIdx 1-6 should produce 'Logi Bolt' transport."""
+    def test_transport_label_logi_bolt_for_bolt_receiver(self):
+        """devIdx 1-6 with Bolt PID 0xC548 should produce 'Logi Bolt'."""
         listener = hid_gesture.HidGestureListener()
         info = {
             "product_id": 0xC548,
@@ -371,14 +371,12 @@ class HidBoltReceiverTests(unittest.TestCase):
             "path": b"/dev/hidraw-test",
         }
         fake_dev = _FakeHidDevice()
-        # Simulate: 0xFF times out, slot 1 has the mouse
         call_count = [0]
 
         def fake_find_feature(feature_id):
             if feature_id != hid_gesture.FEAT_REPROG_V4:
                 return None
             call_count[0] += 1
-            # First call is devIdx=0xFF → not found, second is devIdx=1 → found
             return 0x09 if call_count[0] >= 2 else None
 
         with (
@@ -400,8 +398,49 @@ class HidBoltReceiverTests(unittest.TestCase):
         ):
             self.assertTrue(listener._try_connect())
 
-        # devIdx 1 = receiver slot = Logi Bolt
         self.assertEqual(listener.connected_device.transport, "Logi Bolt")
+
+    def test_transport_label_usb_receiver_for_non_bolt(self):
+        """devIdx 1-6 with non-Bolt PID (e.g. Unifying 0xC52B) should produce
+        'USB Receiver', not 'Logi Bolt'."""
+        listener = hid_gesture.HidGestureListener()
+        info = {
+            "product_id": 0xC52B,
+            "usage_page": 0xFF00,
+            "usage": 0x0001,
+            "source": "hidapi-enumerate",
+            "product_string": "USB Receiver",
+            "path": b"/dev/hidraw-test",
+        }
+        fake_dev = _FakeHidDevice()
+        call_count = [0]
+
+        def fake_find_feature(feature_id):
+            if feature_id != hid_gesture.FEAT_REPROG_V4:
+                return None
+            call_count[0] += 1
+            return 0x09 if call_count[0] >= 2 else None
+
+        with (
+            patch.object(listener, "_vendor_hid_infos", return_value=[info]),
+            patch.object(listener, "_find_feature", side_effect=fake_find_feature),
+            patch.object(listener, "_discover_reprog_controls", return_value=[]),
+            patch.object(listener, "_divert", return_value=True),
+            patch.object(listener, "_divert_extras"),
+            patch.object(hid_gesture, "HIDAPI_OK", True),
+            patch.object(hid_gesture, "_BACKEND_PREFERENCE", "hidapi"),
+            patch.object(hid_gesture, "_HID_API_STYLE", "hidapi"),
+            patch.object(
+                hid_gesture,
+                "_hid",
+                SimpleNamespace(device=lambda: fake_dev),
+                create=True,
+            ),
+            patch("builtins.print"),
+        ):
+            self.assertTrue(listener._try_connect())
+
+        self.assertEqual(listener.connected_device.transport, "USB Receiver")
 
 
 class HidReconnectInvariantTests(unittest.TestCase):

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -6,8 +6,8 @@ from core import hid_gesture
 
 
 class HidBackendPreferenceTests(unittest.TestCase):
-    def test_default_backend_uses_iokit_on_macos(self):
-        self.assertEqual(hid_gesture._default_backend_preference("darwin"), "iokit")
+    def test_default_backend_uses_auto_on_macos(self):
+        self.assertEqual(hid_gesture._default_backend_preference("darwin"), "auto")
 
     def test_default_backend_uses_auto_elsewhere(self):
         self.assertEqual(hid_gesture._default_backend_preference("win32"), "auto")

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -248,6 +248,162 @@ class HidRequestTransportFailureTests(unittest.TestCase):
         self.assertEqual(listener._consecutive_request_timeouts, 1)
 
 
+class HidBoltReceiverTests(unittest.TestCase):
+    """Tests for Logi Bolt receiver support."""
+
+    def test_divert_failure_continues_to_next_receiver_slot(self):
+        """When divert fails on one slot (e.g. keyboard), the loop
+        continues and connects to the mouse on a later slot."""
+        listener = hid_gesture.HidGestureListener()
+        info = {
+            "product_id": 0xC548,
+            "usage_page": 0xFF00,
+            "usage": 0x0001,
+            "source": "hidapi-enumerate",
+            "product_string": "USB Receiver",
+            "path": b"/dev/hidraw-test",
+        }
+        fake_dev = _FakeHidDevice()
+        divert_call_count = [0]
+
+        def fake_find_feature(feature_id):
+            if feature_id == hid_gesture.FEAT_REPROG_V4:
+                return 0x09
+            return None
+
+        def fake_divert():
+            divert_call_count[0] += 1
+            # First call fails (keyboard), second succeeds (mouse)
+            return divert_call_count[0] >= 2
+
+        with (
+            patch.object(listener, "_vendor_hid_infos", return_value=[info]),
+            patch.object(listener, "_find_feature", side_effect=fake_find_feature),
+            patch.object(listener, "_discover_reprog_controls", return_value=[]),
+            patch.object(listener, "_divert", side_effect=fake_divert),
+            patch.object(listener, "_divert_extras"),
+            patch.object(hid_gesture, "HIDAPI_OK", True),
+            patch.object(hid_gesture, "_BACKEND_PREFERENCE", "hidapi"),
+            patch.object(hid_gesture, "_HID_API_STYLE", "hidapi"),
+            patch.object(
+                hid_gesture,
+                "_hid",
+                SimpleNamespace(device=lambda: fake_dev),
+                create=True,
+            ),
+            patch("builtins.print"),
+        ):
+            self.assertTrue(listener._try_connect())
+            self.assertEqual(divert_call_count[0], 2)
+
+    def test_candidates_sorted_direct_devices_before_receivers(self):
+        """Bluetooth devices should be tried before USB receivers."""
+        listener = hid_gesture.HidGestureListener()
+        infos = [
+            {"product_string": "USB Receiver", "product_id": 0xC548,
+             "usage_page": 0xFF00, "usage": 1, "source": "hidapi"},
+            {"product_string": "MX Master 3S", "product_id": 0xB034,
+             "usage_page": 0xFF43, "usage": 1, "source": "hidapi"},
+            {"product_string": "USB Receiver", "product_id": 0xC548,
+             "usage_page": 0xFF00, "usage": 2, "source": "hidapi"},
+        ]
+
+        with patch.object(listener, "_vendor_hid_infos", return_value=infos):
+            # _try_connect sorts infos in place before iterating
+            with (
+                patch.object(listener, "_find_feature", return_value=None),
+                patch("builtins.print"),
+            ):
+                listener._try_connect()
+
+        # After sorting, direct device should be first
+        self.assertEqual(infos[0]["product_string"], "MX Master 3S")
+
+    def test_transport_label_bluetooth_for_direct_connection(self):
+        """devIdx 0xFF should produce 'Bluetooth' transport."""
+        listener = hid_gesture.HidGestureListener()
+        info = {
+            "product_id": 0xB034,
+            "usage_page": 0xFF00,
+            "usage": 0x0001,
+            "source": "hidapi-enumerate",
+            "product_string": "MX Master 3S",
+            "path": b"/dev/hidraw-test",
+        }
+        fake_dev = _FakeHidDevice()
+
+        def fake_find_feature(feature_id):
+            if feature_id == hid_gesture.FEAT_REPROG_V4:
+                return 0x09
+            return None
+
+        with (
+            patch.object(listener, "_vendor_hid_infos", return_value=[info]),
+            patch.object(listener, "_find_feature", side_effect=fake_find_feature),
+            patch.object(listener, "_discover_reprog_controls", return_value=[]),
+            patch.object(listener, "_divert", return_value=True),
+            patch.object(listener, "_divert_extras"),
+            patch.object(hid_gesture, "HIDAPI_OK", True),
+            patch.object(hid_gesture, "_BACKEND_PREFERENCE", "hidapi"),
+            patch.object(hid_gesture, "_HID_API_STYLE", "hidapi"),
+            patch.object(
+                hid_gesture,
+                "_hid",
+                SimpleNamespace(device=lambda: fake_dev),
+                create=True,
+            ),
+            patch("builtins.print"),
+        ):
+            self.assertTrue(listener._try_connect())
+
+        # devIdx 0xFF (first tried) = Bluetooth
+        self.assertEqual(listener.connected_device.transport, "Bluetooth")
+
+    def test_transport_label_logi_bolt_for_receiver_slot(self):
+        """devIdx 1-6 should produce 'Logi Bolt' transport."""
+        listener = hid_gesture.HidGestureListener()
+        info = {
+            "product_id": 0xC548,
+            "usage_page": 0xFF00,
+            "usage": 0x0001,
+            "source": "hidapi-enumerate",
+            "product_string": "USB Receiver",
+            "path": b"/dev/hidraw-test",
+        }
+        fake_dev = _FakeHidDevice()
+        # Simulate: 0xFF times out, slot 1 has the mouse
+        call_count = [0]
+
+        def fake_find_feature(feature_id):
+            if feature_id != hid_gesture.FEAT_REPROG_V4:
+                return None
+            call_count[0] += 1
+            # First call is devIdx=0xFF → not found, second is devIdx=1 → found
+            return 0x09 if call_count[0] >= 2 else None
+
+        with (
+            patch.object(listener, "_vendor_hid_infos", return_value=[info]),
+            patch.object(listener, "_find_feature", side_effect=fake_find_feature),
+            patch.object(listener, "_discover_reprog_controls", return_value=[]),
+            patch.object(listener, "_divert", return_value=True),
+            patch.object(listener, "_divert_extras"),
+            patch.object(hid_gesture, "HIDAPI_OK", True),
+            patch.object(hid_gesture, "_BACKEND_PREFERENCE", "hidapi"),
+            patch.object(hid_gesture, "_HID_API_STYLE", "hidapi"),
+            patch.object(
+                hid_gesture,
+                "_hid",
+                SimpleNamespace(device=lambda: fake_dev),
+                create=True,
+            ),
+            patch("builtins.print"),
+        ):
+            self.assertTrue(listener._try_connect())
+
+        # devIdx 1 = receiver slot = Logi Bolt
+        self.assertEqual(listener.connected_device.transport, "Logi Bolt")
+
+
 class HidReconnectInvariantTests(unittest.TestCase):
     def test_force_release_stale_holds_clears_gesture_and_extra_buttons(self):
         gesture_up = Mock()

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -83,6 +83,7 @@ class Backend(QObject):
         self._device_dpi_min = DEFAULT_DPI_MIN
         self._device_dpi_max = DEFAULT_DPI_MAX
         self._connected_device_source = ""
+        self._connected_device_transport = ""
         self._battery_level = -1
         self._hid_features_ready = False
         self._debug_lines = []
@@ -355,6 +356,10 @@ class Backend(QObject):
     @Property(str, notify=deviceInfoChanged)
     def connectedDeviceKey(self):
         return self._connected_device_key
+
+    @Property(str, notify=deviceInfoChanged)
+    def connectionType(self):
+        return self._connected_device_transport
 
     @Property(int, notify=deviceInfoChanged)
     def deviceDpiMin(self):
@@ -1012,6 +1017,7 @@ class Backend(QObject):
         device_key = getattr(device, "key", "") or ""
         display_name = getattr(device, "display_name", "") or "Logitech mouse"
         source = getattr(device, "source", "") or ""
+        transport = getattr(device, "transport", "") or ""
         dpi_min = getattr(device, "dpi_min", DEFAULT_DPI_MIN) or DEFAULT_DPI_MIN
         dpi_max = getattr(device, "dpi_max", DEFAULT_DPI_MAX) or DEFAULT_DPI_MAX
         info_changed = False
@@ -1023,6 +1029,9 @@ class Backend(QObject):
             info_changed = True
         if source != self._connected_device_source:
             self._connected_device_source = source
+            info_changed = True
+        if transport != self._connected_device_transport:
+            self._connected_device_transport = transport
             info_changed = True
         if dpi_min != self._device_dpi_min:
             self._device_dpi_min = dpi_min

--- a/ui/qml/MousePage.qml
+++ b/ui/qml/MousePage.qml
@@ -884,7 +884,10 @@ Item {
                                     }
                                     Text {
                                         text: backend.mouseConnected
-                                              ? s["mouse.connected"] : s["mouse.not_connected"]
+                                              ? (s["mouse.connected"]
+                                                 + (backend.connectionType !== ""
+                                                    ? " · " + backend.connectionType : ""))
+                                              : s["mouse.not_connected"]
                                         font { family: uiState.fontFamily; pixelSize: 11 }
                                         color: backend.mouseConnected
                                                ? theme.accent : "#e05555"


### PR DESCRIPTION
## Summary

  Fixes #59 — Logitech mice connected via a **Logi Bolt USB receiver** were not detected on macOS.

  **Root causes:**
  - The default HID backend on macOS was `iokit`-only, which skipped `hidapi` enumeration — the Bolt receiver's vendor-specific HID++ interfaces (`usage_page >= 0xFF00`) were never
  discovered
  - A `break` after failed `_divert()` stopped the device-index loop at the first non-mouse device (e.g. MX Keys S keyboard on slot 3), preventing discovery of mice on later slots

  **Changes:**
  - Default backend to `"auto"` on all platforms so `hidapi` enumerates alongside IOKit
  - On macOS, prefer IOKit for **opening** devices (non-exclusive access prevents cursor freeze), hidapi as fallback
  - Replace `break` with `continue` after divert failure so all receiver slots (1–6) are probed
  - Sort candidates so direct devices (Bluetooth) are tried before USB receivers — avoids ~10s of slot-scan timeouts for Bluetooth users
  - Show connection type ("Bluetooth" / "Logi Bolt") in the UI status badge
  - Update README + README_CN

  ## Testing

  Tested on macOS 15 (Apple Silicon) with MX Master 3S For Mac:
  - **Logi Bolt** (PID `0xC548`, receiver slot 4): all HID++ features working — REPROG_V4, DPI, Smart Shift, battery
  - **Bluetooth** (PID `0xB034`, devIdx `0xFF`): instant connection, no regression
 - Switching between modes requires an app restart (auto-reconnect on transport change is not yet supported)
  - 226 tests pass (4 new):
    - Divert failure continues to next receiver slot
    - Candidates sorted: direct devices before USB receivers
    - Transport label "Bluetooth" for devIdx 0xFF
    - Transport label "Logi Bolt" for receiver slots 1–6

  ## Screenshots

  Status badge shows **Connected · Logi Bolt** or **Connected · Bluetooth** depending on transport.

<img width="2548" height="1892" alt="Python 2026-04-12 17 09 06" src="https://github.com/user-attachments/assets/faad7668-af31-41e9-9634-17568be7128b" />
