### PR TITLE
build: preserve symlinks in Linux release archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         run: pyinstaller Mouser-linux.spec --noconfirm
 
       - name: Create archive
-        run: cd dist && zip -r ../Mouser-Linux.zip Mouser
+        run: cd dist && zip -r -y ../Mouser-Linux.zip Mouser
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## What Changed
- preserves symlinks when creating the Linux release archive by switching the zip step to `zip -r -y`
- avoids storing PyInstaller's symlinked Qt libraries as duplicated file contents in `Mouser-Linux.zip`

## Why
PyInstaller's Linux bundle contains many symlinked Qt libraries. The previous archive step used plain `zip -r`, which flattened those symlinks into duplicate files inside the zip and inflated the release artifact significantly.

## Size Comparison
| Build | Linux zip size |
| --- | ---: |
| Current release (`v3.5.3`) | 344.9 MB (`353,154K`) |
| This branch workflow artifact | 200.0 MB (`204,838K`) |
| Delta | `-42.0%` |

## Validation
- ran the `Release` workflow via `workflow_dispatch` on `linux-zip-preserve-symlinks`
- verified `build-linux`, `build-macos`, and `build-windows` all succeeded
- verified the `release` job was skipped because the run was not on a tag
