### PR TITLE
Add Windows ARM64 release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,18 @@ jobs:
           python-version: "3.12"
           architecture: ${{ matrix.python_architecture }}
 
-      - name: Install dependencies
+      - name: Use short pip temp path for ARM64 source builds
+        if: matrix.python_architecture == 'arm64'
         shell: pwsh
         run: |
+          # hidapi does not publish Windows ARM64 wheels yet, so pip builds it
+          # from source. Keep MSVC's generated files under a short/simple path.
           New-Item -ItemType Directory -Force C:/pip-tmp | Out-Null
-          $env:TEMP = "C:/pip-tmp"
-          $env:TMP = "C:/pip-tmp"
+          "TEMP=C:/pip-tmp" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "TMP=C:/pip-tmp" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Install dependencies
+        run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r requirements.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,11 @@ jobs:
           architecture: ${{ matrix.python_architecture }}
 
       - name: Install dependencies
+        shell: pwsh
         run: |
+          New-Item -ItemType Directory -Force C:/pip-tmp | Out-Null
+          $env:TEMP = "C:/pip-tmp"
+          $env:TMP = "C:/pip-tmp"
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r requirements.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,27 +16,45 @@ env:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    name: build-windows (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x64
+            runner: windows-latest
+            python_architecture: x64
+            artifact_name: Mouser-Windows
+            archive_name: Mouser-Windows.zip
+          - name: ARM64
+            runner: windows-11-arm
+            python_architecture: arm64
+            artifact_name: Mouser-Windows-arm64
+            archive_name: Mouser-Windows-arm64.zip
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          architecture: ${{ matrix.python_architecture }}
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements.txt
 
       - name: Build with PyInstaller
         run: pyinstaller Mouser.spec --noconfirm
 
       - name: Create archive
-        run: Compress-Archive -Path dist\Mouser -DestinationPath Mouser-Windows.zip
+        run: Compress-Archive -Path dist/Mouser -DestinationPath "${{ matrix.archive_name }}"
 
       - uses: actions/upload-artifact@v7
         with:
-          name: Mouser-Windows
-          path: Mouser-Windows.zip
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.archive_name }}
 
   build-macos:
     name: build-macos (${{ matrix.name }})
@@ -236,6 +254,7 @@ jobs:
               --repo "${{ github.repository }}" \
               --clobber \
               Mouser-Windows/Mouser-Windows.zip \
+              Mouser-Windows-arm64/Mouser-Windows-arm64.zip \
               Mouser-macOS/Mouser-macOS.zip \
               Mouser-macOS-intel/Mouser-macOS-intel.zip \
               Mouser-Linux/Mouser-Linux.zip
@@ -245,6 +264,7 @@ jobs:
               --title "Mouser ${{ github.ref_name }}" \
               --generate-notes \
               Mouser-Windows/Mouser-Windows.zip \
