### PR TITLE
fix: support Windows F13-F24 shortcuts

### DIFF
--- a/core/key_simulator.py
+++ b/core/key_simulator.py
@@ -29,6 +29,12 @@ def valid_custom_key_names():
         return []
 
 
+WINDOWS_FUNCTION_KEY_CODES = {
+    f"f{n}": 0x6F + n
+    for n in range(1, 25)
+}
+
+
 def normalize_captured_shortcut_parts(modifier_names, key_name="", platform_name=None):
     """Normalize captured modifier/key names into stored shortcut syntax."""
     platform_name = platform_name or sys.platform
@@ -581,9 +587,7 @@ if sys.platform == "win32":
         "p": 0x50, "q": 0x51, "r": 0x52, "s": 0x53, "t": 0x54,
         "u": 0x55, "v": 0x56, "w": 0x57, "x": 0x58, "y": 0x59,
         "z": 0x5A,
-        "f1": VK_F1, "f2": VK_F2, "f3": VK_F3, "f4": VK_F4,
-        "f5": VK_F5, "f6": VK_F6, "f7": VK_F7, "f8": VK_F8,
-        "f9": VK_F9, "f10": VK_F10, "f11": VK_F11, "f12": VK_F12,
+        **WINDOWS_FUNCTION_KEY_CODES,
         "volumeup": VK_VOLUME_UP, "volumedown": VK_VOLUME_DOWN,
         "mute": VK_VOLUME_MUTE, "playpause": VK_MEDIA_PLAY_PAUSE,
         "nexttrack": VK_MEDIA_NEXT_TRACK, "prevtrack": VK_MEDIA_PREV_TRACK,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -347,6 +347,27 @@ class BackendDeviceLayoutTests(unittest.TestCase):
             "esc",
         )
 
+    def test_shortcut_capture_accepts_extended_function_keys(self):
+        backend = self._make_backend()
+
+        with patch("ui.backend.sys.platform", "win32"):
+            self.assertEqual(
+                backend.shortcutComboFromQtEvent(
+                    Qt.Key_F13,
+                    Qt.NoModifier,
+                    "",
+                ),
+                "f13",
+            )
+            self.assertEqual(
+                backend.shortcutComboFromQtEvent(
+                    Qt.Key_F24,
+                    Qt.ControlModifier,
+                    "",
+                ),
+                "ctrl+f24",
+            )
+
     def test_add_profile_stores_catalog_id_for_linux_app(self):
         backend = self._make_backend()
         fake_catalog = [

--- a/tests/test_key_simulator.py
+++ b/tests/test_key_simulator.py
@@ -53,6 +53,12 @@ class CustomShortcutParsingTests(unittest.TestCase):
         )
         self.assertEqual(keys, [17, 52])
 
+    def test_windows_custom_shortcut_codes_include_f13_through_f24(self):
+        self.assertEqual(key_simulator.WINDOWS_FUNCTION_KEY_CODES["f1"], 0x70)
+        self.assertEqual(key_simulator.WINDOWS_FUNCTION_KEY_CODES["f12"], 0x7B)
+        self.assertEqual(key_simulator.WINDOWS_FUNCTION_KEY_CODES["f13"], 0x7C)
+        self.assertEqual(key_simulator.WINDOWS_FUNCTION_KEY_CODES["f24"], 0x87)
+
 
 class LinuxDesktopShortcutTests(unittest.TestCase):
     def _reload_for_linux(self, desktop: str):

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -98,8 +98,9 @@ def _qt_shortcut_key_name(key, text=""):
     if key == _qt_enum_int(Qt.Key_PageDown):
         return "pagedown"
 
-    for n in range(1, 13):
-        if key == _qt_enum_int(getattr(Qt, f"Key_F{n}")):
+    for n in range(1, 25):
+        qt_key = getattr(Qt, f"Key_F{n}", None)
+        if qt_key is not None and key == _qt_enum_int(qt_key):
             return f"f{n}"
 
     if _qt_enum_int(Qt.Key_A) <= key <= _qt_enum_int(Qt.Key_Z):


### PR DESCRIPTION
## Summary
- allow Windows custom shortcut execution for F13-F24 virtual keys
- allow Qt shortcut capture to store F13-F24 keys
- add regression coverage for the Windows key-code table and UI capture path

Fixes #138.

## Tests
- `./.venv/bin/python -m unittest tests.test_key_simulator`
- `./.venv/bin/python -m unittest tests.test_backend`
- `./.venv/bin/python -m unittest discover -s tests`