### PR TITLE
fix: surface macOS start-at-login failures

### DIFF
--- a/core/startup.py
+++ b/core/startup.py
@@ -4,6 +4,7 @@ import os
 import plistlib
 import subprocess
 import sys
+import tempfile
 
 # Windows
 RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
@@ -246,6 +247,70 @@ def _launchctl_run(args: list) -> subprocess.CompletedProcess:
     )
 
 
+def _launchctl_failure_message(action: str, result: subprocess.CompletedProcess) -> str:
+    details = (result.stderr or result.stdout or "").strip()
+    if details:
+        return f"launchctl {action} failed: {details}"
+    return f"launchctl {action} failed with exit code {result.returncode}"
+
+
+def _atomic_write_file(path: str, data: bytes) -> None:
+    directory = os.path.dirname(path) or "."
+    prefix = f".{os.path.basename(path)}."
+    fd, tmp_path = tempfile.mkstemp(prefix=prefix, suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+        tmp_path = ""
+    finally:
+        if tmp_path:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+
+
+def _remove_file_if_present(path: str) -> None:
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+
+
+def _restore_macos_plist(
+    plist_path: str,
+    previous_plist: bytes | None,
+    domain: str,
+) -> None:
+    if previous_plist is None:
+        _remove_file_if_present(plist_path)
+        return
+    _atomic_write_file(plist_path, previous_plist)
+    result = _launchctl_run(["launchctl", "bootstrap", domain, plist_path])
+    if result.returncode != 0:
+        raise RuntimeError(_launchctl_failure_message("restore bootstrap", result))
+
+
+def _restore_macos_plist_then_raise(
+    plist_path: str,
+    previous_plist: bytes | None,
+    domain: str,
+    exc: Exception,
+) -> None:
+    try:
+        _restore_macos_plist(plist_path, previous_plist, domain)
+    except Exception as restore_exc:
+        raise RuntimeError(
+            f"{exc}; additionally failed to restore the previous launch agent: {restore_exc}"
+        ) from exc
+    if isinstance(exc, RuntimeError):
+        raise exc
+    raise RuntimeError(f"failed to update launch agent: {exc}") from exc
+
+
 def _apply_macos(enabled: bool) -> None:
     if sys.platform != "darwin":
         return
@@ -256,21 +321,30 @@ def _apply_macos(enabled: bool) -> None:
 
     if enabled:
         os.makedirs(launch_agents_dir, exist_ok=True)
-        if os.path.isfile(plist_path):
+        plist_existed = os.path.isfile(plist_path)
+        previous_plist = None
+        if plist_existed:
+            try:
+                with open(plist_path, "rb") as f:
+                    previous_plist = f.read()
+            except OSError as exc:
+                raise RuntimeError(
+                    f"failed to preserve existing launch agent: {exc}"
+                ) from exc
             _launchctl_run(["launchctl", "bootout", domain, plist_path])
         payload = {
             "Label": MACOS_LAUNCH_AGENT_LABEL,
             "ProgramArguments": _program_arguments(),
             "RunAtLoad": True,
         }
-        with open(plist_path, "wb") as f:
-            plistlib.dump(payload, f, fmt=plistlib.FMT_XML)
-        result = _launchctl_run(["launchctl", "bootstrap", domain, plist_path])
-        if result.returncode != 0:
-            print(
-                f"[startup] launchctl bootstrap failed: {result.stderr.strip()}",
-                file=sys.stderr,
-            )
+        new_plist = plistlib.dumps(payload, fmt=plistlib.FMT_XML)
+        try:
+            _atomic_write_file(plist_path, new_plist)
+            result = _launchctl_run(["launchctl", "bootstrap", domain, plist_path])
+            if result.returncode != 0:
+                raise RuntimeError(_launchctl_failure_message("bootstrap", result))
+        except Exception as exc:
+            _restore_macos_plist_then_raise(plist_path, previous_plist, domain, exc)
     else:
         if os.path.isfile(plist_path):
             _launchctl_run(["launchctl", "bootout", domain, plist_path])

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -638,6 +638,40 @@ class BackendLoginStartupTests(unittest.TestCase):
             Backend(engine=None)
         sync_mock.assert_called_once_with(True)
 
+    def test_init_clears_start_at_login_when_sync_fails(self):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["settings"]["start_at_login"] = True
+        with (
+            patch("ui.backend.load_config", return_value=cfg),
+            patch("ui.backend.save_config") as save_mock,
+            patch("ui.backend.supports_login_startup", return_value=True),
+            patch(
+                "ui.backend.sync_login_startup_from_config",
+                side_effect=RuntimeError("bootstrap failed"),
+            ),
+        ):
+            backend = Backend(engine=None)
+
+        self.assertFalse(backend.startAtLogin)
+        save_mock.assert_called_once()
+
+    def test_init_sync_failure_keeps_disabled_config_disabled(self):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["settings"]["start_at_login"] = False
+        with (
+            patch("ui.backend.load_config", return_value=cfg),
+            patch("ui.backend.save_config") as save_mock,
+            patch("ui.backend.supports_login_startup", return_value=True),
+            patch(
+                "ui.backend.sync_login_startup_from_config",
+                side_effect=RuntimeError("bootout failed"),
+            ),
+        ):
+            backend = Backend(engine=None)
+
+        self.assertFalse(backend.startAtLogin)
+        save_mock.assert_not_called()
+
     def test_init_clears_start_at_login_when_unsupported(self):
         cfg = copy.deepcopy(DEFAULT_CONFIG)
         cfg["settings"]["start_at_login"] = True

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,8 +1,9 @@
 import os
+import plistlib
 import sys
 import tempfile
 import unittest
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 from core import startup as st
 
@@ -160,8 +161,124 @@ class ApplyLoginStartupMacTests(unittest.TestCase):
         )
 
     def test_macos_enable_writes_plist_and_bootstraps(self):
