### PR TITLE
build: trim Linux release bundle

### DIFF
--- a/Mouser-linux.spec
+++ b/Mouser-linux.spec
@@ -178,14 +178,16 @@ def should_keep(path):
         return True
 
     plugin_marker = "/plugins/"
-    if plugin_marker in lower:
-        plugin_path = normalized.split(plugin_marker, 1)[1]
+    plugin_index = lower.find(plugin_marker)
+    if plugin_index != -1:
+        plugin_path = normalized[plugin_index + len(plugin_marker) :]
         plugin_dir = plugin_path.split("/", 1)[0]
         return plugin_dir in KEEP_PLUGIN_DIRS and base != "libqpdf.so"
 
     qml_marker = "/qml/"
-    if qml_marker in lower:
-        qml_path = normalized.split(qml_marker, 1)[1]
+    qml_index = lower.find(qml_marker)
+    if qml_index != -1:
+        qml_path = normalized[qml_index + len(qml_marker) :]
         parts = [part for part in qml_path.split("/") if part]
         if not parts:
             return True

--- a/Mouser-linux.spec
+++ b/Mouser-linux.spec
@@ -9,7 +9,6 @@ Output: dist/Mouser/  (directory with Mouser executable + dependencies)
 """
 
 import os
-import shutil
 
 ROOT = os.path.abspath(".")
 
@@ -100,93 +99,110 @@ a = Analysis(
     noarchive=False,
 )
 
-# Filter Qt shared libs and optional QML/plugin families that PyInstaller hooks
-# often pull in even though Mouser never loads them.
-UNWANTED_PATTERNS = [
-    "QtWebEngine",
-    "QtWebChannel",
-    "QtWebSockets",
-    "Qt3D",
-    "QtMultimedia",
-    "QtMultimediaWidgets",
-    "QtBluetooth",
-    "QtLocation",
-    "QtPositioning",
-    "QtSensors",
-    "QtSerialPort",
-    "QtPdf",
-    "QtCharts",
-    "QtDataVisualization",
-    "QtRemoteObjects",
-    "QtTextToSpeech",
-    "QtQuick3D",
-    "QtVirtualKeyboard",
-    "QtGraphs",
-    "Qt5Compat",
-    "QtWebView",
-    "QtTest",
-    "QtLabsAnimation",
-    "QtLabsFolderListModel",
-    "QtLabsPlatform",
-    "QtLabsQmlModels",
-    "QtLabsSettings",
-    "QtLabsSharedImage",
-    "QtLabsWavefrontMesh",
-    "QtQuickTest",
-    "QtScxml",
-    "QtScxmlQml",
-    "QtSpatialAudio",
-    "QtSql",
-]
+# Keep only the Qt runtime pieces Mouser actually uses. The negative-match
+# approach still let large transitive Qt payload through on Linux.
+QT_KEEP = {
+    "Qt6Core",
+    "Qt6Gui",
+    "Qt6Widgets",
+    "Qt6Network",
+    "Qt6OpenGL",
+    "Qt6Qml",
+    "Qt6QmlCore",
+    "Qt6QmlMeta",
+    "Qt6QmlModels",
+    "Qt6QmlNetwork",
+    "Qt6QmlWorkerScript",
+    "Qt6Quick",
+    "Qt6QuickControls2",
+    "Qt6QuickControls2Impl",
+    "Qt6QuickControls2Basic",
+    "Qt6QuickControls2BasicStyleImpl",
+    "Qt6QuickControls2Material",
+    "Qt6QuickControls2MaterialStyleImpl",
+    "Qt6QuickTemplates2",
+    "Qt6QuickLayouts",
+    "Qt6QuickEffects",
+    "Qt6QuickShapes",
+    "Qt6ShaderTools",
+    "Qt6Svg",
+    "pyside6",
+    "pyside6qml",
+    "shiboken6",
+}
 
-# Keep the Material + Basic control stacks and drop the unused optional styles.
-UNUSED_QUICK_CONTROLS_PATTERNS = [
-    "QtQuickControls2Fusion",
-    "QtQuickControls2FusionStyleImpl",
-    "QtQuickControls2Imagine",
-    "QtQuickControls2ImagineStyleImpl",
-    "QtQuickControls2Universal",
-    "QtQuickControls2UniversalStyleImpl",
-    "QtQuickControls2FluentWinUI3StyleImpl",
-    "QtQuickControls2IOSStyleImpl",
-    "QtQuickControls2MacOSStyleImpl",
-]
+KEEP_PLUGIN_DIRS = {
+    "platforms",
+    "imageformats",
+    "styles",
+    "iconengines",
+    "platforminputcontexts",
+    "xcbglintegrations",
+    "platformthemes",
+    "tls",
+    "egldeviceintegrations",
+    "networkinformation",
+    "generic",
+    "wayland-decoration-client",
+    "wayland-graphics-integration-client",
+    "wayland-shell-integration",
+}
 
-UNUSED_QUICK_CONTROLS_QML_DIRS = [
-    "/qtquick/controls/fusion/",
-    "/qtquick/controls/fluentwinui3/",
-    "/qtquick/controls/imagine/",
-    "/qtquick/controls/universal/",
-    "/qtquick/controls/ios/",
-    "/qtquick/controls/macos/",
-]
+KEEP_QML_TOP = {"QtCore", "QtQml", "QtQuick", "QtNetwork"}
+KEEP_QTQUICK = {"Controls", "Layouts", "Templates", "Window"}
 
 
-def is_unwanted(path_or_toc_entry):
-    src = ""
-    if isinstance(path_or_toc_entry, (list, tuple)) and len(path_or_toc_entry) >= 1:
-        src = path_or_toc_entry[0] or ""
-    elif isinstance(path_or_toc_entry, str):
-        src = path_or_toc_entry
-    src_lower = src.lower()
-    for pat in UNWANTED_PATTERNS:
-        if pat.lower() in src_lower:
+def normalized_stem(path):
+    base = os.path.basename(path)
+    if ".so" in base:
+        return base.split(".so", 1)[0].removeprefix("lib")
+    stem = os.path.splitext(base)[0]
+    if stem.endswith(".abi3"):
+        stem = stem[:-5]
+    return stem
+
+
+def should_keep(path):
+    normalized = path.replace("\\", "/")
+    lower = normalized.lower()
+
+    if "PySide6" not in normalized and "pyside6" not in lower:
+        return True
+
+    stem = normalized_stem(normalized)
+    if stem in QT_KEEP:
+        return True
+
+    base = os.path.basename(normalized)
+    if base.endswith(".abi3.so"):
+        return True
+
+    plugin_marker = "/plugins/"
+    if plugin_marker in lower:
+        plugin_path = normalized.split(plugin_marker, 1)[1]
+        plugin_dir = plugin_path.split("/", 1)[0]
+        return plugin_dir in KEEP_PLUGIN_DIRS and base != "libqpdf.so"
+
+    qml_marker = "/qml/"
+    if qml_marker in lower:
+        qml_path = normalized.split(qml_marker, 1)[1]
+        parts = [part for part in qml_path.split("/") if part]
+        if not parts:
             return True
-    for pat in UNUSED_QUICK_CONTROLS_PATTERNS:
-        if pat.lower() in src_lower:
-            return True
-    for qml_dir in UNUSED_QUICK_CONTROLS_QML_DIRS:
-        if qml_dir in src_lower:
-            return True
-    if "/plugins/" in src_lower:
-        for pat in ("webengine", "multimedia", "printsupport", "qmltooling", "sensorgestures"):
-            if pat in src_lower:
-                return True
+        if parts[0] not in KEEP_QML_TOP:
+            return False
+        if parts[0] == "QtQuick" and len(parts) > 1 and parts[1] not in KEEP_QTQUICK:
+            return False
+        style_parts = {part.lower() for part in parts}
+        if style_parts & {"fusion", "imagine", "universal", "fluentwinui3", "ios", "macos"}:
+            return False
+        return True
+
     return False
 
 
-a.binaries = [b for b in a.binaries if not is_unwanted(b)]
-a.datas = [d for d in a.datas if not is_unwanted(d)]
+a.binaries = [b for b in a.binaries if should_keep(b[0])]
+a.datas = [d for d in a.datas if should_keep(d[0])]
 
 pyz = PYZ(a.pure)
 
@@ -213,76 +229,3 @@ coll = COLLECT(
     upx_exclude=[],
     name="Mouser",
 )
-
-# PyInstaller can still pull transitive Qt payload into the collected dist
-# even after Analysis-time filtering, so trim the packaged tree directly.
-DIST_QT = os.path.join("dist", "Mouser", "_internal", "PySide6", "Qt")
-KEEP_QML = {"QtCore", "QtQml", "QtQuick", "QtNetwork"}
-KEEP_QTQUICK = {"Controls", "Layouts", "Templates", "Window"}
-UNWANTED_PLUGIN_DIRS = {"webengine", "multimedia", "printsupport", "qmltooling", "sensorgestures"}
-UNWANTED_FILENAMES = {"libqpdf.so"}
-
-
-def cleanup_path(path):
-    if os.path.isdir(path):
-        shutil.rmtree(path, ignore_errors=True)
-        print(f"  [cleanup] removed {path}")
-        return
-    if os.path.exists(path):
-        os.remove(path)
-        print(f"  [cleanup] removed {path}")
-
-
-def cleanup_qt_dist():
-    if not os.path.isdir(DIST_QT):
-        return
-
-    lib_root = os.path.join(DIST_QT, "lib")
-    if os.path.isdir(lib_root):
-        for name in os.listdir(lib_root):
-            full_path = os.path.join(lib_root, name)
-            if name in UNWANTED_FILENAMES or is_unwanted(full_path):
-                cleanup_path(full_path)
-
-    qml_root = os.path.join(DIST_QT, "qml")
-    if os.path.isdir(qml_root):
-        for name in os.listdir(qml_root):
-            full_path = os.path.join(qml_root, name)
-            if name not in KEEP_QML:
-                cleanup_path(full_path)
-
-        qtquick_root = os.path.join(qml_root, "QtQuick")
-        if os.path.isdir(qtquick_root):
-            for name in os.listdir(qtquick_root):
-                full_path = os.path.join(qtquick_root, name)
-                if name not in KEEP_QTQUICK:
-                    cleanup_path(full_path)
-
-        for current_root, dirnames, filenames in os.walk(qml_root, topdown=False):
-            for filename in filenames:
-                full_path = os.path.join(current_root, filename)
-                if is_unwanted(full_path):
-                    cleanup_path(full_path)
-            for dirname in dirnames:
-                full_path = os.path.join(current_root, dirname)
-                if is_unwanted(full_path):
-                    cleanup_path(full_path)
-
-    plugins_root = os.path.join(DIST_QT, "plugins")
-    if os.path.isdir(plugins_root):
-        for name in os.listdir(plugins_root):
-            full_path = os.path.join(plugins_root, name)
-            if name in UNWANTED_PLUGIN_DIRS or is_unwanted(full_path):
-                cleanup_path(full_path)
-            elif os.path.isdir(full_path):
-                for child_name in os.listdir(full_path):
-                    child_path = os.path.join(full_path, child_name)
-                    if child_name in UNWANTED_FILENAMES or is_unwanted(child_path):
-                        cleanup_path(child_path)
-
-    cleanup_path(os.path.join(DIST_QT, "translations"))
-
-
-print("[Mouser] Post-build Linux Qt cleanup...")
-cleanup_qt_dist()
-print("[Mouser] Linux Qt cleanup done.")

--- a/Mouser-linux.spec
+++ b/Mouser-linux.spec
@@ -9,6 +9,7 @@ Output: dist/Mouser/  (directory with Mouser executable + dependencies)
 """
 
 import os
