### PR TITLE
fix: High memory usage, Bound hook dispatch backlogs

### DIFF
--- a/core/mouse_hook_base.py
+++ b/core/mouse_hook_base.py
@@ -2,6 +2,7 @@
 Shared mouse hook behavior used by platform implementations.
 """
 
+import queue
 import time
 
 try:
@@ -41,6 +42,33 @@ class BaseMouseHook:
         self._gesture_cooldown_until = 0.0
         self._gesture_input_source = None
         self._connected_device = None
+        self._dispatch_queue = None
+
+    def _init_dispatch_queue(self, maxsize=0):
+        """Initialize dispatch queue storage for subclasses with event threads."""
+        self._dispatch_queue = queue.Queue(maxsize=max(0, int(maxsize)))
+
+    def _enqueue_dispatch_event(self, event):
+        """Best-effort enqueue that bounds memory when queue has a max size."""
+        q = self._dispatch_queue
+        if q is None:
+            return
+        if q.maxsize <= 0:
+            q.put(event)
+            return
+        try:
+            q.put_nowait(event)
+            return
+        except queue.Full:
+            pass
+        try:
+            q.get_nowait()
+        except queue.Empty:
+            pass
+        try:
+            q.put_nowait(event)
+        except queue.Full:
+            self._emit_debug(f"Dropped event due to full dispatch queue: {event.event_type}")
 
     def register(self, event_type, callback):
         self._callbacks.setdefault(event_type, []).append(callback)
@@ -254,3 +282,24 @@ class BaseMouseHook:
     def _on_hid_disconnect(self):
         self._connected_device = None
         self._set_device_connected(False)
+
+    def _on_hid_gesture_down(self):
+        self._dispatch(MouseEvent(MouseEvent.GESTURE_DOWN))
+
+    def _on_hid_gesture_up(self):
+        self._dispatch(MouseEvent(MouseEvent.GESTURE_UP))
+
+    def _on_hid_gesture_move(self, dx, dy):
+        self._accumulate_gesture_delta(dx, dy, "hid_rawxy")
+
+    def _on_hid_mode_shift_down(self):
+        self._dispatch(MouseEvent(MouseEvent.MODE_SHIFT_DOWN))
+
+    def _on_hid_mode_shift_up(self):
+        self._dispatch(MouseEvent(MouseEvent.MODE_SHIFT_UP))
+
+    def _on_hid_dpi_switch_down(self):
+        self._dispatch(MouseEvent(MouseEvent.DPI_SWITCH_DOWN))
+
+    def _on_hid_dpi_switch_up(self):
+        self._dispatch(MouseEvent(MouseEvent.DPI_SWITCH_UP))

--- a/core/mouse_hook_macos.py
+++ b/core/mouse_hook_macos.py
@@ -63,7 +63,7 @@ class MouseHook(BaseMouseHook):
         self._wake_observer = None
         self._session_resign_observer = None
         self._session_activate_observer = None
-        self._dispatch_queue = queue.Queue()
+        self._init_dispatch_queue(maxsize=512)
         self._dispatch_thread = None
         self._first_event_logged = False
 
@@ -219,7 +219,7 @@ class MouseHook(BaseMouseHook):
                     "dy": self._gesture_delta_y,
                 }
             )
-            self._dispatch_queue.put(
+            self._enqueue_dispatch_event(
                 MouseEvent(
                     gesture_event,
                     {
@@ -400,7 +400,7 @@ class MouseHook(BaseMouseHook):
                         mouse_event = MouseEvent(MouseEvent.HSCROLL_LEFT, abs(h_delta))
                         should_block = MouseEvent.HSCROLL_LEFT in self._blocked_events
                 if mouse_event:
-                    self._dispatch_queue.put(mouse_event)
+                    self._enqueue_dispatch_event(mouse_event)
                     mouse_event = None
                 if should_block:
                     return None
@@ -409,7 +409,7 @@ class MouseHook(BaseMouseHook):
                         return None
 
             if mouse_event:
-                self._dispatch_queue.put(mouse_event)
+                self._enqueue_dispatch_event(mouse_event)
 
             if should_block:
                 return None

--- a/core/mouse_hook_windows.py
+++ b/core/mouse_hook_windows.py
@@ -241,7 +241,7 @@ class MouseHook(BaseMouseHook):
         self._startup_ok = False
         self._prev_raw_buttons = {}
         self._last_rehook_time = 0
-        self._dispatch_queue = queue.Queue()
+        self._init_dispatch_queue(maxsize=512)
         self._dispatch_worker_thread = None
 
     def _accumulate_gesture_delta(self, delta_x, delta_y, source):
@@ -466,7 +466,7 @@ class MouseHook(BaseMouseHook):
                         )
 
             if event:
-                self._dispatch_queue.put(event)
+                self._enqueue_dispatch_event(event)
                 if should_block:
                     return 1
 

--- a/tests/test_mouse_hook.py
+++ b/tests/test_mouse_hook.py
@@ -1,4 +1,5 @@
 import importlib
+import queue
 import sys
 import unittest
 from types import SimpleNamespace
@@ -81,6 +82,37 @@ class BaseMouseHookRuntimeStateTests(unittest.TestCase):
         self.assertTrue(state.input_ready)
         self.assertTrue(state.hid_ready)
         self.assertIs(state.connected_device, device)
+
+
+
+class BaseMouseHookDispatchQueueTests(unittest.TestCase):
+    def test_enqueue_keeps_queue_bounded_and_drops_oldest(self):
+        hook = BaseMouseHook()
+        hook._init_dispatch_queue(maxsize=2)
+
+        hook._enqueue_dispatch_event(SimpleNamespace(event_type="e1", raw_data=None))
+        hook._enqueue_dispatch_event(SimpleNamespace(event_type="e2", raw_data=None))
+        hook._enqueue_dispatch_event(SimpleNamespace(event_type="e3", raw_data=None))
+
+        self.assertEqual(hook._dispatch_queue.qsize(), 2)
+        first = hook._dispatch_queue.get_nowait()
+        second = hook._dispatch_queue.get_nowait()
+        self.assertEqual(first.event_type, "e2")
+        self.assertEqual(second.event_type, "e3")
+
+    def test_enqueue_drops_and_emits_debug_when_still_full(self):
+        hook = BaseMouseHook()
+        hook._init_dispatch_queue(maxsize=1)
+        hook.debug_mode = True
+        hook.set_debug_callback(Mock())
+
+        hook._dispatch_queue.put_nowait(SimpleNamespace(event_type="old", raw_data=None))
+        with patch.object(hook._dispatch_queue, "get_nowait", side_effect=queue.Empty):
+            with patch.object(hook._dispatch_queue, "put_nowait", side_effect=[queue.Full, queue.Full]):
+                hook._enqueue_dispatch_event(SimpleNamespace(event_type="new", raw_data=None))
+
+        hook._debug_callback.assert_called_once()
+        self.assertIn("Dropped event due to full dispatch queue", hook._debug_callback.call_args[0][0])
 
 
 class LinuxMouseHookReconnectTests(unittest.TestCase):


### PR DESCRIPTION
This is a fix for Issue #150 

Root cause:
Long-running memory growth came from dispatch backlog risk in hook event pipelines. Producer callbacks can outpace consumer dispatch temporarily (gesture/scroll bursts, scheduling stalls, reconnect periods), and without a hard queue bound this can accumulate unbounded event objects over time.

What changed:
- Added shared dispatch queue management in BaseMouseHook:
  - _dispatch_queue attribute
  - _init_dispatch_queue(maxsize)
  - _enqueue_dispatch_event(event) with best-effort behavior:
    - non-blocking enqueue
    - if full: drop oldest, retry once
    - if still full: drop new event and emit debug message
- Updated platform hooks to use shared bounded queue init:
  - macOS: _init_dispatch_queue(maxsize=512)
  - Windows: _init_dispatch_queue(maxsize=512)
- Updated event producer paths to use _enqueue_dispatch_event(...) rather
  than direct queue puts.
- Added unit tests for queue overflow semantics:
  - verifies bounded capacity with oldest-drop behavior
  - verifies debug emission when queue remains saturated

Why:
This makes memory usage stable under transient overload and keeps recent input intent prioritized over stale backlog replay, improving long-run correctness and resilience.