-        plist = "/tmp/io.github.tombadash.mouser.plist"
         domain = "gui/501"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "LaunchAgents", "io.github.tombadash.mouser.plist")
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+            ):
+                m_lc.return_value = MagicMock(returncode=0)
+                st.apply_login_startup(True)
+
+            with open(plist, "rb") as f:
+                payload = plistlib.load(f)
+            self.assertEqual(payload["ProgramArguments"], ["/X/Mouser"])
+            self.assertTrue(payload["RunAtLoad"])
+            self.assertEqual(m_lc.call_count, 1)
+            m_lc.assert_called_with(
+                ["launchctl", "bootstrap", domain, plist]
+            )
+
+    def test_macos_enable_raises_and_removes_plist_when_bootstrap_fails(self):
+        domain = "gui/501"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "io.github.tombadash.mouser.plist")
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+            ):
+                m_lc.return_value = MagicMock(
+                    returncode=5,
+                    stderr="Bootstrap failed",
+                    stdout="",
+                )
+                with self.assertRaisesRegex(RuntimeError, "launchctl bootstrap failed"):
+                    st.apply_login_startup(True)
+
+            m_lc.assert_called_once_with(
+                ["launchctl", "bootstrap", domain, plist]
+            )
+            self.assertFalse(os.path.exists(plist))
+
+    def test_macos_enable_reports_cleanup_failure_after_bootstrap_fails(self):
+        domain = "gui/501"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "io.github.tombadash.mouser.plist")
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+                patch("core.startup.os.remove", side_effect=OSError("cleanup failed")),
+            ):
+                m_lc.return_value = MagicMock(
+                    returncode=5,
+                    stderr="Bootstrap failed",
+                    stdout="",
+                )
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "additionally failed to restore the previous launch agent",
+                ) as ctx:
+                    st.apply_login_startup(True)
+
+            self.assertIn("cleanup failed", str(ctx.exception))
+
+    def test_macos_enable_restores_existing_plist_when_bootstrap_fails(self):
+        domain = "gui/501"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "io.github.tombadash.mouser.plist")
+            with open(plist, "wb") as f:
+                f.write(b"old plist")
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+            ):
+                m_lc.side_effect = [
+                    MagicMock(returncode=0),
+                    MagicMock(returncode=5, stderr="Bootstrap failed", stdout=""),
+                    MagicMock(returncode=0),
+                ]
+
+                with self.assertRaisesRegex(RuntimeError, "launchctl bootstrap failed"):
+                    st.apply_login_startup(True)
+
+            with open(plist, "rb") as f:
+                self.assertEqual(f.read(), b"old plist")
+            self.assertEqual(
+                [call.args[0] for call in m_lc.call_args_list],
+                [
+                    ["launchctl", "bootout", domain, plist],
+                    ["launchctl", "bootstrap", domain, plist],
+                    ["launchctl", "bootstrap", domain, plist],
+                ],
+            )
+
+    def test_macos_enable_does_not_bootout_when_existing_plist_cannot_be_preserved(self):
+        plist = "/tmp/io.github.tombadash.mouser.plist"
 
         with (
             patch.object(sys, "platform", "darwin"),
@@ -170,20 +287,59 @@ class ApplyLoginStartupMacTests(unittest.TestCase):
             patch.object(st, "_macos_plist_path", return_value=plist),
             patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
             patch.object(st, "_launchctl_run") as m_lc,
-            patch("os.makedirs") as m_makedirs,
-            patch("os.path.isfile", return_value=False),
-            patch("builtins.open", mock_open()) as m_open,
-            patch("core.startup.plistlib.dump"),
+            patch("os.makedirs"),
+            patch("os.path.isfile", return_value=True),
+            patch("builtins.open", side_effect=OSError("read failed")),
         ):
