### PR TITLE
fix: gate wider mouse catalog buttons by HID capabilities

### DIFF
--- a/CONTRIBUTING_DEVICES.md
+++ b/CONTRIBUTING_DEVICES.md
@@ -84,6 +84,14 @@ Pick the right button tuple for `supported_buttons`:
 - `GENERIC_BUTTONS` -- middle, back, forward (safe default)
 - Or define a new tuple if your mouse has a unique button set.
 
+`supported_buttons` is a static fallback.  When Mouser connects through HID++
+and discovers `REPROG_V4` controls, it may narrow HID++-gated buttons such as
+gesture, Smart Shift / mode shift, and DPI switch based on the runtime control
+table.  Unknown CIDs are intentionally not exposed until Mouser has code that
+knows how to handle them.  Horizontal scroll remains catalog-driven because
+some devices implement it as OS events or side-button + wheel behavior instead
+of a standalone reprogrammable control.
+
 Use `core/logi_devices.py` only when you are adding a broader family fallback
 without exact art yet.
 

--- a/CONTRIBUTING_DEVICES.md
+++ b/CONTRIBUTING_DEVICES.md
@@ -48,6 +48,8 @@ Look at the `reprog_controls` array.  Each entry has a `cid` (Control ID) and
 
 Not all CIDs are divertable.  Check the `flags` field -- if bit `0x0020` is
 set, the control can be intercepted by Mouser.
+Directional gesture mappings also require RawXY support (`0x0100` or
+`0x0200`) and a successful RawXY divert during connection.
 
 ---
 

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -1801,6 +1801,7 @@ class HidGestureListener:
                             transport=actual_transport,
                             source=source,
                             gesture_cids=self._gesture_candidates,
+                            reprog_controls=controls,
                         )
                         return True
                     continue     # divert failed — try next receiver slot

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -1802,6 +1802,8 @@ class HidGestureListener:
                             source=source,
                             gesture_cids=self._gesture_candidates,
                             reprog_controls=controls,
+                            active_gesture_cid=self._gesture_cid,
+                            gesture_rawxy_enabled=self._rawxy_enabled,
                         )
                         return True
                     continue     # divert failed — try next receiver slot

