### PR TITLE
fix: preserve scroll mode fallback when Smart Shift is enabled

### DIFF
--- a/tests/test_smart_shift.py
+++ b/tests/test_smart_shift.py
@@ -494,12 +494,32 @@ class BackendSmartShiftTests(unittest.TestCase):
         engine_mock.set_smart_shift.assert_called_once_with("ratchet", True, 45)
 
     def test_handle_smart_shift_read_updates_in_memory_config(self):
-        backend = self._make_backend()
+        backend = self._make_backend({"smart_shift_threshold": 42})
         with patch("ui.backend.save_config") as save_mock:
             # Simulate the two-step cross-thread call: stage state, then invoke handler
-            backend._pending_smart_shift_state = {"mode": "freespin", "enabled": True, "threshold": 35}
+            backend._pending_smart_shift_state = {"mode": "freespin", "enabled": False, "threshold": 35}
             backend._handleSmartShiftRead()
         # Hardware reads should NOT be persisted — user's explicit saves drive the file.
+        save_mock.assert_not_called()
+        self.assertEqual(backend._cfg["settings"]["smart_shift_mode"], "freespin")
+        self.assertFalse(backend._cfg["settings"]["smart_shift_enabled"])
+        self.assertEqual(backend._cfg["settings"]["smart_shift_threshold"], 42)
+
+    def test_handle_smart_shift_read_preserves_saved_fallback_mode_when_enabled(self):
+        backend = self._make_backend({
+            "smart_shift_mode": "freespin",
+            "smart_shift_enabled": True,
+            "smart_shift_threshold": 30,
+        })
+        with patch("ui.backend.save_config") as save_mock:
+            # Real hardware reads report enabled SmartShift as ratchet + threshold,
+            # which must not overwrite the user's saved fixed-mode fallback.
+            backend._pending_smart_shift_state = {
+                "mode": "ratchet",
+                "enabled": True,
+                "threshold": 35,
+            }
+            backend._handleSmartShiftRead()
         save_mock.assert_not_called()
         self.assertEqual(backend._cfg["settings"]["smart_shift_mode"], "freespin")
         self.assertTrue(backend._cfg["settings"]["smart_shift_enabled"])

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -882,13 +882,20 @@ class Backend(QObject):
         if not isinstance(state, dict):
             return
         settings = self._cfg.setdefault("settings", {})
-        settings["smart_shift_mode"] = state.get("mode", "ratchet")
-        settings["smart_shift_enabled"] = state.get("enabled", False)
+        mode = state.get("mode", "ratchet")
+        enabled = bool(state.get("enabled", False))
+        settings["smart_shift_enabled"] = enabled
+        # Hardware reads cannot report the user's saved fixed-mode fallback while
+        # SmartShift auto-switching is enabled: the device only exposes ratchet +
+        # threshold in that state. Preserve the existing fallback mode unless the
+        # callback explicitly carries free-spin (the engine's saved-state replay).
+        if not enabled or mode == "freespin":
+            settings["smart_shift_mode"] = mode
         # Only accept the device-reported threshold when SmartShift is
         # enabled (device returns the real value 1-50).  When disabled the
         # device returns 0xFF which the read code maps to a hardcoded 25,
         # overwriting whatever the user chose in the UI.
-        if state.get("enabled", False):
+        if enabled:
             settings["smart_shift_threshold"] = state.get("threshold", 25)
         self.smartShiftChanged.emit()
 


### PR DESCRIPTION
## Summary
This fixes the Smart Shift persistence bug reported in #84.

When Smart Shift is enabled, the hardware readback only reports `ratchet + threshold`, not the user's saved fallback fixed mode. The backend was treating that read as authoritative and overwriting a previously saved `freespin` fallback to `ratchet`, which made `Toggle SmartShift` come back in Ratchet after restart.

## What changed
- preserve the saved fallback scroll mode while Smart Shift is enabled
- still accept the device-reported threshold while Smart Shift is enabled
- add a regression test for the `Free Spin -> enable Smart Shift -> restart -> Toggle SmartShift falls back to Ratchet` path

## Validation
- `python3 -m unittest tests.test_smart_shift`
- `python3 -m unittest tests.test_engine`

Refs #84
