### PR TITLE
fix: repair Linux release asset packaging

### DIFF
--- a/Mouser-linux.spec
+++ b/Mouser-linux.spec
@@ -92,15 +92,15 @@ a = Analysis(
         (os.path.join(ROOT, "images"), "images"),
         (
             os.path.join(ROOT, "packaging", "linux", "69-mouser-logitech.rules"),
-            os.path.join("linux", "69-mouser-logitech.rules"),
+            "linux",
         ),
         (
             os.path.join(ROOT, "packaging", "linux", "install-linux-permissions.sh"),
-            os.path.join("linux", "install-linux-permissions.sh"),
+            "linux",
         ),
         (
             os.path.join(ROOT, "packaging", "linux", "io.github.tombadash.mouser.desktop.in"),
-            os.path.join("linux", "io.github.tombadash.mouser.desktop.in"),
+            "linux",
         ),
         (BUILD_INFO_DATA, "."),
     ],

--- a/tests/test_build_support.py
+++ b/tests/test_build_support.py
@@ -1,4 +1,5 @@
 import os
+import re
 import stat
 import unittest
 
@@ -63,6 +64,32 @@ class LinuxPermissionPackagingTests(unittest.TestCase):
         self.assertTrue(os.path.isfile(helper))
         self.assertTrue(os.stat(helper).st_mode & stat.S_IXUSR)
         self.assertTrue(os.path.isfile(rules))
+
+    def test_linux_spec_packages_linux_files_into_linux_directory(self):
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        spec_path = os.path.join(root, "Mouser-linux.spec")
+        with open(spec_path, encoding="utf-8") as spec_file:
+            spec_text = spec_file.read()
+
+        linux_assets = (
+            "69-mouser-logitech.rules",
+            "install-linux-permissions.sh",
+            "io.github.tombadash.mouser.desktop.in",
+        )
+        for asset_name in linux_assets:
+            with self.subTest(asset=asset_name):
+                self.assertRegex(
+                    spec_text,
+                    re.compile(
+                        rf'os\.path\.join\(ROOT, "packaging", "linux", '
+                        rf'"{re.escape(asset_name)}"\),\s*"linux",',
+                        re.MULTILINE,
+                    ),
+                )
+                self.assertNotIn(
+                    f'os.path.join("linux", "{asset_name}")',
+                    spec_text,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fix the Linux release bundle so the packaged `.desktop` template, udev rules,
  and permission helper land at `_internal/linux/<file>` instead of inside
  same-named directories.
- Restore the packaged Linux launcher refresh and start-at-login enable/disable
  paths, which failed because the template file could not be read.
- Add a packaging spec invariant test to prevent the regression from recurring.

## Addresses

- #146

## Validation

- Unit tests: `python -m pytest tests/test_startup.py tests/test_build_support.py`
- Full suite: `python -m pytest`
- Manual verification on Fedora-based Linux:
  - headless startup succeeds without `Is a directory` warnings;
  - start-at-login enable creates `~/.config/autostart/io.github.tombadash.mouser.desktop`;
  - start-at-login disable removes that file with no launcher-refresh errors.

## Notes

- Does not add new Linux package formats.
- An existing non-fatal Qt Wayland plugin warning is outside the scope of this fix.