-            m_lc.return_value = MagicMock(returncode=0)
-            st.apply_login_startup(True)
+            with self.assertRaisesRegex(RuntimeError, "failed to preserve"):
+                st.apply_login_startup(True)
 
-        m_makedirs.assert_called_once()
-        m_open.assert_called_once_with(plist, "wb")
-        self.assertEqual(m_lc.call_count, 1)
-        m_lc.assert_called_with(
-            ["launchctl", "bootstrap", domain, plist]
-        )
+        m_lc.assert_not_called()
+
+    def test_macos_enable_restores_existing_plist_when_write_fails_after_bootout(self):
+        domain = "gui/501"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "io.github.tombadash.mouser.plist")
+            with open(plist, "wb") as f:
+                f.write(b"old plist")
+
+            write_calls = []
+
+            def fake_atomic_write(path, data):
+                write_calls.append((path, data))
+                if len(write_calls) == 1:
+                    raise OSError("write failed")
+                with open(path, "wb") as f:
+                    f.write(data)
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+                patch.object(st, "_atomic_write_file", side_effect=fake_atomic_write),
+            ):
+                m_lc.side_effect = [
+                    MagicMock(returncode=0),
+                    MagicMock(returncode=0),
+                ]
+
+                with self.assertRaisesRegex(RuntimeError, "failed to update launch agent"):
+                    st.apply_login_startup(True)
+
+            with open(plist, "rb") as f:
+                self.assertEqual(f.read(), b"old plist")
+            self.assertEqual(len(write_calls), 2)
+            self.assertEqual(
+                [call.args[0] for call in m_lc.call_args_list],
+                [
+                    ["launchctl", "bootout", domain, plist],
+                    ["launchctl", "bootstrap", domain, plist],
+                ],
+            )
 
     def test_macos_disable_bootout_and_remove_when_plist_exists(self):
         plist = "/tmp/io.github.tombadash.mouser.plist"

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -295,6 +295,20 @@ class Backend(QObject):
                 sync_login_startup_from_config(self.startAtLogin)
             except Exception as exc:
                 print(f"[startup] Failed to sync desktop integration: {exc}", file=sys.stderr)
+                if self.startAtLogin:
+                    self._cfg.setdefault("settings", {})["start_at_login"] = False
+                    try:
+                        save_config(self._cfg)
+                    except Exception as save_exc:
+                        print(
+                            "[startup] Failed to save start-at-login recovery state: "
+                            f"{save_exc}",
+                            file=sys.stderr,
+                        )
+                    self.settingsChanged.emit()
+                    self.statusMessage.emit(
+                        "Start at login could not be enabled. Please try again."
+                    )
         else:
             self._cfg.setdefault("settings", {})["start_at_login"] = False
         self._sync_connected_device_info()


### PR DESCRIPTION
## Summary

- Report macOS Start at login registration failures instead of silently treating the setting as enabled.
- Remove the generated login item file if `launchctl bootstrap` rejects a new registration.
- Preserve and restore an existing login item file if re-registration fails while updating it, so Mouser does not erase a previously working startup entry.
- If Mouser cannot re-sync an enabled login item when the app starts, reset the setting to off instead of showing a stale enabled state.
- Keep the existing disable path unchanged.

## Addresses

- #157

## Validation

- `python -m pytest tests/test_backend.py tests/test_startup.py`
- `python -m pytest`
- `python -m py_compile core/startup.py ui/backend.py`
- `git diff --check`

## Notes

- This only changes macOS login item error handling.
- Linux and Windows startup behavior are unchanged.