+              Mouser-Windows-arm64/Mouser-Windows-arm64.zip \
               Mouser-macOS/Mouser-macOS.zip \
               Mouser-macOS-intel/Mouser-macOS-intel.zip \
               Mouser-Linux/Mouser-Linux.zip

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ Action labels adapt by platform. For example, Windows exposes `Win+D` and `Task 
 
 <p align="center">
   <a href="https://github.com/TomBadash/Mouser/releases/latest">
-    <img src="https://img.shields.io/github/downloads/TomBadash/Mouser/latest/Mouser-Windows.zip?style=for-the-badge&color=00d4aa&logo=windows&label=Windows&displayAssetName=false" alt="Windows Downloads" />
+    <img src="https://img.shields.io/github/downloads/TomBadash/Mouser/latest/Mouser-Windows.zip?style=for-the-badge&color=00d4aa&logo=windows&label=Windows%20x64&displayAssetName=false" alt="Windows x64 Downloads" />
+  </a>
+  <a href="https://github.com/TomBadash/Mouser/releases/latest">
+    <img src="https://img.shields.io/github/downloads/TomBadash/Mouser/latest/Mouser-Windows-arm64.zip?style=for-the-badge&color=00d4aa&logo=windows&label=Windows%20ARM64&displayAssetName=false" alt="Windows ARM64 Downloads" />
   </a>
   <a href="https://github.com/TomBadash/Mouser/releases/latest">
     <img src="https://img.shields.io/github/downloads/TomBadash/Mouser/latest/Mouser-macOS.zip?style=for-the-badge&color=00d4aa&logo=apple&label=macOS%20Apple%20Silicon&displayAssetName=false" alt="macOS Apple Silicon Downloads" />
@@ -121,7 +124,7 @@ Action labels adapt by platform. For example, Windows exposes `Win+D` and `Task 
 ### Steps
 
 1. Go to the [**latest release page**](https://github.com/TomBadash/Mouser/releases/latest)
-2. Download the zip for your platform: **Mouser-Windows.zip**, **Mouser-macOS.zip** (Apple Silicon), **Mouser-macOS-intel.zip** (Intel macOS), or **Mouser-Linux.zip**
+2. Download the zip for your platform: **Mouser-Windows.zip** (Windows x64), **Mouser-Windows-arm64.zip** (Windows ARM64), **Mouser-macOS.zip** (Apple Silicon), **Mouser-macOS-intel.zip** (Intel macOS), or **Mouser-Linux.zip**
 3. **Extract** the zip to any folder (Desktop, Documents, wherever you like)
 4. **Run** the executable: `Mouser.exe` (Windows), `Mouser.app` (macOS), or `./Mouser` (Linux)
 
@@ -306,7 +309,7 @@ pyinstaller Mouser-linux.spec --noconfirm
 
 The output is in `dist/Mouser/`. Zip that entire folder and distribute it.
 
-> **Automated releases:** Pushing a `v*` tag triggers the [release workflow](.github/workflows/release.yml), which builds all three platforms in CI and publishes them as GitHub Release assets.
+> **Automated releases:** Pushing a `v*` tag triggers the [release workflow](.github/workflows/release.yml), which builds Windows x64, Windows ARM64, macOS, and Linux artifacts in CI and publishes them as GitHub Release assets.
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -105,7 +105,10 @@
 
 <p align="center">
   <a href="https://github.com/TomBadash/Mouser/releases/latest">
-    <img src="https://img.shields.io/github/downloads/TomBadash/Mouser/latest/Mouser-Windows.zip?style=for-the-badge&color=00d4aa&logo=windows&label=Windows&displayAssetName=false" alt="Windows Downloads" />
+    <img src="https://img.shields.io/github/downloads/TomBadash/Mouser/latest/Mouser-Windows.zip?style=for-the-badge&color=00d4aa&logo=windows&label=Windows%20x64&displayAssetName=false" alt="Windows x64 Downloads" />
+  </a>
+  <a href="https://github.com/TomBadash/Mouser/releases/latest">
+    <img src="https://img.shields.io/github/downloads/TomBadash/Mouser/latest/Mouser-Windows-arm64.zip?style=for-the-badge&color=00d4aa&logo=windows&label=Windows%20ARM64&displayAssetName=false" alt="Windows ARM64 Downloads" />
   </a>
   <a href="https://github.com/TomBadash/Mouser/releases/latest">
     <img src="https://img.shields.io/github/downloads/TomBadash/Mouser/latest/Mouser-macOS.zip?style=for-the-badge&color=00d4aa&logo=apple&label=macOS&displayAssetName=false" alt="macOS Downloads" />
@@ -120,7 +123,7 @@
 ### 步骤
 
 1. 进入 [**最新 Release 页面**](https://github.com/TomBadash/Mouser/releases/latest)
-2. 下载对应平台的 zip：**Mouser-Windows.zip**、**Mouser-macOS.zip**、**Mouser-Linux.zip**
+2. 下载对应平台的 zip：**Mouser-Windows.zip**（Windows x64）、**Mouser-Windows-arm64.zip**（Windows ARM64）、**Mouser-macOS.zip**、**Mouser-Linux.zip**
 3. **解压**到任意目录（桌面/文档等均可）
 4. **运行**：`Mouser.exe`（Windows）、`Mouser.app`（macOS）、`./Mouser`（Linux）
 
@@ -313,7 +316,7 @@ pyinstaller Mouser-linux.spec --noconfirm
 
 输出目录为 `dist/Mouser/`，将整个目录打包 zip 即可分发。
 
-> **自动化发布：** 推送 `v*` 标签会触发 [release 工作流](.github/workflows/release.yml)，在 CI 中构建三平台产物并发布到 GitHub Releases。
+> **自动化发布：** 推送 `v*` 标签会触发 [release 工作流](.github/workflows/release.yml)，在 CI 中构建 Windows x64、Windows ARM64、macOS 与 Linux 产物并发布到 GitHub Releases。
 
 #### 多语言支持（无需额外构建步骤）
 


### PR DESCRIPTION
## Summary

- Add a Windows release matrix that builds both the existing x64 portable zip and a new native ARM64 portable zip.
- Publish `Mouser-Windows-arm64.zip` as a GitHub Release asset alongside the existing platform artifacts.
- Update English and Chinese download docs to list the Windows x64 and Windows ARM64 assets separately.
- Use a short pip temp directory only for the Windows ARM64 job because `hidapi` currently builds from source there.

Refs #134.

## Validation

- `actionlint .github/workflows/release.yml`
- YAML parse of `.github/workflows/release.yml`
- `git diff --check`
- `.venv/bin/python -m py_compile main_qml.py core/*.py ui/*.py`
- `.venv/bin/python -m unittest discover -s tests -p 'test_*.py'`
- QML lint using the repo CI command
- Manual `Release` workflow run on `windows-arm-support`: https://github.com/TomBadash/Mouser/actions/runs/25140432906

## Artifact check

Downloaded the `Mouser-Windows-arm64` artifact from the latest manual Release run. The zip is 44 MB, contains `Mouser/Mouser.exe`, and the executable is detected as `PE32+ executable (GUI) Aarch64, for MS Windows`.

## Notes for testing

This PR is still draft because the remaining validation needs an actual Windows ARM64 machine. A tester should download the `Mouser-Windows-arm64` artifact from the manual Release workflow run and confirm Logitech device detection, button remapping, gestures, tray behavior, and startup settings.
