### PR TITLE
fix: custom shortcut parsing for number keys

### DIFF
--- a/core/key_simulator.py
+++ b/core/key_simulator.py
@@ -29,6 +29,27 @@ def valid_custom_key_names():
         return []
 
 
+_CUSTOM_KEY_NAME_ALIASES = {
+    "control": "ctrl",
+    "option": "alt",
+    "cmd": "super",
+    "command": "super",
+    "meta": "super",
+    "return": "enter",
+    "escape": "esc",
+}
+
+
+def _build_custom_key_name_map(base_map):
+    """Add common aliases to a per-platform key-name map."""
+    key_map = dict(base_map)
+    for alias, canonical in _CUSTOM_KEY_NAME_ALIASES.items():
+        code = key_map.get(canonical)
+        if code is not None:
+            key_map[alias] = code
+    return key_map
+
+
 def _parse_custom_combo(action_id, key_name_to_code):
     """Parse 'custom:ctrl+a' → list of platform key codes using given mapping."""
     if not action_id.startswith("custom:"):
@@ -502,13 +523,15 @@ if sys.platform == "win32":
         },
     }
 
-    _KEY_NAME_TO_CODE = {
+    _KEY_NAME_TO_CODE = _build_custom_key_name_map({
         "ctrl": VK_CONTROL, "shift": VK_SHIFT, "alt": VK_MENU,
         "super": VK_LWIN, "tab": VK_TAB, "space": VK_SPACE,
         "enter": VK_RETURN, "esc": VK_ESCAPE, "backspace": VK_BACK,
         "delete": VK_DELETE, "left": VK_LEFT, "right": VK_RIGHT,
         "up": VK_UP, "down": VK_DOWN,
         "pageup": VK_PRIOR, "pagedown": VK_NEXT, "home": VK_HOME, "end": VK_END,
+        "0": 0x30, "1": 0x31, "2": 0x32, "3": 0x33, "4": 0x34,
+        "5": 0x35, "6": 0x36, "7": 0x37, "8": 0x38, "9": 0x39,
         "a": 0x41, "b": 0x42, "c": 0x43, "d": 0x44, "e": 0x45,
         "f": 0x46, "g": 0x47, "h": 0x48, "i": 0x49, "j": 0x4A,
         "k": 0x4B, "l": 0x4C, "m": 0x4D, "n": 0x4E, "o": 0x4F,
@@ -521,7 +544,7 @@ if sys.platform == "win32":
         "volumeup": VK_VOLUME_UP, "volumedown": VK_VOLUME_DOWN,
         "mute": VK_VOLUME_MUTE, "playpause": VK_MEDIA_PLAY_PAUSE,
         "nexttrack": VK_MEDIA_NEXT_TRACK, "prevtrack": VK_MEDIA_PREV_TRACK,
-    }
+    })
 
     def execute_action(action_id):
         try:
@@ -594,6 +617,16 @@ elif sys.platform == "darwin":
     kVK_ANSI_S = 0x01
     kVK_ANSI_D = 0x02
     kVK_ANSI_F = 0x03
+    kVK_ANSI_1 = 0x12
+    kVK_ANSI_2 = 0x13
+    kVK_ANSI_3 = 0x14
+    kVK_ANSI_4 = 0x15
+    kVK_ANSI_6 = 0x16
+    kVK_ANSI_5 = 0x17
+    kVK_ANSI_9 = 0x19
+    kVK_ANSI_7 = 0x1A
+    kVK_ANSI_0 = 0x1D
+    kVK_ANSI_8 = 0x1C
     kVK_ANSI_N = 0x2D
     kVK_ANSI_T = 0x11
     kVK_ANSI_W = 0x0D
@@ -1063,7 +1096,7 @@ elif sys.platform == "darwin":
         },
     }
 
