### PR TITLE
chore: ignore local IDE + per-machine dev-environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,19 @@ build/
 # IDE
 .vscode/
 .idea/
+.cursor/
 *.swp
 *.swo
+
+# Per-machine / per-user dev-environment pins. These commonly carry
+# signing identities, API keys, install dirs, or runtime versions that
+# are local to a single developer's setup.
+.python-version
+.tool-versions
+.envrc
+.env
+.env.*
+*.local.json
 
 # OS
 Thumbs.db


### PR DESCRIPTION
## Summary

Extends `.gitignore` to cover the IDE workspace and per-machine
dev-environment files that have no business landing in commit
history.

```gitignore
# Per-machine / per-user dev-environment pins. These commonly carry
# signing identities, API keys, install dirs, or runtime versions that
# are local to a single developer's setup.
.python-version
.tool-versions
.envrc
.env
.env.*
*.local.json
```

Also adds `.cursor/` (alongside the existing `.vscode/` and `.idea/`
entries) since Cursor stores per-checkout IDE state there (agent
transcripts, hook scripts, project metadata) which carries the
developer's local workflow, not anything intended for the repo.

## Why these specifically

| Path | Tool | Risk it routinely carries |
|---|---|---|
| `.cursor/` | Cursor IDE | agent transcripts, project metadata |
| `.python-version` | pyenv | per-machine Python pin |
| `.tool-versions` | asdf | per-machine runtime pins |
| `.envrc` | direnv | secrets, signing identities, install dirs |
| `.env` / `.env.*` | dotenv | credentials, API keys |
| `*.local.json` | various IDEs | per-machine overrides |

Ignoring by pattern protects against `git add .` from a stale shell
or a fast-typing teammate, rather than relying on every developer
to remember every artefact every time.

## Test plan

- [x] `git check-ignore -v .python-version` resolves to the new rule
- [x] `git check-ignore -v .env` resolves
- [x] `git status` on a checkout with `.python-version`, `.cursor/`,
      and a `local.env.local.json` shows none of them as untracked
- [x] `pytest tests/` -- 406 tests, 155 subtests, green (unchanged)
- [x] `git diff --check` -- clean