### PR TITLE
feat(macos): launcher identity, Dock tile, hide-to-tray, native menu-bar item

### DIFF
--- a/main_qml.py
+++ b/main_qml.py
@@ -1,5 +1,5 @@
 """
-Mouser — QML Entry Point
+Mouser -- QML Entry Point
 ==============================
 Launches the Qt Quick / QML UI with PySide6.
 Replaces the old tkinter-based main.py.
@@ -17,7 +17,7 @@ import getpass
 import time
 from urllib.parse import parse_qs, unquote
 
-# Ensure project root on path — works for both normal Python and PyInstaller.
+# Ensure project root on path -- works for both normal Python and PyInstaller.
 # PyInstaller on Windows/Linux stores bundled data in `_internal/` next to the
 # executable, while macOS app bundles expose resources from `Contents/Resources`.
 def _resolve_root_dir():
@@ -47,7 +47,7 @@ os.environ["QT_QUICK_CONTROLS_MATERIAL_ACCENT"] = "#00d4aa"
 
 _t1 = _time.perf_counter()
 from PySide6.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QFileIconProvider, QMessageBox
-from PySide6.QtGui import QAction, QColor, QIcon, QPainter, QPixmap
+from PySide6.QtGui import QAction, QColor, QIcon, QPainter, QPixmap, QWindow
 from PySide6.QtCore import QObject, Property, QCoreApplication, QRectF, Qt, QUrl, Signal, QFileInfo
 from PySide6.QtQml import QQmlApplicationEngine
 from PySide6.QtQuick import QQuickImageProvider
@@ -161,21 +161,19 @@ def _single_instance_acquire(app: QApplication, server_name: str):
 
 
 def _app_icon() -> QIcon:
-    if sys.platform == "darwin":
-        icon = QIcon()
-        source = QPixmap(os.path.join(ROOT, "images", "logo_icon.png"))
-        if not source.isNull():
-            for size in (16, 32, 64, 128, 256):
-                icon.addPixmap(
-                    source.scaled(
-                        size,
-                        size,
-                        Qt.AspectRatioMode.KeepAspectRatio,
-                        Qt.TransformationMode.SmoothTransformation,
-                    )
-                )
-        return icon
-    return QIcon(os.path.join(ROOT, "images", "logo.ico"))
+    """Build the QIcon for the window title bar. On macOS, hand QIcon the
+    full-resolution 1024px PNG so AppKit's setApplicationIconImage_
+    (called via QApplication.setWindowIcon) renders crisply at the full
+    Dock tile size instead of the upscaled-256px blur the pre-scaled
+    pixmap path produced. Logs and returns an empty QIcon if the asset
+    file is missing.
+    """
+    icon_name = "logo_icon.png" if sys.platform == "darwin" else "logo.ico"
+    icon_path = os.path.join(ROOT, "images", icon_name)
+    if not os.path.isfile(icon_path):
+        print(f"[Mouser] App icon missing: {icon_path}")
+        return QIcon()
+    return QIcon(icon_path)
 
 
 def _render_svg_pixmap(path: str, color: QColor, size: int) -> QPixmap:
@@ -220,16 +218,231 @@ def _tray_icon() -> QIcon:
     return icon
 
 
-def _configure_macos_app_mode():
+_MACOS_RELAUNCH_GUARD = "MOUSER_MACOS_RELAUNCHED"
+
+
+def _macos_named_executable_path() -> str:
+    """Return a stable path for the `Mouser`-named launcher symlink.
+
+    When ``sys.executable`` is in a virtualenv, place the symlink next to
+    the venv's python shim so `pyvenv.cfg` discovery still resolves
+    site-packages after the re-exec. Otherwise fall back to a path inside
+    the project tree so it stays stable across reboots.
+    """
+    exec_dir = os.path.dirname(sys.executable)
+    pyvenv_cfg = os.path.join(os.path.dirname(exec_dir), "pyvenv.cfg")
+    if os.path.isfile(pyvenv_cfg):
+        return os.path.join(exec_dir, "Mouser")
+    return os.path.join(ROOT, "build", "macos", "bin", "Mouser")
+
+
+def _maybe_relaunch_with_mouser_process_name() -> None:
+    """Re-exec the interpreter through a `Mouser`-named symlink.
+
+    macOS reads the user-visible process name from the Mach-O image
+    header at execve() time. For a bundle-less launch (``python
+    main_qml.py``) that means the Dock tile, Cmd+Tab caption, Force
+    Quit, and Activity Monitor all read "python", and there is no
+    in-process API to rename the image afterwards. Re-execing through
+    a symlink whose basename is `Mouser` is the only reliable fix.
+
+    Returns immediately on non-macOS, on PyInstaller-frozen bundles
+    (already correctly named), when the env-var guard shows we already
+    relaunched, when the basename already starts with "mouser", or
+    when the symlink can't be staged.
+    """
+    if sys.platform != "darwin":
+        return
+    if getattr(sys, "frozen", False):
+        return
+    if os.environ.get(_MACOS_RELAUNCH_GUARD) == "1":
+        return
+    source_executable = sys.executable
+    if not source_executable or not os.path.isfile(source_executable):
+        print("[Mouser] sys.executable missing or not a file; skipping relaunch")
+        return
+    # Important: link the venv shim (`sys.executable`), NOT the underlying
+    # interpreter (`os.path.realpath(sys.executable)`). The shim is what
+    # holds the venv's identity; the real interpreter has no venv context.
+    current_basename = os.path.basename(source_executable)
+    if current_basename.lower().startswith("mouser"):
+        return
+    target = _macos_named_executable_path()
+    target_dir = os.path.dirname(target)
+    # Stage atomically via a unique temp symlink + os.replace(). This
+    # avoids the unlink/symlink TOCTOU window where a concurrent launch
+    # could observe `target` missing, and never leaves a moment when the
+    # launcher path doesn't resolve to a usable executable.
+    staging = f"{target}.staging.{os.getpid()}"
+    try:
+        os.makedirs(target_dir, exist_ok=True)
+        try:
+            os.symlink(source_executable, staging)
+        except FileExistsError:
+            # Crashed prior run left a staging symlink behind. Clear it
+            # and retry once; any further failure falls through to the
+            # outer except and the in-place fallback.
+            os.remove(staging)
+            os.symlink(source_executable, staging)
+        try:
+            os.replace(staging, target)
+        except OSError:
+            # Best-effort cleanup of our staging entry so we don't leak
+            # one per failed relaunch attempt.
+            try:
+                os.remove(staging)
+            except OSError:
+                pass
+            raise
+    except OSError as exc:
+        print(f"[Mouser] Could not stage Mouser-named launcher: {exc}")
+        return
+    os.environ[_MACOS_RELAUNCH_GUARD] = "1"
+    new_argv = [target, *sys.argv]
+    print(
+        f"[Mouser] Re-execing through {target} so the Dock shows 'Mouser' "
+        f"instead of '{current_basename}'"
+    )
+    try:
+        os.execv(target, new_argv)
+    except OSError as exc:
+        # If exec fails for any reason, fall back to in-place launch so
+        # the user still gets a working app, just with the wrong label.
+        print(f"[Mouser] Re-exec failed: {exc}; continuing with current process")
+        os.environ.pop(_MACOS_RELAUNCH_GUARD, None)
+
+
+def _rename_macos_bundle_for_dock():
+    """Override CFBundleName / CFBundleDisplayName before NSApplication
+    is constructed. AppKit reads `[NSBundle mainBundle]` once during init
+    to populate the application menu, Force Quit, notification banners,
+    etc. The Dock label itself is still driven by the relaunch above.
+    """
     if sys.platform != "darwin":
         return
     try:
-        import AppKit
-        AppKit.NSApp.setActivationPolicy_(
-            AppKit.NSApplicationActivationPolicyAccessory
-        )
+        from Foundation import NSBundle
+        bundle = NSBundle.mainBundle()
+        info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+        if info is None:
+            return
+        info["CFBundleName"] = "Mouser"
+        info["CFBundleDisplayName"] = "Mouser"
+        info.setdefault("CFBundleExecutable", "Mouser")
     except Exception as exc:
-        print(f"[Mouser] Failed to configure macOS app mode: {exc}")
+        print(f"[Mouser] Could not pre-rename bundle for Dock: {exc}")
+
+
+# Cached AppKit module + Dock-icon NSImage + last-applied activation policy.
+# These are populated only after the corresponding AppKit calls succeed so
+# a failure path doesn't leave the cached state out of sync with reality.
+# Caching matters because `visibilityChanged` can fire repeatedly under
+# rapid window state churn (minimize/restore storms, Spaces switches), and
+# without a cache each fire would re-decode the 1024px PNG and re-issue
+# AppKit calls that are no-ops for the Dock anyway.
+_MACOS_APPKIT = None
+_MACOS_DOCK_ICON_NSIMAGE = None
+_MACOS_ACTIVATION_POLICY_REGULAR: "bool | None" = None
+_MACOS_NATIVE_STATUS_ITEM = None
+_MACOS_NATIVE_STATUS_TARGET = None
+
+
+def _macos_appkit():
+    """Lazy-import + cache of the AppKit module. Returns None on import
+    failure (logged once) so callers can no-op cleanly."""
+    global _MACOS_APPKIT
+    if _MACOS_APPKIT is not None:
+        return _MACOS_APPKIT
+    try:
+        import AppKit
+    except Exception as exc:
+        print(f"[Mouser] Failed to import AppKit: {exc}")
+        return None
+    _MACOS_APPKIT = AppKit
+    return AppKit
+
+
+def _configure_macos_app_mode():
+    """Initial activation policy at launch time. Stays Accessory (menu-bar
+    only) until the window opens, at which point we promote to Regular so
+    Mouser becomes a real Cmd+Tab-able foreground app."""
+    _set_macos_activation_policy(regular=False)
+
+
+def _install_macos_dock_icon():
+    """Replace the Dock / Cmd+Tab / Mission Control icon with Mouser's
+    logo. Qt's ``app.setWindowIcon()`` only covers the title bar on
+    macOS, so without this override a bare ``python main_qml.py`` shows
+    the generic Python launcher icon. The decoded NSImage is cached at
+    module scope so repeated calls only re-issue the cheap
+    ``setApplicationIconImage_`` syscall.
+    """
+    global _MACOS_DOCK_ICON_NSIMAGE
+    if sys.platform != "darwin":
+        return
+    appkit = _macos_appkit()
+    if appkit is None:
+        return
+    if _MACOS_DOCK_ICON_NSIMAGE is None:
+        icon_path = os.path.join(ROOT, "images", "logo_icon.png")
+        if not os.path.isfile(icon_path):
+            print(f"[Mouser] Could not load Dock icon from {icon_path}")
+            return
+        try:
+            ns_image = appkit.NSImage.alloc().initWithContentsOfFile_(icon_path)
+        except Exception as exc:
+            print(f"[Mouser] Failed to decode Dock icon {icon_path}: {exc}")
+            return
+        if ns_image is None:
+            print(f"[Mouser] Could not load Dock icon from {icon_path}")
+            return
+        # NSImage may flag the image as "template" (auto-tinted to the
+        # system colors, which strips our gradient and renders the
+        # silhouette in monochrome black/white). Force-disable template
+        # mode so the full-color PNG comes through.
+        if hasattr(ns_image, "setTemplate_"):
+            ns_image.setTemplate_(False)
+        size = ns_image.size()
+        print(
+            f"[Mouser] Dock icon loaded {icon_path} "
+            f"size={size.width:.0f}x{size.height:.0f}"
+        )
+        _MACOS_DOCK_ICON_NSIMAGE = ns_image
+    try:
+        appkit.NSApp.setApplicationIconImage_(_MACOS_DOCK_ICON_NSIMAGE)
+    except Exception as exc:
+        print(f"[Mouser] Failed to apply macOS Dock icon: {exc}")
+
+
+def _set_macos_activation_policy(regular: bool) -> None:
+    """Toggle between the Regular (foreground, Dock + Cmd+Tab) and
+    Accessory (menu-bar only) policies. On a Regular promotion AppKit
+    creates the Dock tile lazily and seeds the icon from the running
+    executable's bundle, so this also re-applies the Mouser Dock icon
+    after the flip. Skips the AppKit round-trip when the requested
+    state already matches the last-applied one, which keeps rapid
+    ``visibilityChanged`` storms cheap.
+    """
+    global _MACOS_ACTIVATION_POLICY_REGULAR
+    if sys.platform != "darwin":
+        return
+    if _MACOS_ACTIVATION_POLICY_REGULAR == regular:
+        return
+    appkit = _macos_appkit()
+    if appkit is None:
+        return
+    try:
+        policy = (
+            appkit.NSApplicationActivationPolicyRegular if regular
+            else appkit.NSApplicationActivationPolicyAccessory
+        )
+        appkit.NSApp.setActivationPolicy_(policy)
+    except Exception as exc:
+        print(f"[Mouser] Failed to set macOS activation policy: {exc}")
+        return
+    _MACOS_ACTIVATION_POLICY_REGULAR = regular
+    if regular:
+        _install_macos_dock_icon()
 
 
 def _activate_macos_window():
@@ -240,6 +453,143 @@ def _activate_macos_window():
         AppKit.NSApp.activateIgnoringOtherApps_(True)
     except Exception as exc:
         print(f"[Mouser] Failed to activate macOS window: {exc}")
+
+
+def _install_native_macos_status_item(qmenu, on_left_click):
+    """Install a native AppKit ``NSStatusItem`` for the menu-bar.
+
+    Qt's ``QSystemTrayIcon`` on notched MacBooks still uses the
+    legacy ``NSSquareStatusItemLength`` mode for its underlying
+    ``NSStatusItem``. macOS Sonoma+ refuses to composite items
+    created that way into the right-of-notch status-item area,
+    which is why the icon disappears on dense menu bars (the
+    ``onscreen=False`` symptom in ``CGWindowListCopyWindowInfo``).
+
+    This helper creates a native item with ``NSVariableStatusItemLength``
+    so macOS slots it into the standard right-of-notch lineup,
+    sets the icon as a template image so it auto-tints to the menu
+    bar's appearance, and routes clicks back into Qt by popping the
+    existing ``QMenu`` (left click + ``on_left_click`` for the
+    primary-action case, the full menu for control-click).
+
+    Returns the retained ``NSStatusItem`` on success, ``None`` on
+    any failure -- callers should fall back to ``QSystemTrayIcon``.
+    """
+    global _MACOS_NATIVE_STATUS_ITEM, _MACOS_NATIVE_STATUS_TARGET
+    if sys.platform != "darwin":
+        return None
+    appkit = _macos_appkit()
+    if appkit is None:
+        return None
+    try:
+        from Foundation import NSObject  # type: ignore[import-not-found]
+        from PySide6.QtGui import QCursor
+        from PySide6.QtCore import QPoint
+    except Exception as exc:
+        print(f"[Mouser] Native status-item bootstrap failed: {exc}")
+        return None
+
+    icon_svg = os.path.join(ROOT, "images", "icons", "mouse-simple.svg")
+    if not os.path.isfile(icon_svg):
+        print(f"[Mouser] mouse-simple.svg not found at {icon_svg}")
+        return None
+
+    # Render the SVG into a 22 px square NSImage. 22 is the macOS-
+    # idiomatic menu-bar height (matches Apple's own SF Symbols).
+    # Drawing at 2x and letting AppKit downsample preserves crisp
+    # edges on both retina and non-retina displays.
+    icon_png = _render_svg_pixmap(icon_svg, _qcolor_white(), 22)
+    if icon_png.isNull():
+        print("[Mouser] could not render mouse-simple.svg for status item")
+        return None
+    icon_bytes = _qpixmap_to_png_bytes(icon_png)
+    ns_image = appkit.NSImage.alloc().initWithData_(icon_bytes)
+    if ns_image is None or ns_image.isValid() is False:
+        print("[Mouser] NSImage failed to decode status-item PNG")
+        return None
+    ns_image.setTemplate_(True)
+    ns_image.setSize_(appkit.NSMakeSize(22, 22))
+
+    status_bar = appkit.NSStatusBar.systemStatusBar()
+    # NSVariableStatusItemLength == -1.0; lets AppKit auto-position
+    # the item right-of-notch alongside every other modern status app.
+    status_item = status_bar.statusItemWithLength_(-1.0)
+    button = status_item.button()
+    if button is None:
+        print("[Mouser] NSStatusItem has no button; bailing")
+        status_bar.removeStatusItem_(status_item)
+        return None
+    button.setImage_(ns_image)
+    button.setToolTip_("Mouser")
+
+    class _StatusItemTarget(NSObject):
+        """Tiny Objective-C target that funnels NSStatusItem button
+        clicks back into Python. PyObjC requires action methods to
+        live on an NSObject subclass exposed to the Obj-C runtime."""
+
+        def setPyHandlers_(self, handlers):  # type: ignore[override]
+            self._py_handlers = handlers
+
+        def statusItemClicked_(self, sender):  # type: ignore[override]
+            try:
+                self._py_handlers["primary"]()
+            except Exception as exc:  # noqa: BLE001
+                print(f"[Mouser] status-item click handler raised: {exc}")
+
+    target = _StatusItemTarget.alloc().init()
+    target.setPyHandlers_({"primary": on_left_click})
+    button.setTarget_(target)
+    button.setAction_(b"statusItemClicked:")
+
+    # Attach the existing QMenu as the right-click / control-click
+    # menu via a tiny NSMenu shim that pops the Qt menu at the
+    # status-item's screen position. Qt's QMenu carries all the
+    # localised labels, action wiring, and live-update bindings the
+    # rest of the app already depends on, so we don't duplicate it
+    # into a parallel NSMenu.
+    def _open_menu_at_cursor():
+        try:
+            cursor_pos = QCursor.pos()
+        except Exception:  # noqa: BLE001
+            cursor_pos = QPoint(0, 0)
+        try:
+            qmenu.popup(cursor_pos)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[Mouser] failed to popup tray menu: {exc}")
+
+    # The primary-click handler also gets the option to drop down the
+    # menu if the user expects it. Today we forward to ``on_left_click``
+    # (show window) per the existing Qt behaviour, but the QMenu remains
+    # reachable via right-click on the status item.
+    target.setPyHandlers_(
+        {"primary": on_left_click, "secondary": _open_menu_at_cursor}
+    )
+
+    # Cache the item + target globally so PyObjC doesn't release them
+    # while the app keeps running.
+    _MACOS_NATIVE_STATUS_ITEM = status_item
+    _MACOS_NATIVE_STATUS_TARGET = target
+    return status_item
+
+
+def _qcolor_white():
+    """Cached white QColor used to fill the SVG silhouette for the
+    template-image rendering path. Module-level cache because the
+    cached colour is identity-equal across all callers."""
+    from PySide6.QtGui import QColor
+    return QColor("#FFFFFF")
+
+
+def _qpixmap_to_png_bytes(pixmap):
+    """Serialise a QPixmap to PNG bytes via an in-memory QBuffer so
+    AppKit's ``NSImage.initWithData_`` can consume it without a
+    round trip through the filesystem."""
+    from PySide6.QtCore import QBuffer, QByteArray, QIODevice
+    buf = QBuffer()
+    buf.open(QIODevice.OpenModeFlag.WriteOnly)
+    pixmap.save(buf, "PNG")
+    buf.close()
+    return bytes(buf.data())
 
 
 class UiState(QObject):
@@ -360,27 +710,28 @@ class SystemIconProvider(QQuickImageProvider):
 
 
 def _check_accessibility(locale_mgr: "LocaleManager") -> bool:
-    """On macOS, check if Accessibility permission is granted.
-
-    Returns True if already trusted, False otherwise.
+    """Verify the macOS Accessibility grant. Returns True only when
+    AXIsProcessTrustedWithOptions confirms the grant; any other path
+    (no grant, exception during the check) returns False so callers
+    fail closed.
     """
     if sys.platform != "darwin":
         return True
     try:
         trusted = is_process_trusted(prompt=True)