-    _KEY_NAME_TO_CODE = {
+    _KEY_NAME_TO_CODE = _build_custom_key_name_map({
         "ctrl": kVK_Control, "shift": kVK_Shift, "alt": kVK_Option,
         "super": kVK_Command, "tab": kVK_Tab, "space": kVK_Space,
         "enter": kVK_Return, "esc": kVK_Escape, "backspace": kVK_Delete,
@@ -1071,6 +1104,10 @@ elif sys.platform == "darwin":
         "right": kVK_RightArrow, "up": kVK_UpArrow, "down": kVK_DownArrow,
         "pageup": kVK_PageUp, "pagedown": kVK_PageDown,
         "home": kVK_Home, "end": kVK_End,
+        "0": kVK_ANSI_0, "1": kVK_ANSI_1, "2": kVK_ANSI_2,
+        "3": kVK_ANSI_3, "4": kVK_ANSI_4, "5": kVK_ANSI_5,
+        "6": kVK_ANSI_6, "7": kVK_ANSI_7, "8": kVK_ANSI_8,
+        "9": kVK_ANSI_9,
         "a": 0x00, "b": 0x0B, "c": 0x08, "d": 0x02, "e": 0x0E,
         "f": 0x03, "g": 0x05, "h": 0x04, "i": 0x22, "j": 0x26,
         "k": 0x28, "l": 0x25, "m": 0x2E, "n": 0x2D, "o": 0x1F,
@@ -1080,7 +1117,7 @@ elif sys.platform == "darwin":
         "f1": kVK_F1, "f2": kVK_F2, "f3": kVK_F3, "f4": kVK_F4,
         "f5": kVK_F5, "f6": kVK_F6, "f7": kVK_F7, "f8": kVK_F8,
         "f9": kVK_F9, "f10": kVK_F10, "f11": kVK_F11, "f12": kVK_F12,
-    }
+    })
 
     def execute_action(action_id):
         if action_id.startswith("custom:"):
@@ -1127,6 +1164,16 @@ elif sys.platform == "linux":
     KEY_PAGEDOWN = 109
     KEY_HOME = 102
     KEY_END = 107
+    KEY_1 = 2
+    KEY_2 = 3
+    KEY_3 = 4
+    KEY_4 = 5
+    KEY_5 = 6
+    KEY_6 = 7
+    KEY_7 = 8
+    KEY_8 = 9
+    KEY_9 = 10
+    KEY_0 = 11
     KEY_A = 30; KEY_B = 48; KEY_C = 46; KEY_D = 32; KEY_E = 18
     KEY_F = 33; KEY_G = 34; KEY_H = 35; KEY_I = 23; KEY_J = 36
     KEY_K = 37; KEY_L = 38; KEY_M = 50; KEY_N = 49; KEY_O = 24
@@ -1159,6 +1206,8 @@ elif sys.platform == "linux":
         KEY_TAB, KEY_SPACE, KEY_ENTER, KEY_BACKSPACE, KEY_DELETE, KEY_ESC,
         KEY_LEFT, KEY_UP, KEY_RIGHT, KEY_DOWN,
         KEY_PAGEUP, KEY_PAGEDOWN, KEY_HOME, KEY_END,
+        KEY_0, KEY_1, KEY_2, KEY_3, KEY_4,
+        KEY_5, KEY_6, KEY_7, KEY_8, KEY_9,
         KEY_A, KEY_B, KEY_C, KEY_D, KEY_E, KEY_F, KEY_G, KEY_H, KEY_I,
         KEY_J, KEY_K, KEY_L, KEY_M, KEY_N, KEY_O, KEY_P, KEY_Q, KEY_R,
         KEY_S, KEY_T, KEY_U, KEY_V, KEY_W, KEY_X, KEY_Y, KEY_Z,
@@ -1466,7 +1515,7 @@ elif sys.platform == "linux":
         },
     }
 