+import shutil
 
 ROOT = os.path.abspath(".")
 
@@ -212,3 +213,76 @@ coll = COLLECT(
     upx_exclude=[],
     name="Mouser",
 )
+
+# PyInstaller can still pull transitive Qt payload into the collected dist
+# even after Analysis-time filtering, so trim the packaged tree directly.
+DIST_QT = os.path.join("dist", "Mouser", "_internal", "PySide6", "Qt")
+KEEP_QML = {"QtCore", "QtQml", "QtQuick", "QtNetwork"}
+KEEP_QTQUICK = {"Controls", "Layouts", "Templates", "Window"}
+UNWANTED_PLUGIN_DIRS = {"webengine", "multimedia", "printsupport", "qmltooling", "sensorgestures"}
+UNWANTED_FILENAMES = {"libqpdf.so"}
+
+
+def cleanup_path(path):
+    if os.path.isdir(path):
+        shutil.rmtree(path, ignore_errors=True)
+        print(f"  [cleanup] removed {path}")
+        return
+    if os.path.exists(path):
+        os.remove(path)
+        print(f"  [cleanup] removed {path}")
+
+
+def cleanup_qt_dist():
+    if not os.path.isdir(DIST_QT):
+        return
+
+    lib_root = os.path.join(DIST_QT, "lib")
+    if os.path.isdir(lib_root):
+        for name in os.listdir(lib_root):
+            full_path = os.path.join(lib_root, name)
+            if name in UNWANTED_FILENAMES or is_unwanted(full_path):
+                cleanup_path(full_path)
+
+    qml_root = os.path.join(DIST_QT, "qml")
+    if os.path.isdir(qml_root):
+        for name in os.listdir(qml_root):
+            full_path = os.path.join(qml_root, name)
+            if name not in KEEP_QML:
+                cleanup_path(full_path)
+
+        qtquick_root = os.path.join(qml_root, "QtQuick")
+        if os.path.isdir(qtquick_root):
+            for name in os.listdir(qtquick_root):
+                full_path = os.path.join(qtquick_root, name)
+                if name not in KEEP_QTQUICK:
+                    cleanup_path(full_path)
+
+        for current_root, dirnames, filenames in os.walk(qml_root, topdown=False):
+            for filename in filenames:
+                full_path = os.path.join(current_root, filename)
+                if is_unwanted(full_path):
+                    cleanup_path(full_path)
+            for dirname in dirnames:
+                full_path = os.path.join(current_root, dirname)
+                if is_unwanted(full_path):
+                    cleanup_path(full_path)
+
+    plugins_root = os.path.join(DIST_QT, "plugins")
+    if os.path.isdir(plugins_root):
+        for name in os.listdir(plugins_root):
+            full_path = os.path.join(plugins_root, name)
+            if name in UNWANTED_PLUGIN_DIRS or is_unwanted(full_path):
+                cleanup_path(full_path)
+            elif os.path.isdir(full_path):
+                for child_name in os.listdir(full_path):
+                    child_path = os.path.join(full_path, child_name)
+                    if child_name in UNWANTED_FILENAMES or is_unwanted(child_path):
+                        cleanup_path(child_path)
+
+    cleanup_path(os.path.join(DIST_QT, "translations"))
+
+
+print("[Mouser] Post-build Linux Qt cleanup...")
+cleanup_qt_dist()
+print("[Mouser] Linux Qt cleanup done.")