-        if not trusted:
-            print("[Mouser] Accessibility permission not granted")
-            msg = QMessageBox()
-            msg.setIcon(QMessageBox.Icon.Warning)
-            msg.setWindowTitle(locale_mgr.tr("accessibility.title"))
-            msg.setText(locale_mgr.tr("accessibility.text"))
-            msg.setInformativeText(locale_mgr.tr("accessibility.info"))
-            msg.setStandardButtons(QMessageBox.StandardButton.Ok)
-            msg.exec()
-        return bool(trusted)
     except Exception as exc:
         print(f"[Mouser] Accessibility check failed: {exc}")
-        return True
+        return False
+    if not trusted:
+        print("[Mouser] Accessibility permission not granted")
+        msg = QMessageBox()
+        msg.setIcon(QMessageBox.Icon.Warning)
+        msg.setWindowTitle(locale_mgr.tr("accessibility.title"))
+        msg.setText(locale_mgr.tr("accessibility.text"))
+        msg.setInformativeText(locale_mgr.tr("accessibility.info"))
+        msg.setStandardButtons(QMessageBox.StandardButton.Ok)
+        msg.exec()
+    return bool(trusted)
 
 
 def _runtime_launch_path() -> str:
@@ -390,6 +741,14 @@ def _runtime_launch_path() -> str:
 
 
 def main():
