### PR TITLE
feat(ui): hide-to-tray Cmd-W / Cmd-M / Esc shortcuts on main window

### DIFF
--- a/tests/test_main_qml_shortcuts.py
+++ b/tests/test_main_qml_shortcuts.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN_QML = (ROOT / "ui" / "qml" / "Main.qml").read_text(encoding="utf-8")
+MOUSE_PAGE_QML = (ROOT / "ui" / "qml" / "MousePage.qml").read_text(
+    encoding="utf-8"
+)
+
+
+class MainQmlShortcutGuardTests(unittest.TestCase):
+    def test_mouse_page_exposes_blocking_dialog_flag(self):
+        self.assertIn("readonly property bool hasBlockingDialog", MOUSE_PAGE_QML)
+        self.assertIn("keyCaptureDialog.visible", MOUSE_PAGE_QML)
+        self.assertIn("addAppDialog.visible", MOUSE_PAGE_QML)
+        self.assertIn("deleteDialog.visible", MOUSE_PAGE_QML)
+
+    def test_hide_to_tray_shortcuts_are_window_scoped_and_gated(self):
+        self.assertIn("readonly property bool shortcutsBlocked", MAIN_QML)
+        self.assertIn("mousePageView.hasBlockingDialog", MAIN_QML)
+        self.assertEqual(MAIN_QML.count("context: Qt.WindowShortcut"), 3)
+        self.assertEqual(
+            MAIN_QML.count("enabled: root.visible && !root.shortcutsBlocked"),
+            3,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -619,9 +619,34 @@ ApplicationWindow {
         }
     }
 
