### PR TITLE
feat(macos): add Zoom In / Zoom Out as built-in actions

### DIFF
--- a/core/key_simulator.py
+++ b/core/key_simulator.py
@@ -678,6 +678,8 @@ elif sys.platform == "darwin":
     kVK_ANSI_C = 0x08
     kVK_ANSI_V = 0x09
     kVK_ANSI_Z = 0x06
+    kVK_ANSI_Equal = 0x18
+    kVK_ANSI_Minus = 0x1B
 
     kVK_F1  = 0x7A
     kVK_F2  = 0x78
@@ -928,7 +930,17 @@ elif sys.platform == "darwin":
             if not was_enabled:
                 _APP_SERVICES.CGSSetSymbolicHotKeyEnabled(hotkey, False)
 
+    _ZOOM_REPEAT = 3  # key presses per gesture trigger
+
     def _execute_mac_action(action_id):
+        if action_id == "zoom_in":
+            for _ in range(_ZOOM_REPEAT):
+                send_key_combo([kVK_Command, kVK_ANSI_Equal], hold_ms=0)
+            return True
+        if action_id == "zoom_out":
+            for _ in range(_ZOOM_REPEAT):
+                send_key_combo([kVK_Command, kVK_ANSI_Minus], hold_ms=0)
+            return True
         if action_id == "mission_control":
             return _dock_notification("com.apple.expose.awake")
         if action_id == "app_expose":
@@ -1094,6 +1106,16 @@ elif sys.platform == "darwin":
             "keys": [],
             "mac_fn": _NX_PREV,
             "category": "Media",
+        },
+        "zoom_in": {
+            "label": "Zoom In",
+            "keys": [],
+            "category": "Navigation",
+        },
+        "zoom_out": {
+            "label": "Zoom Out",
+            "keys": [],
+            "category": "Navigation",
         },
         "page_up": {
             "label": "Page Up",

--- a/tests/test_key_simulator.py
+++ b/tests/test_key_simulator.py
@@ -2,7 +2,7 @@ import importlib
 import os
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from core import key_simulator
 
@@ -95,6 +95,61 @@ class LinuxDesktopShortcutTests(unittest.TestCase):
         self.assertIn(module.KEY_4, module._ALL_KEY_CODES)
         self.assertEqual(module._KEY_NAME_TO_CODE["control"], module.KEY_LEFTCTRL)
         self.assertEqual(module._KEY_NAME_TO_CODE["cmd"], module.KEY_LEFTMETA)
+
+
+class MacOSZoomActionTests(unittest.TestCase):
+    def _reload_for_macos(self):
+        with patch.object(sys, "platform", "darwin"):
+            importlib.reload(key_simulator)
+        self.addCleanup(importlib.reload, key_simulator)
+        return key_simulator
+
+    def test_zoom_actions_exist(self):
+        module = self._reload_for_macos()
+
+        self.assertEqual(module.ACTIONS["zoom_in"]["label"], "Zoom In")
+        self.assertEqual(module.ACTIONS["zoom_in"]["category"], "Navigation")
+        self.assertEqual(module.ACTIONS["zoom_in"]["keys"], [])
+        self.assertEqual(module.ACTIONS["zoom_out"]["label"], "Zoom Out")
+        self.assertEqual(module.ACTIONS["zoom_out"]["category"], "Navigation")
+        self.assertEqual(module.ACTIONS["zoom_out"]["keys"], [])
+
+    def test_zoom_in_sends_three_command_equal_presses(self):
+        module = self._reload_for_macos()
+
+        with patch.object(module, "send_key_combo") as send_key_combo:
+            module.execute_action("zoom_in")
+
+        expected = [module.kVK_Command, module.kVK_ANSI_Equal]
+        self.assertEqual(send_key_combo.call_count, 3)
+        send_key_combo.assert_has_calls([
+            call(expected, hold_ms=0),
+            call(expected, hold_ms=0),
+            call(expected, hold_ms=0),
+        ])
+
+    def test_zoom_out_sends_three_command_minus_presses(self):
+        module = self._reload_for_macos()
+
+        with patch.object(module, "send_key_combo") as send_key_combo:
+            module.execute_action("zoom_out")
+
+        expected = [module.kVK_Command, module.kVK_ANSI_Minus]
+        self.assertEqual(send_key_combo.call_count, 3)
+        send_key_combo.assert_has_calls([
+            call(expected, hold_ms=0),
+            call(expected, hold_ms=0),
+            call(expected, hold_ms=0),
+        ])
+
+    def test_existing_alt_tab_action_still_uses_standard_key_path(self):
+        module = self._reload_for_macos()
+
+        with patch.object(module, "send_key_combo") as send_key_combo:
+            module.execute_action("alt_tab")
+
+        send_key_combo.assert_called_once_with([module.kVK_Command, module.kVK_Tab])
+
 
 class CustomShortcutCaptureTests(unittest.TestCase):
     def test_custom_action_label_uses_super_as_canonical_name(self):


### PR DESCRIPTION
## Summary

- Adds **Zoom In** and **Zoom Out** as built-in actions in the Navigation category (macOS only)
- Each gesture trigger sends 3 rapid `Cmd+=` / `Cmd+-` key presses with zero hold delay for smooth zoom
- Works in browsers, Finder, Preview, and any app that supports the standard zoom shortcuts

Closes #112 — as requested by @Rsd20041202:
> *"Please add zoom in (Ctrl+=) and zoom out (Ctrl+-) as built-in actions, or support minus and equal as valid keys in the custom shortcut input."*

## Changes

- `core/key_simulator.py`: Added `kVK_ANSI_Equal` and `kVK_ANSI_Minus` key codes, `zoom_in`/`zoom_out` entries in macOS `ACTIONS` dict, and special handling in `_execute_mac_action()` to fire rapid key combos

## Test plan

- [x] Assigned gesture-up → Zoom In, gesture-down → Zoom Out on MX Master 3S
- [x] Verified zoom works in Safari, Chrome, Finder, and Preview
- [x] Confirmed other gesture actions (Mission Control, etc.) still work
- [x] Confirmed non-gesture button mappings unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)