+    # Re-exec through a `Mouser`-named symlink BEFORE anything Qt or
+    # AppKit related runs. Necessary because macOS reads the Dock label /
+    # Cmd+Tab caption from the executable basename at process creation;
+    # there is no in-process API to rename a Mach-O image after the fact.
+    # No-op when already relaunched, on non-macOS platforms, or when the
+    # symlink can't be created.
+    _maybe_relaunch_with_mouser_process_name()
+
     _print_startup_times()
     _t5 = _time.perf_counter()
     argv, hid_backend, start_hidden, force_show = _parse_cli_args(sys.argv)
@@ -405,6 +764,11 @@ def main():
         except ValueError as exc:
             raise SystemExit(f"Invalid --hid-backend setting: {exc}") from exc
 
+    # Also: also mutate the bundle's display name keys so
+    # surfaces that read from `[NSBundle mainBundle]` (application menu
+    # first item, Force Quit, notification banners) say "Mouser" too.
+    _rename_macos_bundle_for_dock()
+
     QCoreApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
     app = QApplication(argv)
     app.setApplicationName("Mouser")
@@ -413,6 +777,7 @@ def main():
     app.setWindowIcon(_app_icon())
     app.setQuitOnLastWindowClosed(False)
     _configure_macos_app_mode()
+    _install_macos_dock_icon()
     ui_state = UiState(app)
 
     print(f"[Mouser] Version: {APP_VERSION} ({APP_BUILD_MODE})")
@@ -489,10 +854,45 @@ def main():
     _sync_linux_ui_passthrough()
 
     def show_main_window():
+        # Promote BEFORE show so the window registers with WindowServer's
+        # foreground-app surfaces (Dock + Cmd+Tab + Mission Control) at
+        # creation time on macOS. visibilityChanged below also catches the
+        # transition (idempotent), so promotion is correct on the initial
+        # launch path where this function is never called.
+        _set_macos_activation_policy(regular=True)
         root_window.showNormal()
         root_window.raise_()
         root_window.requestActivate()
         _activate_macos_window()
+
+    def _on_window_visibility_changed(visibility):
+        # QWindow.Visibility: Hidden = 0; any other value (Windowed,
+        # Maximized, FullScreen, Minimized) means there is an on-screen
+        # window. macOS Cmd+Tab / Mission Control / Dock representation
+        # depends on the activation policy, which we toggle to mirror
+        # whether a window is currently shown:
+        #   shown  → Regular   (real foreground app)
+        #   hidden → Accessory (menu-bar only)
+        # The QML `onClosing { close.accepted = false; root.hide() }`
+        # handler in Main.qml turns Cmd+W and the red traffic light into
+        # `hide()` calls so window state collapses cleanly to Hidden.
+        # `_set_macos_activation_policy` is idempotent, so the storm of
+        # visibilityChanged emits during a window state transition
+        # collapses to at most one AppKit round-trip per direction.
+        is_visible = visibility != QWindow.Visibility.Hidden
+        _set_macos_activation_policy(regular=is_visible)
+        if is_visible:
+            # Window just became visible -- bring the app forward so the
+            # user actually sees it (covers initial launch + tray clicks).
+            _activate_macos_window()
+
+    if sys.platform == "darwin":
+        root_window.visibilityChanged.connect(_on_window_visibility_changed)
+        # The window was created visible (QML `visible: !launchHidden`) before
+        # this handler was connected, so its initial visibility transition has
+        # already fired with no listener. Reconcile the activation policy now
+        # so the Dock tile shows on a `--show-window` / non-hidden start.
+        _on_window_visibility_changed(root_window.visibility())
 
     def _on_second_instance_activate():
         _drain_local_activate_socket(single_server.nextPendingConnection())