--- a/core/logi_devices.py
+++ b/core/logi_devices.py
@@ -67,6 +67,18 @@ GENERIC_BUTTONS = (
 # Backward-compat alias used by config.py and other modules.
 DEFAULT_BUTTON_LAYOUT = MX_MASTER_BUTTONS
 
+_GESTURE_BUTTON_KEYS = (
+    "gesture",
+    "gesture_left",
+    "gesture_right",
+    "gesture_up",
+    "gesture_down",
+)
+_CID_GATED_BUTTONS = {
+    "mode_shift": 0x00C4,
+    "dpi_switch": 0x00FD,
+}
+
 
 @dataclass(frozen=True)
 class LogiDeviceSpec:
@@ -147,6 +159,51 @@ def resolve_device(product_id=None, product_name=None) -> LogiDeviceSpec | None:
         if device.matches(product_id=product_id, product_name=product_name):
             return device
     return None
+
+
+def _control_cid(control) -> int | None:
+    if not isinstance(control, dict):
+        return None
+    cid = control.get("cid")
+    if cid in (None, ""):
+        return None
+    try:
+        return int(cid, 0) if isinstance(cid, str) else int(cid)
+    except (TypeError, ValueError):
+        return None
+
+
+def derive_supported_buttons_from_reprog_controls(
+    static_buttons: tuple[str, ...],
+    controls,
+    gesture_cids=None,
+) -> tuple[str, ...]:
+    """Narrow HID++-gated buttons using discovered REPROG_V4 controls.
+
+    OS-level buttons and horizontal scroll remain catalog-driven because they
+    are not always represented as divertable HID++ controls.
+    """
+    if not controls:
+        return static_buttons
+
+    control_cids = {
+        cid
+        for cid in (_control_cid(control) for control in controls)
+        if cid is not None
+    }
+    if not control_cids:
+        return static_buttons
+
+    allowed = set(static_buttons)
+    gesture_candidates = tuple(gesture_cids or DEFAULT_GESTURE_CIDS)
+    if not any(cid in control_cids for cid in gesture_candidates):
+        allowed.difference_update(_GESTURE_BUTTON_KEYS)
+
+    for button_key, cid in _CID_GATED_BUTTONS.items():
+        if cid not in control_cids:
+            allowed.discard(button_key)
+
+    return tuple(button for button in static_buttons if button in allowed)
 
 
 # Maps family layout keys to their button sets so the override picker can

--- a/core/logi_devices.py
+++ b/core/logi_devices.py
@@ -233,10 +233,12 @@ def build_connected_device_info(
     transport=None,
     source=None,
     gesture_cids=None,
+    reprog_controls=None,
 ) -> ConnectedDeviceInfo:
     spec = resolve_device(product_id=product_id, product_name=product_name)
     pid = int(product_id) if product_id not in (None, "") else None
     if spec:
+        resolved_gesture_cids = tuple(gesture_cids or spec.gesture_cids)
         return ConnectedDeviceInfo(
             key=spec.key,
             display_name=spec.display_name,
@@ -246,8 +248,12 @@ def build_connected_device_info(
             source=source,
             ui_layout=spec.ui_layout,
             image_asset=spec.image_asset,
-            supported_buttons=spec.supported_buttons,
-            gesture_cids=tuple(gesture_cids or spec.gesture_cids),
+            supported_buttons=derive_supported_buttons_from_reprog_controls(
+                spec.supported_buttons,
+                reprog_controls,
+                gesture_cids=resolved_gesture_cids,
+            ),
+            gesture_cids=resolved_gesture_cids,
             dpi_min=spec.dpi_min,
             dpi_max=spec.dpi_max,
         )

--- a/core/logi_devices.py
+++ b/core/logi_devices.py
@@ -78,6 +78,11 @@ _CID_GATED_BUTTONS = {
     "mode_shift": 0x00C4,
     "dpi_switch": 0x00FD,
 }
+_KEY_FLAG_DIVERTABLE = 0x0020
+_KEY_FLAG_RAW_XY = 0x0100
+_KEY_FLAG_FORCE_RAW_XY = 0x0200
+_MAPPING_FLAG_RAW_XY_DIVERTED = 0x0010
+_MAPPING_FLAG_FORCE_RAW_XY_DIVERTED = 0x0040
 
 
 @dataclass(frozen=True)
@@ -173,10 +178,56 @@ def _control_cid(control) -> int | None:
         return None
 
 
+def _control_int(control, field) -> int | None:
+    if not isinstance(control, dict):
+        return None
+    value = control.get(field)
+    if value in (None, ""):
+        return None
+    try:
+        return int(value, 0) if isinstance(value, str) else int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _control_by_cid(controls) -> dict[int, dict]:
+    by_cid = {}
+    for control in controls:
+        cid = _control_cid(control)
+        if cid is not None and isinstance(control, dict):
+            by_cid[cid] = control
+    return by_cid
+
+
+def _control_is_divertable(control) -> bool:
+    flags = _control_int(control, "flags")
+    if flags is None:
+        # Older tests and manually supplied dumps may only include CIDs.  Do not
+        # narrow those more aggressively than the previous CID-only behavior.
+        return True
+    return bool(flags & _KEY_FLAG_DIVERTABLE)
+
+
+def _control_has_raw_xy(control) -> bool:
+    flags = _control_int(control, "flags")
+    mapping_flags = _control_int(control, "mapping_flags")
+    if flags is None and mapping_flags is None:
+        return True
+    flags = flags or 0
+    mapping_flags = mapping_flags or 0
+    return bool(
+        flags & (_KEY_FLAG_RAW_XY | _KEY_FLAG_FORCE_RAW_XY)
+        or mapping_flags
+        & (_MAPPING_FLAG_RAW_XY_DIVERTED | _MAPPING_FLAG_FORCE_RAW_XY_DIVERTED)
+    )
+
+
 def derive_supported_buttons_from_reprog_controls(
     static_buttons: tuple[str, ...],
     controls,
     gesture_cids=None,
+    active_gesture_cid=None,
+    gesture_rawxy_enabled=None,
 ) -> tuple[str, ...]:
     """Narrow HID++-gated buttons using discovered REPROG_V4 controls.
 
@@ -186,21 +237,36 @@ def derive_supported_buttons_from_reprog_controls(
     if not controls:
         return static_buttons
 
-    control_cids = {
-        cid
-        for cid in (_control_cid(control) for control in controls)
-        if cid is not None
-    }
-    if not control_cids:
+    controls_by_cid = _control_by_cid(controls)
+    if not controls_by_cid:
         return static_buttons
 
     allowed = set(static_buttons)
     gesture_candidates = tuple(gesture_cids or DEFAULT_GESTURE_CIDS)
-    if not any(cid in control_cids for cid in gesture_candidates):
+    active_cid = _control_cid({"cid": active_gesture_cid})
+    if active_cid is None:
+        active_cid = next(
+            (
+                cid
+                for cid in gesture_candidates
+                if cid in controls_by_cid and _control_is_divertable(controls_by_cid[cid])
+            ),
+            None,
+        )
+    gesture_control = controls_by_cid.get(active_cid)
+    if not gesture_control or not _control_is_divertable(gesture_control):
         allowed.difference_update(_GESTURE_BUTTON_KEYS)
+    elif not (
+        (gesture_rawxy_enabled is not False)
+        and _control_has_raw_xy(gesture_control)
+    ):
+        allowed.difference_update(
+            ("gesture_left", "gesture_right", "gesture_up", "gesture_down")
+        )
 
     for button_key, cid in _CID_GATED_BUTTONS.items():
-        if cid not in control_cids:
+        control = controls_by_cid.get(cid)
+        if not control or not _control_is_divertable(control):
             allowed.discard(button_key)
 
     return tuple(button for button in static_buttons if button in allowed)
@@ -234,6 +300,8 @@ def build_connected_device_info(
     source=None,
     gesture_cids=None,
     reprog_controls=None,
+    active_gesture_cid=None,
+    gesture_rawxy_enabled=None,
 ) -> ConnectedDeviceInfo:
     spec = resolve_device(product_id=product_id, product_name=product_name)
     pid = int(product_id) if product_id not in (None, "") else None
@@ -252,6 +320,8 @@ def build_connected_device_info(
                 spec.supported_buttons,
                 reprog_controls,
                 gesture_cids=resolved_gesture_cids,
+                active_gesture_cid=active_gesture_cid,
+                gesture_rawxy_enabled=gesture_rawxy_enabled,
             ),
             gesture_cids=resolved_gesture_cids,
             dpi_min=spec.dpi_min,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -133,6 +133,29 @@ class BackendDeviceLayoutTests(unittest.TestCase):
         self.assertEqual(overrides, {"mx_master_4": "mx_master"})
         self.assertEqual(backend.effectiveDeviceLayoutKey, "mx_master")
 
+    def test_connected_device_supported_buttons_filter_mapping_list(self):
+        device = SimpleNamespace(
+            key="mx_master_3s",
+            display_name="MX Master 3S",
+            dpi_min=200,
+            dpi_max=8000,
+            ui_layout="mx_master_3s",
+            supported_buttons=("middle", "xbutton1"),
+        )
+
+        with (
+            patch("ui.backend.load_config", return_value=copy.deepcopy(DEFAULT_CONFIG)),
+            patch("ui.backend.save_config"),
+            patch("ui.backend.supports_login_startup", return_value=False),
+        ):
+            backend = Backend(engine=_FakeEngine(device_connected=True, connected_device=device))
+
+        button_keys = [button["key"] for button in backend.buttons]
+        self.assertIn("middle", button_keys)
+        self.assertIn("xbutton1", button_keys)
+        self.assertNotIn("gesture", button_keys)
+        self.assertNotIn("mode_shift", button_keys)
+
     def test_disconnect_clears_stale_linux_device_identity_and_layout(self):
         device = SimpleNamespace(
             key="mx_master_3",

--- a/tests/test_device_layouts.py
+++ b/tests/test_device_layouts.py
@@ -1,9 +1,29 @@
 import unittest
+from pathlib import Path
 
 from core.device_layouts import get_device_layout, get_manual_layout_choices
+from core.logi_devices import KNOWN_LOGI_DEVICES
 
 
 class DeviceLayoutTests(unittest.TestCase):
+    def test_known_devices_have_interactive_layouts_and_assets(self):
+        image_root = Path(__file__).resolve().parents[1] / "images"
+        for device in KNOWN_LOGI_DEVICES:
+            with self.subTest(device=device.key, ui_layout=device.ui_layout):
+                layout = get_device_layout(device.ui_layout)
+
+                self.assertTrue(layout["interactive"])
+                self.assertEqual(layout["key"], device.ui_layout)
+                self.assertTrue((image_root / layout["image_asset"]).is_file())
+
+    def test_known_device_hotspots_are_supported_buttons(self):
+        for device in KNOWN_LOGI_DEVICES:
+            layout = get_device_layout(device.ui_layout)
+            supported_buttons = set(device.supported_buttons)
+            for hotspot in layout["hotspots"]:
+                with self.subTest(device=device.key, button=hotspot["buttonKey"]):
+                    self.assertIn(hotspot["buttonKey"], supported_buttons)
+
     def test_master_layout_is_interactive(self):
         layout = get_device_layout("mx_master")
 

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -556,6 +556,51 @@ class HidBoltReceiverTests(unittest.TestCase):
         # devIdx 0xFF (first tried) = Bluetooth
         self.assertEqual(listener.connected_device.transport, "Bluetooth")
 
+    def test_try_connect_applies_runtime_supported_buttons(self):
+        listener = hid_gesture.HidGestureListener()
+        info = {
+            "product_id": 0xB034,
+            "usage_page": 0xFF00,
+            "usage": 0x0001,
+            "source": "hidapi-enumerate",
+            "product_string": "MX Master 3S",
+            "path": b"/dev/hidraw-test",
+        }
+        controls = [
+            {"cid": 0x0052, "flags": 0x0030, "mapping_flags": 0x0001},
+            {"cid": 0x0053, "flags": 0x0030, "mapping_flags": 0x0001},
+            {"cid": 0x0056, "flags": 0x0030, "mapping_flags": 0x0001},
+            {"cid": 0x00C3, "flags": 0x0130, "mapping_flags": 0x0011},
+        ]
+        fake_dev = _FakeHidDevice()
+
+        def fake_find_feature(feature_id):
+            if feature_id == hid_gesture.FEAT_REPROG_V4:
+                return 0x09
+            return None
+
+        with (
+            patch.object(listener, "_vendor_hid_infos", return_value=[info]),
+            patch.object(listener, "_find_feature", side_effect=fake_find_feature),
+            patch.object(listener, "_discover_reprog_controls", return_value=controls),
+            patch.object(listener, "_divert", return_value=True),
+            patch.object(listener, "_divert_extras"),
+            patch.object(hid_gesture, "HIDAPI_OK", True),
+            patch.object(hid_gesture, "_BACKEND_PREFERENCE", "hidapi"),
+            patch.object(hid_gesture, "_HID_API_STYLE", "hidapi"),
+            patch.object(
+                hid_gesture,
+                "_hid",
+                SimpleNamespace(device=lambda: fake_dev),
+                create=True,
+            ),
+            patch("builtins.print"),
+        ):
+            self.assertTrue(listener._try_connect())
+
+        self.assertIn("gesture", listener.connected_device.supported_buttons)
+        self.assertNotIn("mode_shift", listener.connected_device.supported_buttons)
+
     def test_transport_label_logi_bolt_for_bolt_receiver(self):
         """devIdx 1-6 with Bolt PID 0xC548 should produce 'Logi Bolt'."""
         listener = hid_gesture.HidGestureListener()

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -599,7 +599,60 @@ class HidBoltReceiverTests(unittest.TestCase):
             self.assertTrue(listener._try_connect())
 
         self.assertIn("gesture", listener.connected_device.supported_buttons)
+        self.assertNotIn("gesture_up", listener.connected_device.supported_buttons)
         self.assertNotIn("mode_shift", listener.connected_device.supported_buttons)
+
+    def test_try_connect_preserves_directional_gestures_after_rawxy_divert(self):
+        listener = hid_gesture.HidGestureListener()
+        info = {
+            "product_id": 0xB034,
+            "usage_page": 0xFF00,
+            "usage": 0x0001,
+            "source": "hidapi-enumerate",
+            "product_string": "MX Master 3S",
+            "path": b"/dev/hidraw-test",
+        }
+        controls = [
+            {"cid": 0x0052, "flags": 0x0030, "mapping_flags": 0x0001},
+            {"cid": 0x0053, "flags": 0x0030, "mapping_flags": 0x0001},
+            {"cid": 0x0056, "flags": 0x0030, "mapping_flags": 0x0001},
+            {"cid": 0x00C3, "flags": 0x0130, "mapping_flags": 0x0011},
+            {"cid": 0x00C4, "flags": 0x0130, "mapping_flags": 0x0001},
+        ]
+        fake_dev = _FakeHidDevice()
+
+        def fake_find_feature(feature_id):
+            if feature_id == hid_gesture.FEAT_REPROG_V4:
+                return 0x09
+            return None
+
+        def fake_divert():
+            listener._gesture_cid = 0x00C3
+            listener._rawxy_enabled = True
+            return True
+
+        with (
+            patch.object(listener, "_vendor_hid_infos", return_value=[info]),
+            patch.object(listener, "_find_feature", side_effect=fake_find_feature),
+            patch.object(listener, "_discover_reprog_controls", return_value=controls),
+            patch.object(listener, "_divert", side_effect=fake_divert),
+            patch.object(listener, "_divert_extras"),
+            patch.object(hid_gesture, "HIDAPI_OK", True),
+            patch.object(hid_gesture, "_BACKEND_PREFERENCE", "hidapi"),
+            patch.object(hid_gesture, "_HID_API_STYLE", "hidapi"),
+            patch.object(
+                hid_gesture,
+                "_hid",
+                SimpleNamespace(device=lambda: fake_dev),
+                create=True,
+            ),
+            patch("builtins.print"),
+        ):
+            self.assertTrue(listener._try_connect())
+
+        self.assertIn("gesture", listener.connected_device.supported_buttons)
+        self.assertIn("gesture_up", listener.connected_device.supported_buttons)
+        self.assertIn("mode_shift", listener.connected_device.supported_buttons)
 
     def test_transport_label_logi_bolt_for_bolt_receiver(self):
         """devIdx 1-6 with Bolt PID 0xC548 should produce 'Logi Bolt'."""

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -3,8 +3,11 @@ import unittest
 from core.logi_devices import (
     DEFAULT_GESTURE_CIDS,
     KNOWN_LOGI_DEVICES,
+    MX_MASTER_BUTTONS,
+    MX_VERTICAL_BUTTONS,
     build_connected_device_info,
     clamp_dpi,
+    derive_supported_buttons_from_reprog_controls,
     get_buttons_for_layout,
     resolve_device,
 )
@@ -154,6 +157,102 @@ class LogiDeviceRegistryTests(unittest.TestCase):
     def test_clamp_dpi_defaults_without_device(self):
         self.assertEqual(clamp_dpi(100, None), 200)
         self.assertEqual(clamp_dpi(9000, None), 8000)
+
+
+class RuntimeSupportedButtonTests(unittest.TestCase):
+    @staticmethod
+    def _control(cid):
+        return {"cid": cid}
+
+    def test_reprog_control_filter_keeps_static_buttons_without_controls(self):
+        self.assertEqual(
+            derive_supported_buttons_from_reprog_controls(
+                MX_MASTER_BUTTONS,
+                [],
+                gesture_cids=(0x00C3,),
+            ),
+            MX_MASTER_BUTTONS,
+        )
+
+    def test_reprog_control_filter_removes_missing_gesture_group(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            MX_MASTER_BUTTONS,
+            [
+                self._control(0x0052),
+                self._control(0x0053),
+                self._control(0x0056),
+                self._control(0x00C4),
+            ],
+            gesture_cids=(0x00C3,),
+        )
+
+        self.assertNotIn("gesture", buttons)
+        self.assertNotIn("gesture_left", buttons)
+        self.assertNotIn("gesture_right", buttons)
+
+    def test_reprog_control_filter_keeps_selected_gesture_cid(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            MX_MASTER_BUTTONS,
+            [
+                self._control(0x00D7),
+                self._control(0x00C4),
+            ],
+            gesture_cids=(0x00D7,),
+        )
+
+        self.assertIn("gesture", buttons)
+        self.assertIn("gesture_up", buttons)
+
+    def test_reprog_control_filter_removes_missing_mode_shift(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            MX_MASTER_BUTTONS,
+            [
+                self._control(0x00C3),
+                self._control(0x0052),
+            ],
+            gesture_cids=(0x00C3,),
+        )
+
+        self.assertNotIn("mode_shift", buttons)
+
+    def test_reprog_control_filter_removes_missing_dpi_switch(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            MX_VERTICAL_BUTTONS,
+            [
+                self._control(0x0052),
+                self._control(0x0053),
+                self._control(0x0056),
+            ],
+        )
+
+        self.assertNotIn("dpi_switch", buttons)
+
+    def test_reprog_control_filter_preserves_hscroll_without_hscroll_cids(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            MX_MASTER_BUTTONS,
+            [
+                self._control(0x00C3),
+                self._control(0x00C4),
+            ],
+            gesture_cids=(0x00C3,),
+        )
+
+        self.assertIn("hscroll_left", buttons)
+        self.assertIn("hscroll_right", buttons)
+
+    def test_reprog_control_filter_ignores_unknown_cids_and_preserves_order(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            MX_MASTER_BUTTONS,
+            [
+                self._control("0x01A0"),
+                self._control("0x00C3"),
+                self._control("0x00C4"),
+            ],
+            gesture_cids=(0x00C3,),
+        )
+
+        self.assertNotIn("0x01A0", buttons)
+        self.assertEqual(buttons, tuple(button for button in MX_MASTER_BUTTONS))
 
 
 if __name__ == "__main__":

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -181,8 +181,13 @@ class LogiDeviceRegistryTests(unittest.TestCase):
 
 class RuntimeSupportedButtonTests(unittest.TestCase):
     @staticmethod
-    def _control(cid):
-        return {"cid": cid}
+    def _control(cid, flags=None, mapping_flags=None):
+        control = {"cid": cid}
+        if flags is not None:
+            control["flags"] = flags
+        if mapping_flags is not None:
+            control["mapping_flags"] = mapping_flags
+        return control
 
     def test_reprog_control_filter_keeps_static_buttons_without_controls(self):
         self.assertEqual(
@@ -214,23 +219,59 @@ class RuntimeSupportedButtonTests(unittest.TestCase):
         buttons = derive_supported_buttons_from_reprog_controls(
             MX_MASTER_BUTTONS,
             [
-                self._control(0x00D7),
-                self._control(0x00C4),
+                self._control(0x00D7, flags=0x03B0),
+                self._control(0x00C4, flags=0x0130),
             ],
             gesture_cids=(0x00D7,),
+            active_gesture_cid=0x00D7,
+            gesture_rawxy_enabled=True,
         )
 
         self.assertIn("gesture", buttons)
         self.assertIn("gesture_up", buttons)
 
+    def test_reprog_control_filter_removes_directional_gestures_without_rawxy(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            MX_MASTER_BUTTONS,
+            [
+                self._control(0x00C3, flags=0x0030),
+                self._control(0x00C4, flags=0x0130),
+            ],
+            gesture_cids=(0x00C3,),
+            active_gesture_cid=0x00C3,
+            gesture_rawxy_enabled=False,
+        )
+
+        self.assertIn("gesture", buttons)
+        self.assertNotIn("gesture_left", buttons)
+        self.assertNotIn("gesture_right", buttons)
+        self.assertNotIn("gesture_up", buttons)
+        self.assertNotIn("gesture_down", buttons)
+
     def test_reprog_control_filter_removes_missing_mode_shift(self):
         buttons = derive_supported_buttons_from_reprog_controls(
             MX_MASTER_BUTTONS,
             [
-                self._control(0x00C3),
+                self._control(0x00C3, flags=0x0130),
                 self._control(0x0052),
             ],
             gesture_cids=(0x00C3,),
+            active_gesture_cid=0x00C3,
+            gesture_rawxy_enabled=True,
+        )
+
+        self.assertNotIn("mode_shift", buttons)
+
+    def test_reprog_control_filter_removes_non_divertable_mode_shift(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            MX_MASTER_BUTTONS,
+            [
+                self._control(0x00C3, flags=0x0130),
+                self._control(0x00C4, flags=0x0110),
+            ],
+            gesture_cids=(0x00C3,),
+            active_gesture_cid=0x00C3,
+            gesture_rawxy_enabled=True,
         )
 
         self.assertNotIn("mode_shift", buttons)
@@ -251,10 +292,12 @@ class RuntimeSupportedButtonTests(unittest.TestCase):
         buttons = derive_supported_buttons_from_reprog_controls(
             MX_MASTER_BUTTONS,
             [
-                self._control(0x00C3),
-                self._control(0x00C4),
+                self._control(0x00C3, flags=0x0130),
+                self._control(0x00C4, flags=0x0130),
             ],
             gesture_cids=(0x00C3,),
+            active_gesture_cid=0x00C3,
+            gesture_rawxy_enabled=True,
         )
 
         self.assertIn("hscroll_left", buttons)
@@ -264,15 +307,81 @@ class RuntimeSupportedButtonTests(unittest.TestCase):
         buttons = derive_supported_buttons_from_reprog_controls(
             MX_MASTER_BUTTONS,
             [
-                self._control("0x01A0"),
-                self._control("0x00C3"),
-                self._control("0x00C4"),
+                self._control("0x01A0", flags="0x0130"),
+                self._control("0x00C3", flags="0x0130"),
+                self._control("0x00C4", flags="0x0130"),
             ],
             gesture_cids=(0x00C3,),
+            active_gesture_cid="0x00C3",
+            gesture_rawxy_enabled=True,
         )
 
         self.assertNotIn("0x01A0", buttons)
         self.assertEqual(buttons, tuple(button for button in MX_MASTER_BUTTONS))
+
+    def test_mx_anywhere_2s_solaar_controls_keep_tilt_hscroll_without_mode_shift(self):
+        info = build_connected_device_info(
+            product_id=0xB01A,
+            reprog_controls=[
+                self._control(0x0052, flags=0x0130),
+                self._control(0x0053, flags=0x0130),
+                self._control(0x0056, flags=0x0130),
+                self._control(0x005B, flags=0x0130),
+                self._control(0x005D, flags=0x0130),
+                self._control(0x00D7, flags=0x03A0),
+            ],
+            gesture_cids=(0x00D7,),
+            active_gesture_cid=0x00D7,
+            gesture_rawxy_enabled=True,
+        )
+
+        self.assertIn("gesture_left", info.supported_buttons)
+        self.assertIn("gesture_right", info.supported_buttons)
+        self.assertIn("hscroll_left", info.supported_buttons)
+        self.assertIn("hscroll_right", info.supported_buttons)
+        self.assertNotIn("mode_shift", info.supported_buttons)
+
+    def test_mx_anywhere_3s_solaar_controls_keep_mode_shift_and_catalog_hscroll(self):
+        info = build_connected_device_info(
+            product_id=0xB037,
+            reprog_controls=[
+                self._control(0x0052, flags=0x0130),
+                self._control(0x0053, flags=0x0130),
+                self._control(0x0056, flags=0x0130),
+                self._control(0x00C4, flags=0x0130),
+                self._control(0x00D7, flags=0x03A0),
+            ],
+            gesture_cids=(0x00D7,),
+            active_gesture_cid=0x00D7,
+            gesture_rawxy_enabled=True,
+        )
+
+        self.assertIn("mode_shift", info.supported_buttons)
+        self.assertIn("gesture_up", info.supported_buttons)
+        self.assertIn("hscroll_left", info.supported_buttons)
+        self.assertIn("hscroll_right", info.supported_buttons)
+
+    def test_mx_master_4_haptic_control_does_not_create_supported_button(self):
+        info = build_connected_device_info(
+            product_id=0xB042,
+            reprog_controls=[
+                self._control(0x0052, flags=0x0130),
+                self._control(0x0053, flags=0x0130),
+                self._control(0x0056, flags=0x0130),
+                self._control(0x00C3, flags=0x0130),
+                self._control(0x00C4, flags=0x0130),
+                self._control(0x01A0, flags=0x0130),
+                self._control(0x00D7, flags=0x03A0),
+            ],
+            gesture_cids=(0x00C3, 0x00D7),
+            active_gesture_cid=0x00C3,
+            gesture_rawxy_enabled=True,
+        )
+
+        self.assertIn("mode_shift", info.supported_buttons)
+        self.assertIn("gesture_down", info.supported_buttons)
+        self.assertNotIn("action_ring", info.supported_buttons)
+        self.assertNotIn("haptic", info.supported_buttons)
 
 
 if __name__ == "__main__":

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -134,11 +134,31 @@ class LogiDeviceRegistryTests(unittest.TestCase):
         self.assertEqual(info.transport, "Bluetooth Low Energy")
         self.assertEqual(info.gesture_cids, DEFAULT_GESTURE_CIDS)
         self.assertEqual(info.ui_layout, "mx_master_3")
+        self.assertIn("mode_shift", info.supported_buttons)
+
+    def test_build_connected_device_info_filters_runtime_hid_buttons(self):
+        info = build_connected_device_info(
+            product_id=0xB023,
+            reprog_controls=[
+                {"cid": 0x0052},
+                {"cid": 0x0053},
+                {"cid": 0x0056},
+                {"cid": 0x00C3},
+            ],
+            gesture_cids=(0x00C3,),
+        )
+
+        self.assertIn("gesture", info.supported_buttons)
+        self.assertNotIn("mode_shift", info.supported_buttons)
+        self.assertIn("hscroll_left", info.supported_buttons)
 
     def test_build_connected_device_info_falls_back_to_runtime_name(self):
         info = build_connected_device_info(
             product_id=0xB999,
             product_name="Mystery Logitech Mouse",
+            reprog_controls=[
+                {"cid": 0x00C3},
+            ],
             gesture_cids=(0x00F1,),
         )
 

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -2,6 +2,7 @@ import unittest
 
 from core.logi_devices import (
     DEFAULT_GESTURE_CIDS,
+    KNOWN_LOGI_DEVICES,
     build_connected_device_info,
     clamp_dpi,
     get_buttons_for_layout,
@@ -94,6 +95,28 @@ class LogiDeviceRegistryTests(unittest.TestCase):
         self.assertNotIn("mode_shift", anywhere_2s)
         self.assertIn("mode_shift", anywhere_3)
         self.assertIn("mode_shift", anywhere_3s)
+
+    def test_known_product_ids_are_unique(self):
+        product_ids = {}
+        for device in KNOWN_LOGI_DEVICES:
+            for product_id in device.product_ids:
+                with self.subTest(product_id=f"0x{product_id:04X}"):
+                    self.assertNotIn(product_id, product_ids)
+                    product_ids[product_id] = device.key
+
+    def test_all_known_product_ids_resolve_to_their_device(self):
+        for device in KNOWN_LOGI_DEVICES:
+            for product_id in device.product_ids:
+                with self.subTest(device=device.key, product_id=f"0x{product_id:04X}"):
+                    self.assertEqual(resolve_device(product_id=product_id), device)
+
+    def test_all_exact_layout_keys_resolve_to_button_sets(self):
+        for device in KNOWN_LOGI_DEVICES:
+            with self.subTest(device=device.key, ui_layout=device.ui_layout):
+                self.assertEqual(
+                    get_buttons_for_layout(device.ui_layout),
+                    device.supported_buttons,
+                )
 
     def test_build_connected_device_info_uses_registry_defaults(self):
         info = build_connected_device_info(


### PR DESCRIPTION
## Why

Follow-up to #141.

#141 adds broader MX Master / MX Anywhere visual catalog support, but the catalog still needs a runtime safety layer before those buttons are exposed to users.

The static catalog can say a device family has gesture, mode shift, horizontal scroll, or DPI switch controls, but the actual connected device may expose a different HID++ control set. Solaar’s device dumps show this clearly across the MX Anywhere and MX
Master families:
- MX Anywhere 2S has tilt controls and virtual gesture, but no Smart Shift / mode shift control.
- MX Anywhere 3 / 3S expose Smart Shift and virtual gesture, but horizontal scroll is not represented as the same simple REPROG control shape.
- MX Master 4 exposes a real `0x01A0` Haptic control, but Mouser does not yet implement an action-ring/haptic button type.

Without a runtime guardrail, #141 could make the UI show buttons that are only present in the visual catalog, not actually usable through the connected device’s HID++ capabilities.

## What changed
- Narrow `supported_buttons` using discovered `REPROG_CONTROLS_V4` data.
- Require divertable controls for HID-gated buttons:
  - `mode_shift` requires divertable `0x00C4`
  - `dpi_switch` requires divertable `0x00FD`
- Pass the actual connected gesture state into device info:
  - active gesture CID
  - whether RawXY divert succeeded
- Keep directional gesture mappings only when RawXY is supported and actually enabled.
- Keep horizontal scroll catalog-driven for now, because Solaar data shows it can come from tilt, thumb wheel, virtual thumbwheel, or OS-level paths rather than one universal REPROG CID.
- Keep MX Master 4 `0x01A0` Haptic known-but-not-exposed instead of inventing a new unsupported button key.

## Solaar evidence used
- `KeyFlag` / `MappingFlag` define the relevant `DIVERTABLE`, `RAW_XY`, and `FORCE_RAW_XY` capability bits: https://github.com/pwr-Solaar/Solaar/blob/master/lib/logitech_receiver/hidpp20.py
- MX Anywhere 2S exposes tilt controls and virtual gesture: https://github.com/pwr-Solaar/Solaar/blob/master/docs/devices/Wireless%20Mobile%20Mouse%20MX%20Anywhere%202S%20B01A.txt
- MX Anywhere 3 exposes Smart Shift and virtual gesture: https://github.com/pwr-Solaar/Solaar/blob/master/docs/devices/MX%20Anywhere%203%20B025.txt
- MX Master 4 exposes Haptic `0x01A0`, Thumb Wheel, HiRes Wheel, and Virtual Gesture: https://github.com/pwr-Solaar/Solaar/blob/master/docs/devices/MX%20Master%204.text

## Scope
It does not add support for:
- MX Master 4 action ring / haptic button mapping
- Haptic feature configuration
- Thumb wheel settings
- High sensitivity scroll behavior
- New config schema or migrations

This only makes #141’s static visual catalog safer by filtering HID-gated buttons against the runtime HID++ controls that were actually discovered.

## Tests

```text
uv run --with-requirements requirements.txt python -m unittest tests.test_logi_devices tests.test_hid_gesture tests.test_backend tests.test_device_layouts

Ran 94 tests in 0.110s
OK

uv run --with-requirements requirements.txt python -m unittest discover -s tests

Ran 298 tests in 23.282s
OK
```