--- a/Mouser-linux.spec
+++ b/Mouser-linux.spec
@@ -35,9 +35,157 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=[
+        # Trim PySide6 modules the app does not import at runtime.
+        "PySide6.QtWebEngine",
+        "PySide6.QtWebEngineCore",
+        "PySide6.QtWebEngineWidgets",
+        "PySide6.QtWebChannel",
+        "PySide6.QtWebSockets",
+        "PySide6.Qt3DCore",
+        "PySide6.Qt3DRender",
+        "PySide6.Qt3DInput",
+        "PySide6.Qt3DLogic",
+        "PySide6.Qt3DAnimation",
+        "PySide6.Qt3DExtras",
+        "PySide6.QtMultimedia",
+        "PySide6.QtMultimediaWidgets",
+        "PySide6.QtBluetooth",
+        "PySide6.QtNfc",
+        "PySide6.QtPositioning",
+        "PySide6.QtLocation",
+        "PySide6.QtSensors",
+        "PySide6.QtSerialPort",
+        "PySide6.QtSerialBus",
+        "PySide6.QtTest",
+        "PySide6.QtPdf",
+        "PySide6.QtPdfWidgets",
+        "PySide6.QtCharts",
+        "PySide6.QtDataVisualization",
+        "PySide6.QtRemoteObjects",
+        "PySide6.QtScxml",
+        "PySide6.QtSql",
+        "PySide6.QtTextToSpeech",
+        "PySide6.QtQuick3D",
+        "PySide6.QtVirtualKeyboard",
+        "PySide6.QtGraphs",
+        "PySide6.Qt5Compat",
+        # Designer / tooling modules are not needed in the packaged app.
+        "PySide6.QtDesigner",
+        "PySide6.QtHelp",
+        "PySide6.QtUiTools",
+        "PySide6.QtXml",
+        "PySide6.QtConcurrent",
+        "PySide6.QtStateMachine",
+        "PySide6.QtHttpServer",
+        "PySide6.QtSpatialAudio",
+        # Trim large unused stdlib bundles.
+        "unittest",
+        "xmlrpc",
+        "pydoc",
+        "doctest",
+        "tkinter",
+        "test",
+        "distutils",
+        "setuptools",
+        "ensurepip",
+        "lib2to3",
+        "idlelib",
+        "turtledemo",
+        "turtle",
+        "sqlite3",
+        "multiprocessing",
+    ],
     noarchive=False,
 )