-    _KEY_NAME_TO_CODE = {
+    _KEY_NAME_TO_CODE = _build_custom_key_name_map({
         "ctrl": KEY_LEFTCTRL, "shift": KEY_LEFTSHIFT, "alt": KEY_LEFTALT,
         "super": KEY_LEFTMETA, "tab": KEY_TAB, "space": KEY_SPACE,
         "enter": KEY_ENTER, "esc": KEY_ESC, "backspace": KEY_BACKSPACE,
@@ -1474,6 +1523,8 @@ elif sys.platform == "linux":
         "up": KEY_UP, "down": KEY_DOWN,
         "pageup": KEY_PAGEUP, "pagedown": KEY_PAGEDOWN,
         "home": KEY_HOME, "end": KEY_END,
+        "0": KEY_0, "1": KEY_1, "2": KEY_2, "3": KEY_3, "4": KEY_4,
+        "5": KEY_5, "6": KEY_6, "7": KEY_7, "8": KEY_8, "9": KEY_9,
         "a": KEY_A, "b": KEY_B, "c": KEY_C, "d": KEY_D, "e": KEY_E,
         "f": KEY_F, "g": KEY_G, "h": KEY_H, "i": KEY_I, "j": KEY_J,
         "k": KEY_K, "l": KEY_L, "m": KEY_M, "n": KEY_N, "o": KEY_O,
@@ -1486,7 +1537,7 @@ elif sys.platform == "linux":
         "volumeup": KEY_VOLUMEUP, "volumedown": KEY_VOLUMEDOWN,
         "mute": KEY_MUTE, "playpause": KEY_PLAYPAUSE,
         "nexttrack": KEY_NEXTSONG, "prevtrack": KEY_PREVIOUSSONG,
-    }
+    })
 
     def execute_action(action_id):
         if action_id.startswith("custom:"):

--- a/tests/test_key_simulator.py
+++ b/tests/test_key_simulator.py
@@ -24,6 +24,33 @@ class KeySimulatorActionTests(unittest.TestCase):
         self.assertTrue(len(key_simulator.ACTIONS["next_tab"]["keys"]) > 0)
         self.assertTrue(len(key_simulator.ACTIONS["prev_tab"]["keys"]) > 0)
 
+
+class CustomShortcutParsingTests(unittest.TestCase):
+    def test_build_custom_key_name_map_adds_common_aliases(self):
+        key_map = key_simulator._build_custom_key_name_map({
+            "ctrl": 1,
+            "alt": 2,
+            "super": 3,
+            "enter": 4,
+            "esc": 5,
+        })
+
+        self.assertEqual(key_map["control"], 1)
+        self.assertEqual(key_map["option"], 2)
+        self.assertEqual(key_map["cmd"], 3)
+        self.assertEqual(key_map["command"], 3)
+        self.assertEqual(key_map["meta"], 3)
+        self.assertEqual(key_map["return"], 4)
+        self.assertEqual(key_map["escape"], 5)
+
+    def test_parse_custom_combo_accepts_digit_keys(self):
+        keys = key_simulator._parse_custom_combo(
+            "custom:ctrl+4",
+            {"ctrl": 17, "4": 52},
+        )
+        self.assertEqual(keys, [17, 52])
+
+
 class LinuxDesktopShortcutTests(unittest.TestCase):
     def _reload_for_linux(self, desktop: str):
         with (
@@ -57,6 +84,14 @@ class LinuxDesktopShortcutTests(unittest.TestCase):
             module.ACTIONS["space_right"]["keys"],
             [module.KEY_LEFTCTRL, module.KEY_LEFTMETA, module.KEY_RIGHT],
         )
+
+    def test_linux_custom_shortcuts_include_digit_keys_and_aliases(self):
+        module = self._reload_for_linux("GNOME")
+
+        self.assertEqual(module._KEY_NAME_TO_CODE["4"], module.KEY_4)
+        self.assertIn(module.KEY_4, module._ALL_KEY_CODES)
+        self.assertEqual(module._KEY_NAME_TO_CODE["control"], module.KEY_LEFTCTRL)
+        self.assertEqual(module._KEY_NAME_TO_CODE["cmd"], module.KEY_LEFTMETA)
 
 class MouseButtonActionTests(unittest.TestCase):
     """Tests for the mouse-button-to-mouse-button remapping feature."""

