### PR TITLE
fix(macos): add @_autoreleased to CGEventTap callback to prevent ~1.4 GB memory leak

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,6 +2,24 @@
 
 This document contains technical details designed to help new developers understand the core components of the Mouser project.
 
+## Development Setup
+
+Install the project dependencies before running the app or test suite. Do not rely on the system Python unless it already has the requirements installed.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+On macOS, `requirements.txt` installs PyObjC (`objc`, Quartz, and AppKit bindings), which Mouser needs for CGEventTap, app detection, and key simulation.
+
+Run the test suite from the activated environment:
+
+```bash
+python -m unittest discover -s tests
+```
+
 ## Entry Point: `main_qml.py`
 
 `main_qml.py` is the primary launch script for Mouser, bringing together the core processing logic (Engine) and the graphical user interface (QML Backend). It replaces an older `tkinter`-based interface.

--- a/core/app_detector.py
+++ b/core/app_detector.py
@@ -164,6 +164,17 @@ if sys.platform == "win32":
         return exe_path
 
 elif sys.platform == "darwin":
+    import functools
+    import objc as _objc
+
+    def _autoreleased(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            with _objc.autorelease_pool():
+                return fn(*args, **kwargs)
+        return wrapper
+
+    @_autoreleased
     def get_foreground_exe() -> str | None:
         """Return a stable app identifier for the frontmost app on macOS."""
         try:

--- a/core/app_detector.py
+++ b/core/app_detector.py
@@ -165,7 +165,14 @@ if sys.platform == "win32":
 
 elif sys.platform == "darwin":
     import functools
-    import objc as _objc
+
+    try:
+        import objc as _objc
+    except ImportError as exc:
+        raise ImportError(
+            "PyObjC is required on macOS. Run "
+            "`python -m pip install -r requirements.txt`."
+        ) from exc
 
     def _autoreleased(fn):
         @functools.wraps(fn)

--- a/core/mouse_hook.py
+++ b/core/mouse_hook.py
@@ -977,9 +977,17 @@ if sys.platform == "win32":
 # ==================================================================
 
 elif sys.platform == "darwin":
+    import functools
+
     try:
-        import functools
         import objc
+    except ImportError as exc:
+        raise ImportError(
+            "PyObjC is required on macOS. Run "
+            "`python -m pip install -r requirements.txt`."
+        ) from exc
+
+    try:
         import Quartz
         _QUARTZ_OK = True
     except ImportError:

--- a/core/mouse_hook.py
+++ b/core/mouse_hook.py
@@ -978,12 +978,21 @@ if sys.platform == "win32":
 
 elif sys.platform == "darwin":
     try:
+        import functools
+        import objc
         import Quartz
         _QUARTZ_OK = True
     except ImportError:
         _QUARTZ_OK = False
         print("[MouseHook] pyobjc-framework-Quartz not installed — "
               "pip install pyobjc-framework-Quartz")
+
+    def _autoreleased(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            with objc.autorelease_pool():
+                return fn(*args, **kwargs)
+        return wrapper
 
     # HID button numbers (typical USB/BT HID mapping on macOS)
     _BTN_MIDDLE = 2
@@ -1363,6 +1372,7 @@ elif sys.platform == "darwin":
                 except queue.Empty:
                     continue
 
+        @_autoreleased
         def _event_tap_callback(self, proxy, event_type, cg_event, refcon):
             """CGEventTap callback.  Return the event to pass through, or None to suppress."""
             try:


### PR DESCRIPTION
## Problem

Running Mouser for 2 days results in ~2.6 GB heap usage. Root cause: PyObjC bridge creates temporary ObjC objects on every CGEventTap callback and `NSWorkspace.frontmostApplication()` call. Without an explicit `NSAutoreleasePool`, these objects are never released.

Diagnosed with `heap` on a live process (PID 20922, uptime ~2 days):

| Source | Leaked objects | Count | Size |
|---|---|---|---|
| `_event_tap_callback` | HIDEvent, CGEvent, CGSEventAppendix, NSMutableArray | ~4.5M | **~1.4 GB** |
| `get_foreground_exe` | GPProcessMonitor, GPProcessInfo | ~42K | **~108 MB** |

## Fix

Add an `@_autoreleased` decorator (wraps `objc.autorelease_pool()`) to:
- `_event_tap_callback` in `mouse_hook.py` — called ~19 times/sec from mouse movement alone
- `get_foreground_exe` in `app_detector.py` — polled every 0.3s on a daemon thread