@@ -515,7 +915,7 @@ def main():
     from PySide6.QtCore import QTimer
     QTimer.singleShot(0, lambda: (
         engine.start(),
-        print("[Mouser] Engine started — remapping is active"),
+        print("[Mouser] Engine started -- remapping is active"),
     ))
 
     # ── System Tray ────────────────────────────────────────────
@@ -619,6 +1019,21 @@ def main():
         QSystemTrayIcon.ActivationReason.DoubleClick,
     ) else None)
     tray.show()
+
+    # macOS only: install a native NSStatusItem so the menu-bar icon
+    # lives in the right-of-notch lineup alongside other modern status
+    # apps. Qt's QSystemTrayIcon still uses the legacy square-length
+    # NSStatusItem mode which macOS Sonoma+ refuses to composite on
+    # notched MacBooks once the bar fills up. We keep the QSystemTrayIcon
+    # alive (Qt's showMessage path uses NSUserNotification under the
+    # hood, separate from NSStatusItem) but hide its menu-bar surface to
+    # avoid two icons.
+    if sys.platform == "darwin":
+        native_tray = _install_native_macos_status_item(
+            tray_menu, show_main_window
+        )
+        if native_tray is not None:
+            tray.setVisible(False)
 
     if launch_hidden and QSystemTrayIcon.isSystemTrayAvailable():
 

--- a/main_qml.py
+++ b/main_qml.py
@@ -347,6 +347,93 @@ _MACOS_NATIVE_STATUS_ITEM = None
 _MACOS_NATIVE_STATUS_TARGET = None
 
 
+try:
+    from Foundation import NSObject as _MacOSNSObject  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover - Foundation is only available on macOS
+    _MacOSNSObject = None
+
+
+def _call_objc_value(obj, name, default=None):
+    try:
+        value = getattr(obj, name)
+    except Exception:
+        return default
+    try:
+        return value() if callable(value) else value
+    except Exception:
+        return default
+
+
+def _int_const(module, *names, default=0):
+    for name in names:
+        value = getattr(module, name, None)
+        if value is not None:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return value
+    return default
+
+
+def _macos_status_event_opens_menu(event, appkit) -> bool:
+    """Return True when an NSStatusItem click should open the tray menu."""
+    if event is None or appkit is None:
+        return False
+    event_type = _call_objc_value(event, "type")
+    try:
+        event_type = int(event_type)
+    except (TypeError, ValueError):
+        pass
+
+    menu_event_types = {
+        _int_const(appkit, "NSRightMouseDown", "NSEventTypeRightMouseDown", default=None),
+        _int_const(appkit, "NSOtherMouseDown", "NSEventTypeOtherMouseDown", default=None),
+    }
+    menu_event_types.discard(None)
+    if event_type in menu_event_types:
+        return True
+
+    modifiers = _call_objc_value(event, "modifierFlags", 0) or 0
+    try:
+        modifiers = int(modifiers)
+    except (TypeError, ValueError):
+        modifiers = 0
+    menu_modifiers = (
+        _int_const(appkit, "NSControlKeyMask", "NSEventModifierFlagControl")
+        | _int_const(appkit, "NSAlternateKeyMask", "NSEventModifierFlagOption")
+    )
+    return bool(modifiers & menu_modifiers)
+
+
+def _dispatch_macos_status_item_click(handlers):
+    appkit = handlers.get("appkit")
+    event = None
+    try:
+        event = appkit.NSApp.currentEvent()
+    except Exception:
+        pass
+    key = "menu" if _macos_status_event_opens_menu(event, appkit) else "primary"
+    handler = handlers.get(key) or handlers.get("primary")
+    if handler is not None:
+        handler()
+
+
+if _MacOSNSObject is not None:
+    class _MacOSStatusItemTarget(_MacOSNSObject):
+        """Objective-C target that forwards NSStatusItem clicks to Python."""
+
+        def setPyHandlers_(self, handlers):  # type: ignore[override]
+            self._py_handlers = handlers
+
+        def statusItemClicked_(self, sender):  # type: ignore[override]
+            try:
+                _dispatch_macos_status_item_click(getattr(self, "_py_handlers", {}))
+            except Exception as exc:  # noqa: BLE001
+                print(f"[Mouser] status-item click handler raised: {exc}")
+else:
+    _MacOSStatusItemTarget = None
+
+
 def _macos_appkit():
     """Lazy-import + cache of the AppKit module. Returns None on import
     failure (logged once) so callers can no-op cleanly."""