--- a/ui/locale_manager.py
+++ b/ui/locale_manager.py
@@ -144,7 +144,7 @@ _TRANSLATIONS = {
         # Key-capture dialog
         "key_capture.title": "Custom Shortcut",
         "key_capture.placeholder": "e.g. ctrl+shift+f5",
-        "key_capture.valid_keys": "Valid keys: ctrl, shift, alt, super, a\u2013z, f1\u2013f12,\nspace, tab, enter, esc, left, right, up, down, delete, ...",
+        "key_capture.valid_keys": "Valid keys: ctrl/control, shift, alt/option, super/cmd,\n0\u20139, a\u2013z, f1\u2013f12, space, tab, enter, esc, left, right, up, down, delete, ...",
         "key_capture.cancel": "Cancel",
         "key_capture.confirm": "Confirm",
 
@@ -299,7 +299,7 @@ _TRANSLATIONS = {
 
         "key_capture.title": "\u81ea\u5b9a\u4e49\u5feb\u6377\u952e",
         "key_capture.placeholder": "\u4f8b\u5982\uff1actrl+shift+f5",
-        "key_capture.valid_keys": "\u6709\u6548\u6309\u952e\uff1actrl\u3001shift\u3001alt\u3001super\u3001a\u2013z\u3001f1\u2013f12\u3001\nspace\u3001tab\u3001enter\u3001esc\u3001left\u3001right\u3001up\u3001down\u3001delete\u2026\u2026",
+        "key_capture.valid_keys": "\u6709\u6548\u6309\u952e\uff1actrl/control\u3001shift\u3001alt/option\u3001super/cmd\u30010\u20139\u3001a\u2013z\u3001f1\u2013f12\u3001\nspace\u3001tab\u3001enter\u3001esc\u3001left\u3001right\u3001up\u3001down\u3001delete\u2026\u2026",
         "key_capture.cancel": "\u53d6\u6d88",
         "key_capture.confirm": "\u786e\u8ba4",
 
@@ -450,7 +450,7 @@ _TRANSLATIONS = {
 
         "key_capture.title": "\u81ea\u8a02\u5feb\u901f\u9375",
         "key_capture.placeholder": "\u4f8b\u5982\uff1actrl+shift+f5",
-        "key_capture.valid_keys": "\u6709\u6548\u6309\u9375\uff1actrl\u3001shift\u3001alt\u3001super\u3001a\u2013z\u3001f1\u2013f12\u3001\nspace\u3001tab\u3001enter\u3001esc\u3001left\u3001right\u3001up\u3001down\u3001delete\u2026\u2026",
+        "key_capture.valid_keys": "\u6709\u6548\u6309\u9375\uff1actrl/control\u3001shift\u3001alt/option\u3001super/cmd\u30010\u20139\u3001a\u2013z\u3001f1\u2013f12\u3001\nspace\u3001tab\u3001enter\u3001esc\u3001left\u3001right\u3001up\u3001down\u3001delete\u2026\u2026",
         "key_capture.cancel": "\u53d6\u6d88",
         "key_capture.confirm": "\u78ba\u8a8d",
 


### PR DESCRIPTION
## Summary
- allow custom shortcuts to use digit keys like `cmd+shift+3` and `cmd+shift+4`
- accept common aliases such as `cmd`, `command`, `control`, and `option` in custom shortcuts
- update the shortcut helper text and add parser coverage for the new cases

## Root Cause
Custom shortcuts are validated against hardcoded key-name maps before they are dispatched. Those maps did not include `0-9`, so valid screenshot shortcuts were rejected as unknown keys.

## Validation
- `python3 -m py_compile core/key_simulator.py ui/locale_manager.py tests/test_key_simulator.py`
- `python3 -m unittest tests.test_key_simulator.CustomShortcutParsingTests tests.test_key_simulator.LinuxDesktopShortcutTests tests.test_key_simulator.KeySimulatorActionTests`