+
+# Filter Qt shared libs and optional QML/plugin families that PyInstaller hooks
+# often pull in even though Mouser never loads them.
+UNWANTED_PATTERNS = [
+    "QtWebEngine",
+    "QtWebChannel",
+    "QtWebSockets",
+    "Qt3D",
+    "QtMultimedia",
+    "QtMultimediaWidgets",
+    "QtBluetooth",
+    "QtLocation",
+    "QtPositioning",
+    "QtSensors",
+    "QtSerialPort",
+    "QtPdf",
+    "QtCharts",
+    "QtDataVisualization",
+    "QtRemoteObjects",
+    "QtTextToSpeech",
+    "QtQuick3D",
+    "QtVirtualKeyboard",
+    "QtGraphs",
+    "Qt5Compat",
+    "QtWebView",
+    "QtTest",
+    "QtLabsAnimation",
+    "QtLabsFolderListModel",
+    "QtLabsPlatform",
+    "QtLabsQmlModels",
+    "QtLabsSettings",
+    "QtLabsSharedImage",
+    "QtLabsWavefrontMesh",
+    "QtQuickTest",
+    "QtScxml",
+    "QtScxmlQml",
+    "QtSpatialAudio",
+    "QtSql",
+]
+
+# Keep the Material + Basic control stacks and drop the unused optional styles.
+UNUSED_QUICK_CONTROLS_PATTERNS = [
+    "QtQuickControls2Fusion",
+    "QtQuickControls2FusionStyleImpl",
+    "QtQuickControls2Imagine",
+    "QtQuickControls2ImagineStyleImpl",
+    "QtQuickControls2Universal",
+    "QtQuickControls2UniversalStyleImpl",
+    "QtQuickControls2FluentWinUI3StyleImpl",
+    "QtQuickControls2IOSStyleImpl",
+    "QtQuickControls2MacOSStyleImpl",
+]
+
+UNUSED_QUICK_CONTROLS_QML_DIRS = [
+    "/qtquick/controls/fusion/",
+    "/qtquick/controls/fluentwinui3/",
+    "/qtquick/controls/imagine/",
+    "/qtquick/controls/universal/",
+    "/qtquick/controls/ios/",
+    "/qtquick/controls/macos/",
+]
+
+
+def is_unwanted(path_or_toc_entry):
+    src = ""
+    if isinstance(path_or_toc_entry, (list, tuple)) and len(path_or_toc_entry) >= 1:
+        src = path_or_toc_entry[0] or ""
+    elif isinstance(path_or_toc_entry, str):
+        src = path_or_toc_entry
+    src_lower = src.lower()
+    for pat in UNWANTED_PATTERNS:
+        if pat.lower() in src_lower:
+            return True
+    for pat in UNUSED_QUICK_CONTROLS_PATTERNS:
+        if pat.lower() in src_lower:
+            return True
+    for qml_dir in UNUSED_QUICK_CONTROLS_QML_DIRS:
+        if qml_dir in src_lower:
+            return True
+    if "/plugins/" in src_lower:
+        for pat in ("webengine", "multimedia", "printsupport", "qmltooling", "sensorgestures"):
+            if pat in src_lower:
+                return True
+    return False
+
+
+a.binaries = [b for b in a.binaries if not is_unwanted(b)]
+a.datas = [d for d in a.datas if not is_unwanted(d)]
 
 pyz = PYZ(a.pure)
 