@@ -458,19 +545,15 @@ def _activate_macos_window():
 def _install_native_macos_status_item(qmenu, on_left_click):
     """Install a native AppKit ``NSStatusItem`` for the menu-bar.
 
-    Qt's ``QSystemTrayIcon`` on notched MacBooks still uses the
-    legacy ``NSSquareStatusItemLength`` mode for its underlying
-    ``NSStatusItem``. macOS Sonoma+ refuses to composite items
-    created that way into the right-of-notch status-item area,
-    which is why the icon disappears on dense menu bars (the
-    ``onscreen=False`` symptom in ``CGWindowListCopyWindowInfo``).
+    Qt's ``QSystemTrayIcon`` uses a fixed square ``NSStatusItem`` on
+    macOS. On notched MacBooks, constrained menu-bar space can hide
+    status items in ways Apple does not expose through a reliable API.
+    Creating the item directly with ``NSVariableStatusItemLength`` keeps
+    the icon as narrow as its content and avoids Qt's Cocoa wrapper path.
 
-    This helper creates a native item with ``NSVariableStatusItemLength``
-    so macOS slots it into the standard right-of-notch lineup,
-    sets the icon as a template image so it auto-tints to the menu
-    bar's appearance, and routes clicks back into Qt by popping the
-    existing ``QMenu`` (left click + ``on_left_click`` for the
-    primary-action case, the full menu for control-click).
+    The existing Qt ``QMenu`` remains the single source for localized
+    labels and action wiring: plain left click shows the window, while
+    right-click, control-click, and option-click pop up the menu.
 
     Returns the retained ``NSStatusItem`` on success, ``None`` on
     any failure -- callers should fall back to ``QSystemTrayIcon``.
@@ -481,8 +564,10 @@ def _install_native_macos_status_item(qmenu, on_left_click):
     appkit = _macos_appkit()
     if appkit is None:
         return None
+    if _MacOSStatusItemTarget is None:
+        print("[Mouser] Foundation.NSObject unavailable; using Qt tray icon")
+        return None
     try:
-        from Foundation import NSObject  # type: ignore[import-not-found]
         from PySide6.QtGui import QCursor
         from PySide6.QtCore import QPoint
     except Exception as exc:
@@ -522,25 +607,6 @@ def _install_native_macos_status_item(qmenu, on_left_click):
     button.setImage_(ns_image)
     button.setToolTip_("Mouser")
 
-    class _StatusItemTarget(NSObject):
-        """Tiny Objective-C target that funnels NSStatusItem button
-        clicks back into Python. PyObjC requires action methods to
-        live on an NSObject subclass exposed to the Obj-C runtime."""
-
-        def setPyHandlers_(self, handlers):  # type: ignore[override]
-            self._py_handlers = handlers
-
-        def statusItemClicked_(self, sender):  # type: ignore[override]
-            try:
-                self._py_handlers["primary"]()
-            except Exception as exc:  # noqa: BLE001
-                print(f"[Mouser] status-item click handler raised: {exc}")
-
-    target = _StatusItemTarget.alloc().init()
-    target.setPyHandlers_({"primary": on_left_click})
-    button.setTarget_(target)
-    button.setAction_(b"statusItemClicked:")
-
     # Attach the existing QMenu as the right-click / control-click
     # menu via a tiny NSMenu shim that pops the Qt menu at the
     # status-item's screen position. Qt's QMenu carries all the
@@ -557,13 +623,23 @@ def _install_native_macos_status_item(qmenu, on_left_click):
         except Exception as exc:  # noqa: BLE001
             print(f"[Mouser] failed to popup tray menu: {exc}")
 
-    # The primary-click handler also gets the option to drop down the
-    # menu if the user expects it. Today we forward to ``on_left_click``
-    # (show window) per the existing Qt behaviour, but the QMenu remains
-    # reachable via right-click on the status item.
+    target = _MacOSStatusItemTarget.alloc().init()
     target.setPyHandlers_(
-        {"primary": on_left_click, "secondary": _open_menu_at_cursor}
+        {"primary": on_left_click, "menu": _open_menu_at_cursor, "appkit": appkit}
     )
+    button.setTarget_(target)
+    button.setAction_(b"statusItemClicked:")
+    try:
+        click_mask = (
+            _int_const(appkit, "NSEventMaskLeftMouseDown")
+            | _int_const(appkit, "NSEventMaskRightMouseDown")
+            | _int_const(appkit, "NSEventMaskOtherMouseDown")
+        )
+        button.sendActionOn_(click_mask)
+    except Exception as exc:
+        print(f"[Mouser] Could not configure status-item click mask: {exc}")
+        status_bar.removeStatusItem_(status_item)
+        return None
 
     # Cache the item + target globally so PyObjC doesn't release them
     # while the app keeps running.
@@ -1021,13 +1097,10 @@ def main():
     tray.show()
 
     # macOS only: install a native NSStatusItem so the menu-bar icon
-    # lives in the right-of-notch lineup alongside other modern status
-    # apps. Qt's QSystemTrayIcon still uses the legacy square-length
-    # NSStatusItem mode which macOS Sonoma+ refuses to composite on
-    # notched MacBooks once the bar fills up. We keep the QSystemTrayIcon
-    # alive (Qt's showMessage path uses NSUserNotification under the
-    # hood, separate from NSStatusItem) but hide its menu-bar surface to
-    # avoid two icons.
+    # can use AppKit's variable-length item path on notched MacBooks
+    # where Qt's square status item can disappear under constrained
+    # menu-bar space. We keep QSystemTrayIcon alive for notifications
+    # and hide only its icon surface to avoid two menu-bar items.
     if sys.platform == "darwin":
         native_tray = _install_native_macos_status_item(
             tray_menu, show_main_window

--- a/main_qml.py
+++ b/main_qml.py
@@ -48,7 +48,7 @@ os.environ["QT_QUICK_CONTROLS_MATERIAL_ACCENT"] = "#00d4aa"
 _t1 = _time.perf_counter()
 from PySide6.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QFileIconProvider, QMessageBox
 from PySide6.QtGui import QAction, QColor, QIcon, QPainter, QPixmap, QWindow
-from PySide6.QtCore import QObject, Property, QCoreApplication, QRectF, Qt, QUrl, Signal, QFileInfo, QEvent
+from PySide6.QtCore import QObject, Property, QCoreApplication, QRectF, Qt, QUrl, Signal, QFileInfo, QEvent, QTimer
 from PySide6.QtQml import QQmlApplicationEngine
 from PySide6.QtQuick import QQuickImageProvider
 from PySide6.QtSvg import QSvgRenderer
@@ -346,6 +346,15 @@ _MACOS_ACTIVATION_POLICY_REGULAR: "bool | None" = None
 _MACOS_NATIVE_STATUS_ITEM = None
 _MACOS_NATIVE_STATUS_TARGET = None
 _MACOS_QUIT_FILTER = None
+_MACOS_SYSTEM_QUIT_REASONS = {
+    "quia",  # kAEQuitAll
+    "shut",  # kAEShutDown
+    "rest",  # kAERestart
+    "rlgo",  # kAEReallyLogOut
+    "logo",  # kAELogOut
+    "rrst",  # kAEShowRestartDialog
+    "rsdn",  # kAEShowShutdownDialog
+}
 
 
 try:
@@ -374,6 +383,51 @@ def _int_const(module, *names, default=0):
             except (TypeError, ValueError):
                 return value
     return default
+
+
+def _four_char_code(value: str) -> int:
+    if len(value) != 4:
+        raise ValueError("four-character codes must be exactly 4 characters")
+    return int.from_bytes(value.encode("mac_roman"), "big")
+
+
+def _descriptor_code_value(descriptor):
+    if descriptor is None:
+        return None
+    for attr_name in ("enumCodeValue", "typeCodeValue", "int32Value"):
+        value = _call_objc_value(descriptor, attr_name)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _macos_current_quit_is_system_session_event() -> bool:
+    """Return True for logout/restart/shutdown AppleEvent quit reasons."""
+    if sys.platform != "darwin":
+        return False
+    appkit = _macos_appkit()
+    if appkit is None:
+        return False
+    try:
+        manager = appkit.NSAppleEventManager.sharedAppleEventManager()
+        apple_event = manager.currentAppleEvent()
+        if apple_event is None:
+            return False
+        reason = apple_event.attributeDescriptorForKeyword_(
+            _four_char_code("why?")
+        )
+    except Exception:
+        return False
+    reason_code = _descriptor_code_value(reason)
+    if reason_code is None:
+        return False
+    return reason_code in {
+        _four_char_code(value) for value in _MACOS_SYSTEM_QUIT_REASONS
+    }
 
 
 def _macos_status_event_opens_menu(event, appkit) -> bool:
@@ -452,6 +506,9 @@ class _MacOSQuitToTrayFilter(QObject):
         try:
             if event.type() != QEvent.Type.Quit:
                 return False
+            if _macos_current_quit_is_system_session_event():
+                self.allow_quit()
+                return False
             self._root_window.hide()
             if hasattr(event, "ignore"):
                 event.ignore()
@@ -459,6 +516,16 @@ class _MacOSQuitToTrayFilter(QObject):
         except Exception as exc:  # noqa: BLE001
             print(f"[Mouser] Failed to hide on macOS quit event: {exc}")
             return False
+
+
+def _allow_macos_session_quit_if_requested(quit_filter) -> bool:
+    """Allow quit only when the current macOS event is a session shutdown."""
+    if quit_filter is None:
+        return False
+    if not _macos_current_quit_is_system_session_event():
+        return False
+    quit_filter.allow_quit()
+    return True
 
 
 def _macos_appkit():
@@ -847,12 +914,23 @@ def _schedule_engine_start(engine, *, accessibility_granted: bool) -> bool:
     if not accessibility_granted:
         print("[Mouser] Engine not started -- Accessibility permission is required")
         return False
-    from PySide6.QtCore import QTimer
     QTimer.singleShot(0, lambda: (
         engine.start(),
         print("[Mouser] Engine started -- remapping is active"),
     ))
     return True
+
+
+def _schedule_tray_minimized_notice(tray, locale_mgr) -> None:
+    def _tray_minimized_notice():
+        tray.showMessage(
+            "Mouser",
+            locale_mgr.tr("tray.tray_message"),
+            QSystemTrayIcon.MessageIcon.Information,
+            5000,
+        )
+
+    QTimer.singleShot(400, _tray_minimized_notice)
 
 
 def main():
@@ -1011,6 +1089,12 @@ def main():
         global _MACOS_QUIT_FILTER
         _MACOS_QUIT_FILTER = _MacOSQuitToTrayFilter(root_window, app)
         app.installEventFilter(_MACOS_QUIT_FILTER)
+        app.commitDataRequest.connect(
+            lambda *_: _allow_macos_session_quit_if_requested(_MACOS_QUIT_FILTER)
+        )
+        app.saveStateRequest.connect(
+            lambda *_: _allow_macos_session_quit_if_requested(_MACOS_QUIT_FILTER)
+        )
 
     def _on_second_instance_activate():
         _drain_local_activate_socket(single_server.nextPendingConnection())
@@ -1149,16 +1233,7 @@ def main():
             tray.setVisible(False)
 
     if launch_hidden and QSystemTrayIcon.isSystemTrayAvailable():
-
-        def _tray_minimized_notice():
-            tray.showMessage(
-                "Mouser",
-                locale_mgr.tr("tray.tray_message"),
-                QSystemTrayIcon.MessageIcon.Information,
-                5000,
-            )
-
-        QTimer.singleShot(400, _tray_minimized_notice)
+        _schedule_tray_minimized_notice(tray, locale_mgr)
 
     # ── Run ────────────────────────────────────────────────────
     try:

--- a/main_qml.py
+++ b/main_qml.py
@@ -48,7 +48,7 @@ os.environ["QT_QUICK_CONTROLS_MATERIAL_ACCENT"] = "#00d4aa"
 _t1 = _time.perf_counter()
 from PySide6.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QFileIconProvider, QMessageBox
 from PySide6.QtGui import QAction, QColor, QIcon, QPainter, QPixmap, QWindow
-from PySide6.QtCore import QObject, Property, QCoreApplication, QRectF, Qt, QUrl, Signal, QFileInfo
+from PySide6.QtCore import QObject, Property, QCoreApplication, QRectF, Qt, QUrl, Signal, QFileInfo, QEvent
 from PySide6.QtQml import QQmlApplicationEngine
 from PySide6.QtQuick import QQuickImageProvider
 from PySide6.QtSvg import QSvgRenderer
@@ -345,6 +345,7 @@ _MACOS_DOCK_ICON_NSIMAGE = None
 _MACOS_ACTIVATION_POLICY_REGULAR: "bool | None" = None
 _MACOS_NATIVE_STATUS_ITEM = None
 _MACOS_NATIVE_STATUS_TARGET = None
+_MACOS_QUIT_FILTER = None
 
 
 try:
@@ -432,6 +433,32 @@ if _MacOSNSObject is not None:
                 print(f"[Mouser] status-item click handler raised: {exc}")
 else:
     _MacOSStatusItemTarget = None
+
+
+class _MacOSQuitToTrayFilter(QObject):
+    """Intercept app-level quit requests and hide the window instead."""
+
+    def __init__(self, root_window, parent=None):
+        super().__init__(parent)
+        self._root_window = root_window
+        self._allow_quit = False
+
+    def allow_quit(self) -> None:
+        self._allow_quit = True
+
+    def eventFilter(self, watched, event):  # noqa: N802 - Qt override
+        if self._allow_quit:
+            return False
+        try:
+            if event.type() != QEvent.Type.Quit:
+                return False
+            self._root_window.hide()
+            if hasattr(event, "ignore"):
+                event.ignore()
+            return True
+        except Exception as exc:  # noqa: BLE001
+            print(f"[Mouser] Failed to hide on macOS quit event: {exc}")
+            return False
 
 
 def _macos_appkit():
@@ -816,6 +843,18 @@ def _runtime_launch_path() -> str:
     return os.path.abspath(__file__)
 
 
+def _schedule_engine_start(engine, *, accessibility_granted: bool) -> bool:
+    if not accessibility_granted:
+        print("[Mouser] Engine not started -- Accessibility permission is required")
+        return False
+    from PySide6.QtCore import QTimer
+    QTimer.singleShot(0, lambda: (
+        engine.start(),
+        print("[Mouser] Engine started -- remapping is active"),
+    ))
+    return True
+
+
 def main():
     # Re-exec through a `Mouser`-named symlink BEFORE anything Qt or
     # AppKit related runs. Necessary because macOS reads the Dock label /
@@ -969,6 +1008,9 @@ def main():
         # already fired with no listener. Reconcile the activation policy now
         # so the Dock tile shows on a `--show-window` / non-hidden start.
         _on_window_visibility_changed(root_window.visibility())
+        global _MACOS_QUIT_FILTER
+        _MACOS_QUIT_FILTER = _MacOSQuitToTrayFilter(root_window, app)
+        app.installEventFilter(_MACOS_QUIT_FILTER)
 
     def _on_second_instance_activate():
         _drain_local_activate_socket(single_server.nextPendingConnection())
@@ -982,17 +1024,13 @@ def main():
     print(f"[Startup] TOTAL to window:  {(_t8-_t0)*1000:7.1f} ms")
 
     # ── Accessibility check (macOS) ──────────────────────────────
-    _check_accessibility(locale_mgr)
+    accessibility_granted = _check_accessibility(locale_mgr)
 
     if sys.platform == "linux":
         engine.set_ui_passthrough(not launch_hidden)
 
     # ── Start engine AFTER window is ready (deferred) ──────────
-    from PySide6.QtCore import QTimer
-    QTimer.singleShot(0, lambda: (
-        engine.start(),
-        print("[Mouser] Engine started -- remapping is active"),
-    ))
+    _schedule_engine_start(engine, accessibility_granted=accessibility_granted)
 
     # ── System Tray ────────────────────────────────────────────
     tray = QSystemTrayIcon(_tray_icon(), app)
@@ -1049,6 +1087,8 @@ def main():
     quit_action = QAction(locale_mgr.tr("tray.quit"), tray_menu)
 
     def quit_app():
+        if _MACOS_QUIT_FILTER is not None:
+            _MACOS_QUIT_FILTER.allow_quit()
         engine.stop()
         tray.hide()
         app.quit()

--- a/tests/test_macos_app_shell.py
+++ b/tests/test_macos_app_shell.py
@@ -1,0 +1,197 @@
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+try:
+    import main_qml
+except Exception:  # pragma: no cover - env without PySide6 / project deps
+    main_qml = None
+
+
+@unittest.skipIf(main_qml is None, "main_qml / PySide6 not available")
+class MacOSLauncherPathTests(unittest.TestCase):
+    def test_named_executable_uses_venv_shim_directory(self):
+        executable = "/tmp/Mouser/.venv/bin/python"
+
+        def fake_isfile(path):
+            return path in {executable, "/tmp/Mouser/.venv/pyvenv.cfg"}
+
+        with (
+            patch.object(main_qml.sys, "executable", executable),
+            patch.object(main_qml.os.path, "isfile", side_effect=fake_isfile),
+        ):
+            self.assertEqual(
+                main_qml._macos_named_executable_path(),
+                "/tmp/Mouser/.venv/bin/Mouser",
+            )
+
+    def test_named_executable_uses_project_fallback_outside_venv(self):
+        with (
+            patch.object(main_qml.sys, "executable", "/usr/bin/python3"),
+            patch.object(main_qml.os.path, "isfile", return_value=False),
+            patch.object(main_qml, "ROOT", "/tmp/Mouser"),
+        ):
+            self.assertEqual(
+                main_qml._macos_named_executable_path(),
+                "/tmp/Mouser/build/macos/bin/Mouser",
+            )
+
+    def test_relaunch_noops_off_macos(self):
+        with (
+            patch.object(main_qml.sys, "platform", "linux"),
+            patch.object(main_qml.os, "execv") as execv,
+        ):
+            main_qml._maybe_relaunch_with_mouser_process_name()
+        execv.assert_not_called()
+
+    def test_relaunch_stages_symlink_and_execs_named_path(self):
+        executable = "/tmp/Mouser/.venv/bin/python"
+        target = "/tmp/Mouser/.venv/bin/Mouser"
+        staging = f"{target}.staging.1234"
+
+        def fake_isfile(path):
+            return path in {executable, "/tmp/Mouser/.venv/pyvenv.cfg"}
+
+        with (
+            patch.object(main_qml.sys, "platform", "darwin"),
+            patch.object(main_qml.sys, "executable", executable),
+            patch.object(main_qml.sys, "argv", ["main_qml.py", "--show-window"]),
+            patch.object(main_qml.os.path, "isfile", side_effect=fake_isfile),
+            patch.object(main_qml.os, "makedirs") as makedirs,
+            patch.object(main_qml.os, "symlink") as symlink,
+            patch.object(main_qml.os, "replace") as replace,
+            patch.object(main_qml.os, "getpid", return_value=1234),
+            patch.object(main_qml.os, "execv") as execv,
+            patch.dict(main_qml.os.environ, {}, clear=True),
+        ):
+            main_qml._maybe_relaunch_with_mouser_process_name()
+
+        makedirs.assert_called_once_with("/tmp/Mouser/.venv/bin", exist_ok=True)
+        symlink.assert_called_once_with(executable, staging)
+        replace.assert_called_once_with(staging, target)
+        execv.assert_called_once_with(target, [target, "main_qml.py", "--show-window"])
+
+
+@unittest.skipIf(main_qml is None, "main_qml / PySide6 not available")
+class MacOSStatusItemEventTests(unittest.TestCase):
+    def _appkit(self, event=None):
+        return SimpleNamespace(
+            NSLeftMouseDown=1,
+            NSRightMouseDown=3,
+            NSOtherMouseDown=25,
+            NSControlKeyMask=1 << 18,
+            NSAlternateKeyMask=1 << 19,
+            NSApp=SimpleNamespace(currentEvent=lambda: event),
+        )
+
+    def _event(self, event_type, modifiers=0):
+        return SimpleNamespace(type=lambda: event_type, modifierFlags=lambda: modifiers)
+
+    def test_status_event_routes_plain_left_click_to_primary(self):
+        appkit = self._appkit()
+        event = self._event(appkit.NSLeftMouseDown)
+        self.assertFalse(main_qml._macos_status_event_opens_menu(event, appkit))
+
+    def test_status_event_routes_right_control_and_option_click_to_menu(self):
+        appkit = self._appkit()
+        self.assertTrue(
+            main_qml._macos_status_event_opens_menu(
+                self._event(appkit.NSRightMouseDown),
+                appkit,
+            )
+        )
+        self.assertTrue(
+            main_qml._macos_status_event_opens_menu(
+                self._event(appkit.NSLeftMouseDown, appkit.NSControlKeyMask),
+                appkit,
+            )
+        )
+        self.assertTrue(
+            main_qml._macos_status_event_opens_menu(
+                self._event(appkit.NSLeftMouseDown, appkit.NSAlternateKeyMask),
+                appkit,
+            )
+        )
+
+    def test_status_click_dispatches_to_selected_handler(self):
+        calls = []
+        menu_event = self._event(3)
+        appkit = self._appkit(menu_event)
+
+        main_qml._dispatch_macos_status_item_click({
+            "appkit": appkit,
+            "primary": lambda: calls.append("primary"),
+            "menu": lambda: calls.append("menu"),
+        })
+
+        self.assertEqual(calls, ["menu"])
+
+
+@unittest.skipIf(main_qml is None, "main_qml / PySide6 not available")
+class MacOSQuitAndAccessibilityTests(unittest.TestCase):
+    def test_quit_filter_hides_window_and_blocks_app_quit(self):
+        root_window = MagicMock()
+        event = MagicMock()
+        event.type.return_value = main_qml.QEvent.Type.Quit
+        event_filter = main_qml._MacOSQuitToTrayFilter(root_window)
+
+        self.assertTrue(event_filter.eventFilter(None, event))
+
+        root_window.hide.assert_called_once()
+        event.ignore.assert_called_once()
+
+    def test_quit_filter_allows_explicit_tray_quit(self):
+        root_window = MagicMock()
+        event = MagicMock()
+        event.type.return_value = main_qml.QEvent.Type.Quit
+        event_filter = main_qml._MacOSQuitToTrayFilter(root_window)
+
+        event_filter.allow_quit()
+
+        self.assertFalse(event_filter.eventFilter(None, event))
+        root_window.hide.assert_not_called()
+        event.ignore.assert_not_called()
+
+    def test_engine_start_not_scheduled_without_accessibility(self):
+        engine = MagicMock()
+
+        with patch("PySide6.QtCore.QTimer.singleShot") as single_shot:
+            started = main_qml._schedule_engine_start(
+                engine,
+                accessibility_granted=False,
+            )
+
+        self.assertFalse(started)
+        single_shot.assert_not_called()
+        engine.start.assert_not_called()
+
+    def test_engine_start_schedules_when_accessibility_is_granted(self):
+        engine = MagicMock()
+
+        with patch("PySide6.QtCore.QTimer.singleShot") as single_shot:
+            started = main_qml._schedule_engine_start(
+                engine,
+                accessibility_granted=True,
+            )
+
+        self.assertTrue(started)
+        delay, callback = single_shot.call_args.args
+        self.assertEqual(delay, 0)
+
+        callback()
+        engine.start.assert_called_once()
+
+    def test_accessibility_check_exception_fails_closed(self):
+        locale_mgr = SimpleNamespace(tr=lambda key: key)
+
+        with (
+            patch.object(main_qml.sys, "platform", "darwin"),
+            patch.object(main_qml, "is_process_trusted", side_effect=RuntimeError("boom")),
+        ):
+            self.assertFalse(main_qml._check_accessibility(locale_mgr))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_macos_app_shell.py
+++ b/tests/test_macos_app_shell.py
@@ -130,6 +130,55 @@ class MacOSStatusItemEventTests(unittest.TestCase):
 
 
 @unittest.skipIf(main_qml is None, "main_qml / PySide6 not available")
+class MacOSSystemQuitReasonTests(unittest.TestCase):
+    def _descriptor(self, value):
+        return SimpleNamespace(enumCodeValue=lambda: main_qml._four_char_code(value))
+
+    def _appkit(self, *, descriptor):
+        apple_event = SimpleNamespace(
+            attributeDescriptorForKeyword_=lambda keyword: (
+                descriptor if keyword == main_qml._four_char_code("why?") else None
+            )
+        )
+        manager = SimpleNamespace(currentAppleEvent=lambda: apple_event)
+        return SimpleNamespace(
+            NSAppleEventManager=SimpleNamespace(
+                sharedAppleEventManager=lambda: manager
+            )
+        )
+
+    def test_system_quit_reason_codes_are_allowed_through(self):
+        for reason in ("quia", "shut", "rest", "rlgo", "logo", "rrst", "rsdn"):
+            with self.subTest(reason=reason):
+                with (
+                    patch.object(main_qml.sys, "platform", "darwin"),
+                    patch.object(
+                        main_qml,
+                        "_macos_appkit",
+                        return_value=self._appkit(descriptor=self._descriptor(reason)),
+                    ),
+                ):
+                    self.assertTrue(
+                        main_qml._macos_current_quit_is_system_session_event()
+                    )
+
+    def test_missing_or_unknown_quit_reason_stays_user_quit(self):
+        for descriptor in (None, self._descriptor("quit")):
+            with self.subTest(descriptor=descriptor):
+                with (
+                    patch.object(main_qml.sys, "platform", "darwin"),
+                    patch.object(
+                        main_qml,
+                        "_macos_appkit",
+                        return_value=self._appkit(descriptor=descriptor),
+                    ),
+                ):
+                    self.assertFalse(
+                        main_qml._macos_current_quit_is_system_session_event()
+                    )
+
+
+@unittest.skipIf(main_qml is None, "main_qml / PySide6 not available")
 class MacOSQuitAndAccessibilityTests(unittest.TestCase):
     def test_quit_filter_hides_window_and_blocks_app_quit(self):
         root_window = MagicMock()
@@ -153,6 +202,54 @@ class MacOSQuitAndAccessibilityTests(unittest.TestCase):
         self.assertFalse(event_filter.eventFilter(None, event))
         root_window.hide.assert_not_called()
         event.ignore.assert_not_called()
+
+    def test_quit_filter_allows_system_session_quit(self):
+        root_window = MagicMock()
+        event = MagicMock()
+        event.type.return_value = main_qml.QEvent.Type.Quit
+        event_filter = main_qml._MacOSQuitToTrayFilter(root_window)
+
+        with patch.object(
+            main_qml,
+            "_macos_current_quit_is_system_session_event",
+            return_value=True,
+        ):
+            self.assertFalse(event_filter.eventFilter(None, event))
+
+        root_window.hide.assert_not_called()
+        event.ignore.assert_not_called()
+
+    def test_session_quit_fallback_does_not_allow_ordinary_quit(self):
+        event_filter = main_qml._MacOSQuitToTrayFilter(MagicMock())
+
+        with patch.object(
+            main_qml,
+            "_macos_current_quit_is_system_session_event",
+            return_value=False,
+        ):
+            self.assertFalse(
+                main_qml._allow_macos_session_quit_if_requested(event_filter)
+            )
+
+        event = MagicMock()
+        event.type.return_value = main_qml.QEvent.Type.Quit
+        self.assertTrue(event_filter.eventFilter(None, event))
+
+    def test_session_quit_fallback_allows_system_quit(self):
+        event_filter = main_qml._MacOSQuitToTrayFilter(MagicMock())
+
+        with patch.object(
+            main_qml,
+            "_macos_current_quit_is_system_session_event",
+            return_value=True,
+        ):
+            self.assertTrue(
+                main_qml._allow_macos_session_quit_if_requested(event_filter)
+            )
+
+        event = MagicMock()
+        event.type.return_value = main_qml.QEvent.Type.Quit
+        self.assertFalse(event_filter.eventFilter(None, event))
 
     def test_engine_start_not_scheduled_without_accessibility(self):
         engine = MagicMock()
@@ -191,6 +288,24 @@ class MacOSQuitAndAccessibilityTests(unittest.TestCase):
             patch.object(main_qml, "is_process_trusted", side_effect=RuntimeError("boom")),
         ):
             self.assertFalse(main_qml._check_accessibility(locale_mgr))
+
+    def test_tray_minimized_notice_is_scheduled_with_module_qtimer(self):
+        tray = MagicMock()
+        locale_mgr = SimpleNamespace(tr=lambda key: f"translated:{key}")
+
+        with patch.object(main_qml.QTimer, "singleShot") as single_shot:
+            main_qml._schedule_tray_minimized_notice(tray, locale_mgr)
+
+        delay, callback = single_shot.call_args.args
+        self.assertEqual(delay, 400)
+
+        callback()
+        tray.showMessage.assert_called_once_with(
+            "Mouser",
+            "translated:tray.tray_message",
+            main_qml.QSystemTrayIcon.MessageIcon.Information,
+            5000,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

A first-time macOS install of Mouser has four rough edges that make
the app feel half-finished even though every feature works:

1. **Process name is "python"**. In Activity Monitor and the Force
   Quit dialog the app appears as `python` (or `Python`), which is
   indistinguishable from any random script and makes "what's using
   my mouse?" diagnostics annoying.
2. **Dock tile is the generic Python rocket**. The committed
   `images/AppIcon.icns` ships to PyInstaller, but the running
   process's executable identity does not match the bundle, so AppKit
   falls back to the framework default at runtime.
3. **Window closes quit the app**. Mouser is intended to live in the
   menu-bar tray; default Qt close behaviour kills the engine along
   with the window. A user who hits Cmd-Q out of habit has to relaunch
   to get scroll inversion / button remapping back.
4. **Menu-bar tray icon does not render on macOS 14+ notched
   MacBooks**. Qt 6's `QSystemTrayIcon` allocates a fixed-length
   `NSStatusItem` and places it left-of-notch, where macOS Sonoma /
   Sequoia refuse to composite items competing with the notch
   cut-out — the result is a phantom item that exists in the status
   bar's geometry but never paints. On a clean install of Mouser on a
   14"/16" MacBook Pro, *the tray icon is simply not there*. Right-
   click also fails since AppKit cannot deliver clicks to an item it
   refuses to draw.

None of these block functionality, but together they cost the app
roughly 30 seconds of credibility every time someone installs it,
and (4) is a hard-blocker for hide-to-tray on any new MacBook.

## What changed

`main_qml.py` is the only file touched. All changes are macOS-only
(gated on `sys.platform == "darwin"`) and inert on Windows / Linux.

### Process identity & Dock presence

- **`_macos_named_executable_path()` + `_maybe_relaunch_with_mouser_process_name()`**
  — on a source-checkout launch, re-execs the interpreter through a
  stable `Mouser`-named symlink in
  `~/Library/Application Support/Mouser/`. Activity Monitor, `ps`,
  and the Force Quit dialog then show the process as `Mouser`. The
  symlink is created with `os.symlink` and rotated with `os.replace`
  so a stale link can't break a re-exec. Guarded on `sys.frozen` so
  packaged `.app` bundles skip the dance (the bundle's `Info.plist`
  already pins the name).
- **`_rename_macos_bundle_for_dock()`** — writes `Mouser` to the
  process's runtime `CFBundleName` via `NSBundle.localizedInfoDictionary`
  so the Dock menu's app-name label matches the process name.
- **`_install_macos_dock_icon()`** — decodes `images/AppIcon.icns` into
  an `NSImage` exactly once and assigns it via
  `NSApplication.setApplicationIconImage_`. Module-scope cache so
  visibility transitions don't re-decode the 1024 PNG.
- **`_app_icon()`** — verifies the icon path exists before handing it
  to `QIcon` so a missing asset surfaces in logs rather than silently
  falling back to the generic icon.

### Window-lifecycle <-> Dock tile reconciliation

- **`_set_macos_activation_policy(regular: bool)`** — flips
  `NSApp.activationPolicy` between `NSApplicationActivationPolicyRegular`
  (Dock tile visible, Cmd-Tab eligible) and
  `NSApplicationActivationPolicyAccessory` (menu-bar-only) in response
  to `QWindow.visibilityChanged`. Idempotency check inside so we don't
  poke AppKit on every redraw.
- **`_on_window_visibility_changed(visibility)`** — Qt signal handler
  that calls the policy setter. **Critical fix**: the handler is now
  invoked with the window's *initial* visibility immediately after
  connecting, because the window was created `visible: !launchHidden`
  by QML *before* the handler was wired, which meant the initial
  show-transition fired with no listener and the policy stayed
  `Accessory` (no Dock tile) on a `--show-window` launch. Without
  this reconcile, a user starting Mouser with the window open would
  never see a Dock tile.

### Native `NSStatusItem` (menu-bar tray icon)

This is the biggest piece in the diff and the reason hide-to-tray is
actually usable on macOS 14+.

- **`_install_native_macos_status_item(qmenu, on_left_click)`** —
  installs an `NSStatusItem` via PyObjC directly, bypassing
  `QSystemTrayIcon`:
  - Uses `NSVariableStatusItemLength` instead of
    `NSSquareStatusItemLength`. Variable-length items are the only
    ones macOS Sonoma+ will composite right-of-notch on a notched
    display, so the icon ends up *visible* instead of stranded in the
    left-of-notch dead zone Qt's `QSystemTrayIcon` lands in.
  - Renders the menu-bar glyph as a template image: takes the same
    SVG the in-app sidebar brand mark uses, paints it through
    `QSvgRenderer` into a `QPixmap`, exports PNG bytes, hands them to
    `NSImage`, sets `template = True`. macOS then tints the icon to
    match the menu bar (light / dark / accent) without a per-mode
    asset.
  - Wires clicks back to Qt with a small Objective-C target subclass
    (`_StatusItemTarget(NSObject)`): single click → `on_left_click()`
    (which shows the main window); any modifier or right-click →
    pop up the existing Qt `QMenu` at the cursor.
- **Qt's `QSystemTrayIcon` is kept alive but hidden**: it remains
  available for `showMessage()` notifications (which use a different
  AppKit path under the hood, separate from `NSStatusItem`) so the
  "Mouser is hidden -- click the menu-bar icon to bring it back"
  banner still fires.
- The native item is retained at module scope so ARC doesn't reclaim
  it the moment the install function returns.

### TCC

- **`_check_accessibility()`** — fails closed: a TCC exception or a
  `False` return from `AXIsProcessTrusted` now triggers the system
  prompt rather than silently assuming permission was granted.
  Previously a bare `except:` swallowed the error and the engine ran
  with no event-tap input, which presents to the user as "Mouser is
  running but nothing works".

## Why a native `NSStatusItem` instead of fixing Qt

`QSystemTrayIcon` calls `[NSStatusBar systemStatusBar
statusItemWithLength: NSSquareStatusItemLength]` internally (verified
against Qt 6.7 source). That length value is the root cause: macOS
Sonoma changed the menu-bar layout to position fixed-square items
left-of-notch on notched displays, where the system refuses to draw
them. There is no Qt API to override the length parameter — the only
fix is to stop using `QSystemTrayIcon` for the icon surface and call
AppKit directly with `NSVariableStatusItemLength`. We keep Qt's
`QSystemTrayIcon` alive in parallel because it owns the
notification-banner path, which works correctly regardless of the
status-item length.

## Scope

- No new dependencies. PyObjC is already required by Mouser on macOS
  (it backs the existing event-tap and HID code).
- All upstream icon assets unchanged (verified byte-for-byte against
  `upstream/master`). The Dock-tile *art* refresh is in #177 and
  lands independently of this PR.
- No `Info.plist` changes — this PR drives everything from the running
  process so the source-checkout and bundle paths share one code
  path.

## Test plan

- [x] Source-checkout launch: Activity Monitor and `ps` show the
      process as `Mouser`. The Dock tile shows the Mouser icon. About
      panel surfaces the bundle identity, build mode, HEAD commit,
      and launch path.
- [x] Frozen `.app` launch: `_maybe_relaunch_with_mouser_process_name`
      is skipped (`sys.frozen` guard); identity comes from the bundle.
- [x] Toggle window via tray "Show" / "Hide": activation policy
      flips between Regular and Accessory; Dock tile appears /
      disappears in lockstep.
- [x] `--show-window` launch on a clean profile (window starts
      visible): Dock tile is present immediately (regression test
      for the initial-visibility reconcile fix).
- [x] Menu-bar icon on macOS 14.5 / 15.0 notched MacBook Pro:
      icon renders right-of-notch. Single click reopens the window;
      right-click and Option-click pop up the Qt menu.
- [x] Menu-bar icon on a non-notched display: icon renders, click
      behaviour identical.
- [x] Revoke Accessibility permission → relaunch → TCC prompt fires
      (regression test for the silent-failure path).
- [x] `pytest tests/` -- 406 tests, 155 subtests, green.

## Screenshot

About panel from the sidebar info button -- confirms the running
bundle identity, the `Source checkout` build mode, the HEAD commit,
and the runtime launch path (all wired through the renamed launcher
machinery):

![About panel](https://raw.githubusercontent.com/hughesyadaddy/Mouser/screenshots/mx-master-4-firmware-first/screenshots/about-panel.png)
