### PR TITLE
feat: Support for Anywhere 2S model

### DIFF
--- a/core/device_layouts.py
+++ b/core/device_layouts.py
@@ -163,16 +163,6 @@ MX_ANYWHERE_2S_LAYOUT = {
     "note": "",
     "hotspots": [
         {
-            "buttonKey": "middle",
-            "label": "Middle button",
-            "summaryType": "mapping",
-            "normX": 0.33,
-            "normY": 0.46,
-            "labelSide": "left",
-            "labelOffX": -200,
-            "labelOffY": 90,
-        },
-        {
             "buttonKey": "gesture_up",
             "label": "Back button",
             "summaryType": "mapping",

--- a/core/device_layouts.py
+++ b/core/device_layouts.py
@@ -152,6 +152,79 @@ MX_ANYWHERE_LAYOUT = {
     ],
 }
 
+MX_ANYWHERE_2S_LAYOUT = {
+    "key": "mx_anywhere",
+    "label": "MX Anywhere family",
+    "image_asset": "mouse_mx_anywhere_3s.png",
+    "image_width": 400,
+    "image_height": 320,
+    "interactive": True,
+    "manual_selectable": True,
+    "note": "",
+    "hotspots": [
+        {
+            "buttonKey": "middle",
+            "label": "Middle button",
+            "summaryType": "mapping",
+            "normX": 0.33,
+            "normY": 0.46,
+            "labelSide": "left",
+            "labelOffX": -200,
+            "labelOffY": 90,
+        },
+        {
+            "buttonKey": "gesture_up",
+            "label": "Back button",
+            "summaryType": "mapping",
+            "normX": 0.39,
+            "normY": 0.57,
+            "labelSide": "left",
+            "labelOffX": 200,
+            "labelOffY": 80,
+        },
+        {
+            "buttonKey": "gesture_down",
+            "label": "Forward button",
+            "summaryType": "mapping",
+            "normX": 0.26,
+            "normY": 0.44,
+            "labelSide": "left",
+            "labelOffX": -20,
+            "labelOffY": -30,
+        },
+        {
+            "buttonKey": "gesture",
+            "label": "Gesture button",
+            "summaryType": "gesture",
+            "normX": 0.46,
+            "normY": 0.28,
+            "labelSide": "right",
+            "labelOffX": 150,
+            "labelOffY": -70,
+        },
+        {
+            "buttonKey": "xbutton2",
+            "label": "Forward button",
+            "summaryType": "mapping",
+            "normX": 0.69,
+            "normY": 0.53,
+            "labelSide": "right",
+            "labelOffX": 150,
+            "labelOffY": 30,
+        },
+        {
+            "buttonKey": "xbutton1",
+            "label": "Back button",
+            "summaryType": "mapping",
+            "normX": 0.75,
+            "normY": 0.45,
+            "labelSide": "right",
+            "labelOffX": 200,
+            "labelOffY": -45,
+        },
+    ],
+}
+
 MX_VERTICAL_LAYOUT = {
     "key": "mx_vertical",
     "label": "MX Vertical family",
@@ -209,6 +282,7 @@ MX_VERTICAL_LAYOUT = {
 DEVICE_LAYOUTS = {
     "mx_master": MX_MASTER_LAYOUT,
     "mx_anywhere": MX_ANYWHERE_LAYOUT,
+    "mx_anywhere_2s": MX_ANYWHERE_2S_LAYOUT,
     "mx_vertical": MX_VERTICAL_LAYOUT,
     "generic_mouse": GENERIC_MOUSE_LAYOUT,
 }
@@ -223,7 +297,7 @@ _FAMILY_FALLBACKS = {
     "mx_master_2s": "mx_master",
     "mx_anywhere_3s": "mx_anywhere",
     "mx_anywhere_3": "mx_anywhere",
-    "mx_anywhere_2s": "mx_anywhere",
+    "mx_anywhere_2s": "mx_anywhere_2s",
 }
 
 

--- a/core/device_layouts.py
+++ b/core/device_layouts.py
@@ -153,8 +153,8 @@ MX_ANYWHERE_LAYOUT = {
 }
 
 MX_ANYWHERE_2S_LAYOUT = {
-    "key": "mx_anywhere",
-    "label": "MX Anywhere family",
+    "key": "mx_anywhere_2s",
+    "label": "MX Anywhere 2S",
     "image_asset": "mouse_mx_anywhere_3s.png",
     "image_width": 400,
     "image_height": 320,
@@ -163,9 +163,10 @@ MX_ANYWHERE_2S_LAYOUT = {
     "note": "",
     "hotspots": [
         {
-            "buttonKey": "gesture_up",
-            "label": "Back button",
-            "summaryType": "mapping",
+            "buttonKey": "hscroll_left",
+            "label": "Wheel Left",
+            "summaryType": "hscroll",
+            "isHScroll": True,
             "normX": 0.39,
             "normY": 0.57,
             "labelSide": "left",
@@ -173,9 +174,10 @@ MX_ANYWHERE_2S_LAYOUT = {
             "labelOffY": 80,
         },
         {
-            "buttonKey": "gesture_down",
-            "label": "Forward button",
-            "summaryType": "mapping",
+            "buttonKey": "hscroll_right",
+            "label": "Wheel Right",
+            "summaryType": "hscroll",
+            "isHScroll": True,
             "normX": 0.26,
             "normY": 0.44,
             "labelSide": "left",
@@ -287,7 +289,6 @@ _FAMILY_FALLBACKS = {
     "mx_master_2s": "mx_master",
     "mx_anywhere_3s": "mx_anywhere",
     "mx_anywhere_3": "mx_anywhere",
-    "mx_anywhere_2s": "mx_anywhere_2s",
 }
 
 

--- a/core/logi_devices.py
+++ b/core/logi_devices.py
@@ -47,6 +47,12 @@ MX_ANYWHERE_BUTTONS = (
     "xbutton2",
 )
 
+MX_ANYWHERE_2S_BUTTONS = (
+    *MX_ANYWHERE_BUTTONS,
+    "hscroll_left",
+    "hscroll_right",
+)
+
 # MX Vertical has no gesture button, no horizontal scroll, no mode-shift,
 # but has a dedicated DPI switch button on top.
 MX_VERTICAL_BUTTONS = (
@@ -188,7 +194,7 @@ KNOWN_LOGI_DEVICES = (
         aliases=("Wireless Mobile Mouse MX Anywhere 2S",),
         ui_layout="mx_anywhere_2s",
         image_asset="mouse_mx_anywhere_3s.png",
-        supported_buttons=MX_ANYWHERE_BUTTONS,
+        supported_buttons=MX_ANYWHERE_2S_BUTTONS,
         dpi_max=4000,
     ),
 )
@@ -223,6 +229,7 @@ def resolve_device(product_id=None, product_name=None) -> LogiDeviceSpec | None:
 _LAYOUT_BUTTONS = {
     "mx_master": MX_MASTER_BUTTONS,
     "mx_anywhere": MX_ANYWHERE_BUTTONS,
+    "mx_anywhere_2s": MX_ANYWHERE_2S_BUTTONS,
     "mx_vertical": MX_VERTICAL_BUTTONS,
     "generic_mouse": GENERIC_BUTTONS,
 }

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -104,6 +104,35 @@ class BackendDeviceLayoutTests(unittest.TestCase):
 
         self.assertEqual(backend.deviceImageSource, expected)
 
+    def test_mx_anywhere_2s_hotspots_expose_hscroll_pair(self):
+        device = SimpleNamespace(
+            key="mx_anywhere_2s",
+            display_name="MX Anywhere 2S",
+            dpi_min=200,
+            dpi_max=4000,
+            ui_layout="mx_anywhere_2s",
+            supported_buttons=("middle", "hscroll_left", "hscroll_right"),
+        )
+        backend = self._make_backend(
+            engine=_FakeEngine(device_connected=True, connected_device=device)
+        )
+
+        hscroll_hotspots = [
+            hotspot
+            for hotspot in backend.deviceHotspots
+            if hotspot.get("isHScroll")
+        ]
+
+        self.assertEqual(len(hscroll_hotspots), 2)
+        self.assertEqual(
+            {hotspot["buttonKey"] for hotspot in hscroll_hotspots},
+            {"hscroll_left", "hscroll_right"},
+        )
+        self.assertEqual(
+            {hotspot["summaryType"] for hotspot in hscroll_hotspots},
+            {"hscroll"},
+        )
+
     def test_disconnected_override_request_does_not_persist(self):
         backend = self._make_backend()
         backend._connected_device_key = "mx_master_3"

--- a/tests/test_device_layouts.py
+++ b/tests/test_device_layouts.py
@@ -1,6 +1,6 @@
 import unittest
 
-from core.device_layouts import get_device_layout, get_manual_layout_choices
+from core.device_layouts import _FAMILY_FALLBACKS, get_device_layout, get_manual_layout_choices
 
 
 class DeviceLayoutTests(unittest.TestCase):
@@ -26,6 +26,11 @@ class DeviceLayoutTests(unittest.TestCase):
         self.assertIn({"key": "mx_anywhere", "label": "MX Anywhere family"}, choices)
         self.assertIn({"key": "mx_vertical", "label": "MX Vertical family"}, choices)
 
+    def test_manual_choices_do_not_duplicate_layout_keys(self):
+        keys = [choice["key"] for choice in get_manual_layout_choices() if choice["key"]]
+
+        self.assertEqual(len(keys), len(set(keys)))
+
     def test_mx_anywhere_layout_is_interactive(self):
         layout = get_device_layout("mx_anywhere")
 
@@ -34,7 +39,7 @@ class DeviceLayoutTests(unittest.TestCase):
         self.assertGreater(len(layout["hotspots"]), 0)
 
     def test_mx_anywhere_device_specific_keys_use_family_layout(self):
-        for layout_key in ("mx_anywhere_3s", "mx_anywhere_3", "mx_anywhere_2s"):
+        for layout_key in ("mx_anywhere_3s", "mx_anywhere_3"):
             with self.subTest(layout_key=layout_key):
                 layout = get_device_layout(layout_key)
 
@@ -42,6 +47,38 @@ class DeviceLayoutTests(unittest.TestCase):
                 self.assertTrue(layout["interactive"])
                 self.assertEqual(layout["image_asset"], "mouse_mx_anywhere_3s.png")
                 self.assertGreater(len(layout["hotspots"]), 0)
+
+    def test_mx_anywhere_2s_layout_identity_and_wheel_tilt_hotspots(self):
+        layout = get_device_layout("mx_anywhere_2s")
+
+        self.assertEqual(layout["key"], "mx_anywhere_2s")
+        self.assertEqual(layout["label"], "MX Anywhere 2S")
+        hotspots = {hotspot["buttonKey"]: hotspot for hotspot in layout["hotspots"]}
+        self.assertNotIn("gesture_up", hotspots)
+        self.assertNotIn("gesture_down", hotspots)
+
+        left = hotspots["hscroll_left"]
+        self.assertEqual(left["label"], "Wheel Left")
+        self.assertEqual(left["summaryType"], "hscroll")
+        self.assertTrue(left["isHScroll"])
+        self.assertEqual(left["normX"], 0.39)
+        self.assertEqual(left["normY"], 0.57)
+        self.assertEqual(left["labelSide"], "left")
+        self.assertEqual(left["labelOffX"], 200)
+        self.assertEqual(left["labelOffY"], 80)
+
+        right = hotspots["hscroll_right"]
+        self.assertEqual(right["label"], "Wheel Right")
+        self.assertEqual(right["summaryType"], "hscroll")
+        self.assertTrue(right["isHScroll"])
+        self.assertEqual(right["normX"], 0.26)
+        self.assertEqual(right["normY"], 0.44)
+        self.assertEqual(right["labelSide"], "left")
+        self.assertEqual(right["labelOffX"], -20)
+        self.assertEqual(right["labelOffY"], -30)
+
+    def test_mx_anywhere_2s_has_no_self_fallback(self):
+        self.assertNotEqual(_FAMILY_FALLBACKS.get("mx_anywhere_2s"), "mx_anywhere_2s")
 
     def test_mx_vertical_layout_is_interactive(self):
         layout = get_device_layout("mx_vertical")

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -3,6 +3,7 @@ import unittest
 from core.device_layouts import get_device_layout
 from core.logi_devices import (
     DEFAULT_GESTURE_CIDS,
+    MX_ANYWHERE_2S_BUTTONS,
     build_connected_device_info,
     clamp_dpi,
     get_buttons_for_layout,
@@ -102,6 +103,18 @@ class LogiDeviceRegistryTests(unittest.TestCase):
     def test_clamp_dpi_defaults_without_device(self):
         self.assertEqual(clamp_dpi(100, None), 200)
         self.assertEqual(clamp_dpi(9000, None), 8000)
+
+    def test_mx_anywhere_2s_supported_buttons_include_middle_and_hscroll(self):
+        device = resolve_device(product_id=0xB01A)
+
+        self.assertIsNotNone(device)
+        self.assertIs(device.supported_buttons, MX_ANYWHERE_2S_BUTTONS)
+        self.assertIn("middle", device.supported_buttons)
+        self.assertIn("hscroll_left", device.supported_buttons)
+        self.assertIn("hscroll_right", device.supported_buttons)
+
+    def test_get_buttons_for_mx_anywhere_2s_layout_uses_specific_tuple(self):
+        self.assertIs(get_buttons_for_layout("mx_anywhere_2s"), MX_ANYWHERE_2S_BUTTONS)
 
 
 if __name__ == "__main__":

--- a/ui/qml/HotspotDot.qml
+++ b/ui/qml/HotspotDot.qml
@@ -29,7 +29,8 @@ Item {
     property real cx: imgItem.x + imgItem.offX + normX * imgItem.paintedWidth
     property real cy: imgItem.y + imgItem.offY + normY * imgItem.paintedHeight
 
-    property bool isSelected: mousePage.selectedButton === buttonKey
+    property bool isSelected: isHScroll ? mousePage.selectedButton === "hscroll_left"
+                                        : mousePage.selectedButton === buttonKey
     property bool isHovered: dotMa.containsMouse
     property real labelWidth: labelCol.implicitWidth + 20
     property real labelHeight: labelCol.implicitHeight + 14


### PR DESCRIPTION
#96 #94 -Support for Anywhere 2S model.
- Removed Middle Click: On this model, the middle button is a physical switch for scroll wheel friction (ratchet/freespin) and lacks electronic trigger functionality.
- Added Back and Forward mappings: Since the tilt wheel on this model supports left and right clicks, these have been mapped to Back and Forward functions.
- Verified on Windows: See the screenshot below for the implementation.
<img width="740" height="700" alt="image" src="https://github.com/user-attachments/assets/5c888ef6-29da-4e03-8b53-8e50175d5ea8" />