### PR DESCRIPTION
## What changed
- add Linux PyInstaller excludes for unused PySide6 and stdlib modules
- switch Linux packaging to a whitelist-style Qt runtime filter so only the Qt libs, plugins, and QML trees Mouser actually uses are collected
- keep Linux-specific platform plugin coverage needed for runtime while dropping the same obvious dead-weight families already trimmed elsewhere

## Why
PR #102 reduced the Linux release zip size by preserving symlinks in the archive, but Linux was still packaging a large amount of unused Qt payload. This follow-up trims those collected assets instead of only relying on broad excludes.

## Impact
- much smaller `Mouser-Linux.zip` artifact
- no release behavior change outside Linux packaging contents

## Validation
- local: `python3 -m py_compile Mouser-linux.spec`
- baseline workflow dispatch on `master`: https://github.com/TomBadash/Mouser/actions/runs/24376195998
- final workflow dispatch on `linux-trimming`: https://github.com/TomBadash/Mouser/actions/runs/24377152797
- latest `build-linux` job passed on commit `0b03b38`

## Linux zip size
| Build | Size | Change |
| --- | --- | --- |
| `master` baseline | `202.84 MiB` (`207,707 KB`) | - |
| `linux-trimming` final | `73.98 MiB` (`75,753 KB`) | `-128.86 MiB` (`-131,954 KB`, `-63.53%`) |

## Notes
- the packaged `PySide6/Qt` payload dropped from about `379 MB` uncompressed to about `69 MB`
- the oversized `WebEngine`, `Quick3D`, `Pdf`, `Graphs`, and extra Quick Controls style libraries are no longer present as real bundled payload in the Linux zip