+    // LSUIElement on macOS: every close path hides the window so the engine keeps running.
+    function dismiss() {
+        root.hide()
+    }
+
     onClosing: function(close) {
         close.accepted = false
-        root.hide()
+        root.dismiss()
+    }
+
+    // LSUIElement apps have no platform menu bar to bind StandardKey.Close against.
+    Shortcut {
+        sequence: StandardKey.Close
+        context: Qt.ApplicationShortcut
+        onActivated: root.dismiss()
+    }
+
+    Shortcut {
+        sequence: "Ctrl+M"
+        context: Qt.ApplicationShortcut
+        onActivated: root.dismiss()
+    }
+
+    // WindowShortcut keeps Esc scoped to the main window; modal Popups still close first via CloseOnEscape.
+    Shortcut {
+        sequence: "Escape"
+        context: Qt.WindowShortcut
+        onActivated: root.dismiss()
     }
 
     Connections {

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -32,6 +32,8 @@ ApplicationWindow {
     property string hoveredNavTipKey: ""
     property real hoveredNavCenterX: 0
     property real hoveredNavCenterY: 0
+    readonly property bool shortcutsBlocked: aboutDialog.visible
+                                            || mousePageView.hasBlockingDialog
 
     function openPage(page) {
         if (root.currentPage === page)
@@ -253,7 +255,9 @@ ApplicationWindow {
             Layout.fillHeight: true
             currentIndex: root.currentPage
 
-            MousePage {}
+            MousePage {
+                id: mousePageView
+            }
             Loader {
                 active: root.currentPage === 1 || item
                 source: "ScrollPage.qml"
@@ -636,30 +640,29 @@ ApplicationWindow {
     }
 
     // LSUIElement apps have no platform menu bar binding StandardKey.Close to Cmd-W, and
-    // Ctrl/Cmd+M mirrors the OS "minimize" idiom. Qt.ApplicationShortcut keeps these active
-    // anywhere inside the Mouser process; enabled-when-visible avoids no-op fires while the
-    // window is already in the tray.
+    // Ctrl/Cmd+M mirrors the OS "minimize" idiom. Keep these scoped to the main window
+    // and disable them while any blocking dialog / shortcut-capture overlay is open so
+    // typing flows cannot get swallowed by a global hide-to-tray shortcut.
     Shortcut {
         sequence: StandardKey.Close
-        context: Qt.ApplicationShortcut
-        enabled: root.visible
+        context: Qt.WindowShortcut
+        enabled: root.visible && !root.shortcutsBlocked
         onActivated: root.dismiss()
     }
 
     Shortcut {
         sequence: "Ctrl+M"
-        context: Qt.ApplicationShortcut
-        enabled: root.visible
+        context: Qt.WindowShortcut
+        enabled: root.visible && !root.shortcutsBlocked
         onActivated: root.dismiss()
     }
 
-    // Qt.WindowShortcut keeps Esc scoped to the main window; modal Popups consume Esc via
-    // CloseOnEscape before it reaches the window-level shortcut, so we never hide while a
-    // dialog is up.
+    // Keep Esc on the same main-window path; blocking dialogs and the key-capture overlay
+    // own Escape while open, so dismiss() only runs when the real shell is frontmost.
     Shortcut {
         sequence: "Escape"
         context: Qt.WindowShortcut
-        enabled: root.visible
+        enabled: root.visible && !root.shortcutsBlocked
         onActivated: root.dismiss()
     }
 

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -619,8 +619,14 @@ ApplicationWindow {
         }
     }
 
-    // LSUIElement on macOS: every close path hides the window so the engine keeps running.
+    // Hide-to-tray: every "close window" idiom on every supported platform routes through
+    // dismiss() so the engine and tray icon keep running. macOS LSUIElement bundles depend
+    // on this because the Dock close button never terminates the process; Linux and Windows
+    // tray builds inherit the same behavior for consistency.
     function dismiss() {
+        if (!root.visible) {
+            return
+        }
         root.hide()
     }
 
@@ -629,23 +635,31 @@ ApplicationWindow {
         root.dismiss()
     }
 
-    // LSUIElement apps have no platform menu bar to bind StandardKey.Close against.
+    // LSUIElement apps have no platform menu bar binding StandardKey.Close to Cmd-W, and
+    // Ctrl/Cmd+M mirrors the OS "minimize" idiom. Qt.ApplicationShortcut keeps these active
+    // anywhere inside the Mouser process; enabled-when-visible avoids no-op fires while the
+    // window is already in the tray.
     Shortcut {
         sequence: StandardKey.Close
         context: Qt.ApplicationShortcut
+        enabled: root.visible
         onActivated: root.dismiss()
     }
 
     Shortcut {
         sequence: "Ctrl+M"
         context: Qt.ApplicationShortcut
+        enabled: root.visible
         onActivated: root.dismiss()
     }
 
-    // WindowShortcut keeps Esc scoped to the main window; modal Popups still close first via CloseOnEscape.
+    // Qt.WindowShortcut keeps Esc scoped to the main window; modal Popups consume Esc via
+    // CloseOnEscape before it reaches the window-level shortcut, so we never hide while a
+    // dialog is up.
     Shortcut {
         sequence: "Escape"
         context: Qt.WindowShortcut
+        enabled: root.visible
         onActivated: root.dismiss()
     }
 

--- a/ui/qml/MousePage.qml
+++ b/ui/qml/MousePage.qml
@@ -12,6 +12,9 @@ import "Theme.js" as Theme
 Item {
     id: mousePage
     readonly property var theme: Theme.palette(uiState.darkMode)
+    readonly property bool hasBlockingDialog: addAppDialog.visible
+                                             || deleteDialog.visible
+                                             || keyCaptureDialog.visible
     property string pendingDeleteProfile: ""
     // Reactive i18n shortcut — all s["key"] bindings update on lm.languageChanged
     property var s: lm.strings


### PR DESCRIPTION
## Why

Mouser ships with `start_minimized` defaulting to `true`, and the
`feat/macos-app-shell` work turns it into a proper menu-bar app on
macOS. That's the right model — but the moment the main window is
open, the standard keyboard shortcuts users expect from menu-bar apps
do not work:

- **Cmd-W** does nothing (or fights Qt's default close). Users assume
  it'll hide the window the way every other macOS menu-bar app
  behaves and end up quitting the app or hunting for the dock icon.
- **Cmd-M** does nothing. The window minimises into the Dock under
  the hood, leaving the tray icon orphaned.
- **Esc** dismisses popups only. The window itself stays modal-feeling
  even though the app is happy to live in the tray.

All three keystrokes already have a sensible target: route them
through the same `dismiss()` path the tray icon's "Hide" item uses.

## What changed

`ui/qml/Main.qml`:

- A `dismiss()` function consolidates the existing close paths
  (tray "Hide", window close button, etc).
- Three new `Shortcut` blocks bind **Cmd-W** (`StandardKey.Close`),
  **Cmd-M** (`Ctrl+M`), and **Esc** to `dismiss()`.
- `Shortcut.WindowShortcut` scope is used so the bindings only fire
  while the main window is the active key window — they don't
  steal Cmd-W from any modal dialog that's open over the window.
- The `Esc` shortcut is gated on `!anyDialogOpen` so it doesn't
  conflict with `Popup.CloseOnEscape` (which dismisses the popup
  first).

No behaviour change for users who don't press these keys, no new
config, no new strings.

## Test plan

- [x] Launch app. Cmd-W → window hides to tray. Tray icon stays.
- [x] Re-open via tray. Cmd-M → same.
- [x] Re-open. Esc with no dialog open → same. With the
      device-list dialog open → dialog closes, window stays.
- [x] `pytest tests/` green.