### PR TITLE
feat: translate Shift+wheel into horizontal scroll on macOS/Windows/Linux

### DIFF
--- a/core/mouse_hook_linux.py
+++ b/core/mouse_hook_linux.py
@@ -122,6 +122,8 @@ class MouseHook(BaseMouseHook):
         self._evdev_grabbed = False
         self._evdev_remap_ready = False
         self._evdev_remap_status_state = (False, None)
+        self._keyboard_devices = []
+        self._keyboard_devices_initialised = False
 
     @property
     def evdev_ready(self):
@@ -695,24 +697,116 @@ class MouseHook(BaseMouseHook):
                 caps.pop(filtered_type, None)
         rel_type = _ecodes.EV_REL
         rel_caps = list(caps.get(rel_type, []))
-        if not rel_caps:
-            return caps
         hi_res_codes = {
             getattr(_ecodes, "REL_WHEEL_HI_RES", None),
             getattr(_ecodes, "REL_HWHEEL_HI_RES", None),
         }
         filtered_rel_caps = [code for code in rel_caps if code not in hi_res_codes]
-        if filtered_rel_caps == rel_caps:
-            return caps
-        if filtered_rel_caps:
+        # Ensure REL_HWHEEL is available so Shift+wheel translation can emit
+        # horizontal scroll even on mice without a tilt wheel.  Only add when
+        # the source already exposes REL events (i.e. is a mouse-like device).
+        if rel_caps and _ecodes.REL_HWHEEL not in filtered_rel_caps:
+            filtered_rel_caps.append(_ecodes.REL_HWHEEL)
+        if filtered_rel_caps != rel_caps:
             caps[rel_type] = filtered_rel_caps
-        else:
-            caps.pop(rel_type, None)
-        print(
-            "[MouseHook] Filtering REL_WHEEL_HI_RES / "
-            "REL_HWHEEL_HI_RES from Mouser Virtual Mouse"
-        )
+            if rel_caps and any(c in hi_res_codes for c in rel_caps):
+                print(
+                    "[MouseHook] Filtering REL_WHEEL_HI_RES / "
+                    "REL_HWHEEL_HI_RES from Mouser Virtual Mouse"
+                )
         return caps
+
+    def _ensure_keyboard_devices(self):
+        """Open keyboard evdev devices (read-only) for Shift detection."""
+        if self._keyboard_devices_initialised or not _EVDEV_OK:
+            return
+        self._keyboard_devices_initialised = True
+        try:
+            paths = list(_evdev_mod.list_devices())
+        except Exception as exc:
+            _log_once(
+                ("evdev-keyboard-list-error", type(exc).__name__, str(exc)),
+                f"[MouseHook] Cannot list evdev devices for Shift detection: {exc}",
+            )
+            return
+        shift_codes = {
+            _ecodes.KEY_LEFTSHIFT,
+            _ecodes.KEY_RIGHTSHIFT,
+        }
+        keyboards = []
+        for path in paths:
+            try:
+                dev = _InputDevice(path)
+            except PermissionError:
+                continue
+            except Exception:
+                continue
+            try:
+                caps = dev.capabilities(absinfo=False)
+                key_caps = set(caps.get(_ecodes.EV_KEY, []))
+                if key_caps & shift_codes:
+                    keyboards.append(dev)
+                    continue
+            except Exception:
+                pass
+            try:
+                dev.close()
+            except Exception:
+                pass
+        self._keyboard_devices = keyboards
+        if keyboards:
+            print(
+                f"[MouseHook] Tracking {len(keyboards)} keyboard device(s) "
+                "for Shift+wheel detection"
+            )
+
+    def _close_keyboard_devices(self):
+        for dev in self._keyboard_devices:
+            try:
+                dev.close()
+            except Exception:
+                pass
+        self._keyboard_devices = []
+        self._keyboard_devices_initialised = False
+
+    def _shift_held(self):
+        """Return True if any Shift key is currently held."""
+        if not self._keyboard_devices_initialised:
+            self._ensure_keyboard_devices()
+        if not self._keyboard_devices:
+            return False
+        shift_codes = (
+            _ecodes.KEY_LEFTSHIFT,
+            _ecodes.KEY_RIGHTSHIFT,
+        )
+        stale = []
+        for dev in self._keyboard_devices:
+            try:
+                active = dev.active_keys()
+            except OSError:
+                stale.append(dev)
+                continue
+            except Exception:
+                continue
+            for code in shift_codes:
+                if code in active:
+                    if stale:
+                        self._drop_stale_keyboards(stale)
+                    return True
+        if stale:
+            self._drop_stale_keyboards(stale)
+        return False
+
+    def _drop_stale_keyboards(self, stale):
+        for dev in stale:
+            try:
+                dev.close()
+            except Exception:
+                pass
+            try:
+                self._keyboard_devices.remove(dev)
+            except ValueError:
+                pass
 
     def _cleanup_evdev(self):
         self._disable_evdev_remapping()
@@ -849,6 +943,14 @@ class MouseHook(BaseMouseHook):
 
         rel_wheel_hi_res = getattr(_ecodes, "REL_WHEEL_HI_RES", 0x0B)
         if code == _ecodes.REL_WHEEL or code == rel_wheel_hi_res:
+            if value != 0 and self._shift_held():
+                if code == _ecodes.REL_WHEEL:
+                    h_value = -value if self.invert_hscroll else value
+                    self._uinput.write(_ecodes.EV_REL, _ecodes.REL_HWHEEL, h_value)
+                # REL_WHEEL_HI_RES events are suppressed while Shift is held so
+                # the vertical scroll doesn't double-fire alongside the
+                # translated horizontal scroll.
+                return
             if self.invert_vscroll:
                 self._uinput.write(_ecodes.EV_REL, code, -value)
             else:
@@ -926,6 +1028,7 @@ class MouseHook(BaseMouseHook):
             self._evdev_thread.join(timeout=2)
             self._evdev_thread = None
         self._cleanup_evdev()
+        self._close_keyboard_devices()
 
 
 MouseHook._platform_module = sys.modules[__name__]

--- a/core/mouse_hook_macos.py
+++ b/core/mouse_hook_macos.py
@@ -44,6 +44,7 @@ _BTN_BACK = 3
 _BTN_FORWARD = 4
 _SCROLL_INVERT_MARKER = 0x4D4F5553
 _INJECTED_EVENT_MARKER = 0x4D4F5554
+_SHIFT_WHEEL_HSCROLL_MARKER = 0x4D4F5556
 _kCGEventTapDisabledByTimeout = 0xFFFFFFFE
 _kCGEventTapDisabledByUserInput = 0xFFFFFFFF
 
@@ -79,6 +80,77 @@ class MouseHook(BaseMouseHook):
             value = Quartz.CGEventGetIntegerValueField(cg_event, field)
             if value:
                 Quartz.CGEventSetIntegerValueField(cg_event, field, -value)
+
+    def _post_shift_hscroll_event(self, cg_event):
+        """Translate Shift+vertical-wheel into a horizontal scroll event.
+
+        The translated event has axis-1 zeroed and axis-1 deltas copied onto
+        axis-2.  The Shift modifier is stripped so that apps which already
+        translate Shift+scroll themselves do not double-translate.  The
+        `invert_hscroll` setting flips the direction.
+        """
+        v_line = Quartz.CGEventGetIntegerValueField(
+            cg_event, Quartz.kCGScrollWheelEventDeltaAxis1
+        )
+        v_fixed = Quartz.CGEventGetIntegerValueField(
+            cg_event, Quartz.kCGScrollWheelEventFixedPtDeltaAxis1
+        )
+        v_point = Quartz.CGEventGetIntegerValueField(
+            cg_event, Quartz.kCGScrollWheelEventPointDeltaAxis1
+        )
+
+        if self.invert_hscroll:
+            v_line = -v_line
+            v_fixed = -v_fixed
+            v_point = -v_point
+
+        is_continuous = Quartz.CGEventGetIntegerValueField(cg_event, 88)
+        if is_continuous:
+            unit = Quartz.kCGScrollEventUnitPixel
+            primary_delta = v_point
+        else:
+            unit = Quartz.kCGScrollEventUnitLine
+            primary_delta = v_line
+
+        new_event = Quartz.CGEventCreateScrollWheelEvent(
+            None, unit, 2, 0, primary_delta
+        )
+        if not new_event:
+            return False
+
+        flags = Quartz.CGEventGetFlags(cg_event)
+        Quartz.CGEventSetFlags(new_event, flags & ~Quartz.kCGEventFlagMaskShift)
+        Quartz.CGEventSetIntegerValueField(
+            new_event,
+            Quartz.kCGEventSourceUserData,
+            _SHIFT_WHEEL_HSCROLL_MARKER,
+        )
+
+        for field_name, value in (
+            ("kCGScrollWheelEventDeltaAxis2", v_line),
+            ("kCGScrollWheelEventFixedPtDeltaAxis2", v_fixed),
+            ("kCGScrollWheelEventPointDeltaAxis2", v_point),
+            ("kCGScrollWheelEventDeltaAxis1", 0),
+            ("kCGScrollWheelEventFixedPtDeltaAxis1", 0),
+            ("kCGScrollWheelEventPointDeltaAxis1", 0),
+        ):
+            field = getattr(Quartz, field_name, None)
+            if field is None:
+                continue
+            Quartz.CGEventSetIntegerValueField(new_event, field, value)
+
+        for field_name in (
+            "kCGScrollWheelEventScrollPhase",
+            "kCGScrollWheelEventMomentumPhase",
+        ):
+            field = getattr(Quartz, field_name, None)
+            if field is None:
+                continue
+            value = Quartz.CGEventGetIntegerValueField(cg_event, field)
+            Quartz.CGEventSetIntegerValueField(new_event, field, value)
+
+        Quartz.CGEventPost(Quartz.kCGHIDEventTap, new_event)
+        return True
 
     def _post_inverted_scroll_event(self, cg_event):
         v_point = Quartz.CGEventGetIntegerValueField(
@@ -365,11 +437,12 @@ class MouseHook(BaseMouseHook):
                     should_block = MouseEvent.XBUTTON2_UP in self._blocked_events
 
             elif event_type == Quartz.kCGEventScrollWheel:
-                if (
-                    Quartz.CGEventGetIntegerValueField(
-                        cg_event, Quartz.kCGEventSourceUserData
-                    )
-                    == _SCROLL_INVERT_MARKER
+                source_marker = Quartz.CGEventGetIntegerValueField(
+                    cg_event, Quartz.kCGEventSourceUserData
+                )
+                if source_marker in (
+                    _SCROLL_INVERT_MARKER,
+                    _SHIFT_WHEEL_HSCROLL_MARKER,
                 ):
                     return cg_event
                 if self.ignore_trackpad:
@@ -392,6 +465,15 @@ class MouseHook(BaseMouseHook):
                         self._debug_callback(f"ScrollWheel v={v_delta} h={h_delta}")
                     except Exception:
                         pass
+                if h_delta == 0:
+                    flags = Quartz.CGEventGetFlags(cg_event)
+                    if flags & Quartz.kCGEventFlagMaskShift:
+                        v_fixed = Quartz.CGEventGetIntegerValueField(
+                            cg_event,
+                            Quartz.kCGScrollWheelEventFixedPtDeltaAxis1,
+                        )
+                        if v_fixed != 0 and self._post_shift_hscroll_event(cg_event):
+                            return None
                 if h_delta != 0:
                     if h_delta > 0:
                         mouse_event = MouseEvent(MouseEvent.HSCROLL_RIGHT, abs(h_delta))
@@ -637,6 +719,7 @@ __all__ = [
     "_BTN_FORWARD",
     "_SCROLL_INVERT_MARKER",
     "_INJECTED_EVENT_MARKER",
+    "_SHIFT_WHEEL_HSCROLL_MARKER",
     "_kCGEventTapDisabledByTimeout",
     "_kCGEventTapDisabledByUserInput",
 ]

--- a/core/mouse_hook_windows.py
+++ b/core/mouse_hook_windows.py
@@ -82,6 +82,12 @@ GetModuleHandleW.argtypes = [wintypes.LPCWSTR]
 GetMessageW = windll.user32.GetMessageW
 PostThreadMessageW = windll.user32.PostThreadMessageW
 
+GetAsyncKeyState = windll.user32.GetAsyncKeyState
+GetAsyncKeyState.argtypes = [c_int]
+GetAsyncKeyState.restype = ctypes.c_short
+
+VK_SHIFT = 0x10
+
 WM_QUIT = 0x0012
 INJECTED_FLAG = 0x00000001
 
@@ -208,6 +214,7 @@ def hiword(dword):
 WM_APP = 0x8000
 WM_APP_INJECT_VSCROLL = WM_APP + 1
 WM_APP_INJECT_HSCROLL = WM_APP + 2
+WM_APP_INJECT_SHIFT_HSCROLL = WM_APP + 3
 
 WM_DEVICECHANGE = 0x0219
 DBT_DEVNODES_CHANGED = 0x0007
@@ -232,8 +239,10 @@ class MouseHook(BaseMouseHook):
         self._hook_proc = None
         self._pending_vscroll = 0
         self._pending_hscroll = 0
+        self._pending_shift_hscroll = 0
         self._vscroll_posted = False
         self._hscroll_posted = False
+        self._shift_hscroll_posted = False
         self._ri_wndproc_ref = None
         self._ri_hwnd = None
         self._device_name_cache = {}
@@ -427,8 +436,25 @@ class MouseHook(BaseMouseHook):
                 should_block = MouseEvent.MIDDLE_UP in self._blocked_events
 
             elif wParam == WM_MOUSEWHEEL:
+                delta = hiword(mouse_data)
+                if delta != 0 and (GetAsyncKeyState(VK_SHIFT) & 0x8000):
+                    if self._ri_hwnd:
+                        h_delta = -delta if self.invert_hscroll else delta
+                        self._pending_shift_hscroll += h_delta
+                        if self._shift_hscroll_posted:
+                            return 1
+                        if PostMessageW(
+                            self._ri_hwnd, WM_APP_INJECT_SHIFT_HSCROLL, 0, 0
+                        ):
+                            self._shift_hscroll_posted = True
+                            return 1
+                        self._pending_shift_hscroll -= h_delta
+                    else:
+                        self._emit_debug(
+                            "Shift+wheel translation skipped: "
+                            "raw input window unavailable"
+                        )
                 if self.invert_vscroll:
-                    delta = hiword(mouse_data)
                     if delta != 0 and self._ri_hwnd:
                         self._pending_vscroll += -delta
                         if self._vscroll_posted:
@@ -512,6 +538,14 @@ class MouseHook(BaseMouseHook):
             delta = self._pending_hscroll
             self._pending_hscroll = 0
             self._hscroll_posted = False
+            if delta != 0:
+                _inject_scroll_impl(MOUSEEVENTF_HWHEEL, delta)
+            return 0
+
+        if msg == WM_APP_INJECT_SHIFT_HSCROLL:
+            delta = self._pending_shift_hscroll
+            self._pending_shift_hscroll = 0
+            self._shift_hscroll_posted = False
             if delta != 0:
                 _inject_scroll_impl(MOUSEEVENTF_HWHEEL, delta)
             return 0

--- a/tests/test_mouse_hook.py
+++ b/tests/test_mouse_hook.py
@@ -995,5 +995,211 @@ class MacOSTrackpadScrollFilterTests(unittest.TestCase):
         self.assertEqual(event.event_type, mouse_hook.MouseEvent.HSCROLL_RIGHT)
 
 
+@unittest.skipUnless(sys.platform == "darwin", "macOS-only tests")
+class MacOSShiftWheelHScrollTests(unittest.TestCase):
+    """Verify Shift+wheel translates into a horizontal scroll event."""
+
+    _kCGScrollWheelEventIsContinuous = 88
+    _kCGEventScrollWheel = 22
+    _kCGEventFlagMaskShift = 0x00020000
+    _kCGScrollEventUnitLine = 0
+    _kCGScrollEventUnitPixel = 1
+    _AXIS1_DELTA = "kCGScrollWheelEventDeltaAxis1"
+    _AXIS1_FIXED = "kCGScrollWheelEventFixedPtDeltaAxis1"
+    _AXIS1_POINT = "kCGScrollWheelEventPointDeltaAxis1"
+    _AXIS2_DELTA = "kCGScrollWheelEventDeltaAxis2"
+    _AXIS2_FIXED = "kCGScrollWheelEventFixedPtDeltaAxis2"
+    _AXIS2_POINT = "kCGScrollWheelEventPointDeltaAxis2"
+
+    def setUp(self):
+        self.mock_quartz = MagicMock(name="Quartz")
+        self.mock_quartz.kCGEventScrollWheel = self._kCGEventScrollWheel
+        self.mock_quartz.kCGEventFlagMaskShift = self._kCGEventFlagMaskShift
+        self.mock_quartz.kCGScrollEventUnitLine = self._kCGScrollEventUnitLine
+        self.mock_quartz.kCGScrollEventUnitPixel = self._kCGScrollEventUnitPixel
+        for axis_attr in (
+            self._AXIS1_DELTA, self._AXIS1_FIXED, self._AXIS1_POINT,
+            self._AXIS2_DELTA, self._AXIS2_FIXED, self._AXIS2_POINT,
+        ):
+            setattr(self.mock_quartz, axis_attr, axis_attr)
+        mouse_hook.Quartz = self.mock_quartz
+
+    def tearDown(self):
+        if hasattr(mouse_hook, "Quartz") and isinstance(
+                mouse_hook.Quartz, MagicMock):
+            del mouse_hook.Quartz
+
+    def _make_hook(self, *, block_hscroll=True):
+        hook = mouse_hook.MouseHook()
+        hook._running = True
+        hook._tap = MagicMock(name="tap")
+        if block_hscroll:
+            hook.block(mouse_hook.MouseEvent.HSCROLL_LEFT)
+            hook.block(mouse_hook.MouseEvent.HSCROLL_RIGHT)
+        return hook
+
+    def _field_getter(self, *, shift=False, h_fixed=0, v_line=0, v_fixed=0,
+                      v_point=0, is_continuous=0, source_user_data=0):
+        def _get(event, field):
+            if field == self._kCGScrollWheelEventIsContinuous:
+                return is_continuous
+            if field == self.mock_quartz.kCGEventSourceUserData:
+                return source_user_data
+            if field == self.mock_quartz.kCGScrollWheelEventFixedPtDeltaAxis2:
+                return h_fixed
+            if field == self._AXIS1_DELTA:
+                return v_line
+            if field == self._AXIS1_FIXED:
+                return v_fixed
+            if field == self._AXIS1_POINT:
+                return v_point
+            return 0
+        return _get
+
+    def test_shift_wheel_up_translates_to_horizontal_scroll(self):
+        """Shift held + vertical wheel scroll posts a horizontal-scroll event."""
+        hook = self._make_hook()
+        cg_event = MagicMock(name="cg_event")
+        self.mock_quartz.CGEventGetIntegerValueField.side_effect = \
+            self._field_getter(v_line=1, v_fixed=65536, v_point=10)
+        self.mock_quartz.CGEventGetFlags.return_value = (
+            self._kCGEventFlagMaskShift)
+        new_event = MagicMock(name="translated_event")
+        self.mock_quartz.CGEventCreateScrollWheelEvent.return_value = new_event
+
+        result = hook._event_tap_callback(
+            None, self._kCGEventScrollWheel, cg_event, None)
+
+        self.assertIsNone(result, "original vertical scroll must be blocked")
+        self.mock_quartz.CGEventCreateScrollWheelEvent.assert_called_once()
+        create_args = self.mock_quartz.CGEventCreateScrollWheelEvent.call_args
+        # (source, unit, wheelCount, delta1, delta2)
+        self.assertEqual(create_args.args[2], 2,
+                         "must create a two-axis scroll event")
+        self.assertEqual(create_args.args[3], 0,
+                         "vertical delta on translated event must be 0")
+        self.assertNotEqual(create_args.args[4], 0,
+                            "horizontal delta on translated event must be set")
+        self.mock_quartz.CGEventPost.assert_called_once()
+
+    def test_shift_wheel_strips_shift_modifier_from_translated_event(self):
+        """Translated event must clear Shift so apps don't double-translate."""
+        hook = self._make_hook()
+        cg_event = MagicMock(name="cg_event")
+        self.mock_quartz.CGEventGetIntegerValueField.side_effect = \
+            self._field_getter(v_line=1, v_fixed=65536, v_point=10)
+        self.mock_quartz.CGEventGetFlags.return_value = (
+            self._kCGEventFlagMaskShift | 0x00010000)  # Shift + something else
+        new_event = MagicMock(name="translated_event")
+        self.mock_quartz.CGEventCreateScrollWheelEvent.return_value = new_event
+
+        hook._event_tap_callback(
+            None, self._kCGEventScrollWheel, cg_event, None)
+
+        # Find the CGEventSetFlags call on the translated event
+        set_flags_calls = [
+            c for c in self.mock_quartz.CGEventSetFlags.call_args_list
+            if c.args[0] is new_event
+        ]
+        self.assertEqual(len(set_flags_calls), 1)
+        applied_flags = set_flags_calls[0].args[1]
+        self.assertEqual(applied_flags & self._kCGEventFlagMaskShift, 0,
+                         "Shift mask must be stripped from translated event")
+        self.assertEqual(applied_flags & 0x00010000, 0x00010000,
+                         "other modifier flags must be preserved")
+
+    def test_translated_event_passes_through_tap_on_reentry(self):
+        """The marker on the translated event makes the tap pass it through."""
+        hook = self._make_hook()
+        cg_event = MagicMock(name="re_entered_event")
+        # Source user data set to the shift-wheel marker
+        marker = mouse_hook._SHIFT_WHEEL_HSCROLL_MARKER
+        self.mock_quartz.CGEventGetIntegerValueField.side_effect = \
+            self._field_getter(source_user_data=marker)
+
+        result = hook._event_tap_callback(
+            None, self._kCGEventScrollWheel, cg_event, None)
+
+        self.assertIs(result, cg_event)
+        # No new event should be created for a re-entered marker event
+        self.mock_quartz.CGEventCreateScrollWheelEvent.assert_not_called()
+
+    def test_no_shift_means_no_translation(self):
+        """A plain vertical scroll without Shift must not be translated."""
+        hook = self._make_hook()
+        cg_event = MagicMock(name="cg_event")
+        self.mock_quartz.CGEventGetIntegerValueField.side_effect = \
+            self._field_getter(v_line=1, v_fixed=65536, v_point=10)
+        self.mock_quartz.CGEventGetFlags.return_value = 0  # no modifiers
+
+        result = hook._event_tap_callback(
+            None, self._kCGEventScrollWheel, cg_event, None)
+
+        self.assertIs(result, cg_event, "event must pass through unchanged")
+        self.mock_quartz.CGEventCreateScrollWheelEvent.assert_not_called()
+
+    def test_shift_with_zero_vertical_delta_is_noop(self):
+        """Shift held but no vertical delta (e.g. axis-2 only) does not translate."""
+        hook = self._make_hook()
+        cg_event = MagicMock(name="cg_event")
+        # h_fixed != 0 means the existing hscroll path takes over, not our shift path.
+        self.mock_quartz.CGEventGetIntegerValueField.side_effect = \
+            self._field_getter(h_fixed=3 * 65536)
+        self.mock_quartz.CGEventGetFlags.return_value = (
+            self._kCGEventFlagMaskShift)
+
+        hook._event_tap_callback(
+            None, self._kCGEventScrollWheel, cg_event, None)
+
+        # Existing hscroll path: blocked + dispatched, but NOT translated.
+        self.mock_quartz.CGEventCreateScrollWheelEvent.assert_not_called()
+
+    def test_invert_hscroll_flips_translated_direction(self):
+        """`invert_hscroll` must flip the sign of the translated horizontal delta."""
+        hook = self._make_hook()
+        hook.invert_hscroll = True
+        cg_event = MagicMock(name="cg_event")
+        self.mock_quartz.CGEventGetIntegerValueField.side_effect = \
+            self._field_getter(v_line=1, v_fixed=65536, v_point=10)
+        self.mock_quartz.CGEventGetFlags.return_value = (
+            self._kCGEventFlagMaskShift)
+        new_event = MagicMock(name="translated_event")
+        self.mock_quartz.CGEventCreateScrollWheelEvent.return_value = new_event
+
+        result = hook._event_tap_callback(
+            None, self._kCGEventScrollWheel, cg_event, None)
+
+        self.assertIsNone(result)
+        create_args = self.mock_quartz.CGEventCreateScrollWheelEvent.call_args
+        # delta2 passed to CGEventCreateScrollWheelEvent should be negated (-1 line)
+        self.assertEqual(create_args.args[4], -1)
+        # And the explicit axis-2 set calls should also use negated values.
+        axis2_fixed_calls = [
+            c for c in self.mock_quartz.CGEventSetIntegerValueField.call_args_list
+            if c.args[0] is new_event
+            and c.args[1] == self._AXIS2_FIXED
+        ]
+        self.assertEqual(len(axis2_fixed_calls), 1)
+        self.assertEqual(axis2_fixed_calls[0].args[2], -65536)
+
+    def test_invert_hscroll_off_preserves_translated_direction(self):
+        """Default (invert_hscroll=False) keeps the original sign on translation."""
+        hook = self._make_hook()
+        hook.invert_hscroll = False
+        cg_event = MagicMock(name="cg_event")
+        self.mock_quartz.CGEventGetIntegerValueField.side_effect = \
+            self._field_getter(v_line=1, v_fixed=65536, v_point=10)
+        self.mock_quartz.CGEventGetFlags.return_value = (
+            self._kCGEventFlagMaskShift)
+        new_event = MagicMock(name="translated_event")
+        self.mock_quartz.CGEventCreateScrollWheelEvent.return_value = new_event
+
+        hook._event_tap_callback(
+            None, self._kCGEventScrollWheel, cg_event, None)
+
+        create_args = self.mock_quartz.CGEventCreateScrollWheelEvent.call_args
+        self.assertEqual(create_args.args[4], 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mouse_hook.py
+++ b/tests/test_mouse_hook.py
@@ -12,7 +12,8 @@ from core.mouse_hook_types import HidRuntimeState
 
 
 class _FakeEvdevDevice:
-    def __init__(self, *, name, path, vendor, capabilities, product=0, fd=11):
+    def __init__(self, *, name, path, vendor, capabilities, product=0, fd=11,
+                 active_keys=()):
         self.name = name
         self.path = path
         self.fd = fd
@@ -23,6 +24,7 @@ class _FakeEvdevDevice:
             bustype=0x03,
         )
         self._capabilities = capabilities
+        self._active_keys = list(active_keys)
         self.grab = Mock()
         self.ungrab = Mock()
         self.close = Mock()
@@ -30,6 +32,12 @@ class _FakeEvdevDevice:
 
     def capabilities(self, absinfo=False):
         return self._capabilities
+
+    def active_keys(self, verbose=False):
+        return list(self._active_keys)
+
+    def set_active_keys(self, keys):
+        self._active_keys = list(keys)
 
 
 class _CapturingListener:
@@ -61,11 +69,15 @@ class _FakeLinuxEcodes:
     REL_Y = 0x01
     REL_WHEEL = 0x08
     REL_HWHEEL = 0x06
+    REL_WHEEL_HI_RES = 0x0B
+    REL_HWHEEL_HI_RES = 0x0C
     BTN_LEFT = 0x110
     BTN_RIGHT = 0x111
     BTN_MIDDLE = 0x112
     BTN_SIDE = 0x113
     BTN_EXTRA = 0x114
+    KEY_LEFTSHIFT = 42
+    KEY_RIGHTSHIFT = 54
 
 
 class _FakeLinuxUInput:
@@ -824,6 +836,214 @@ class LinuxMouseHookReconnectTests(unittest.TestCase):
                 module.MouseEvent.MODE_SHIFT_UP,
             ],
         )
+
+
+class LinuxShiftWheelHScrollTests(unittest.TestCase):
+    """Verify Linux REL_WHEEL is translated to REL_HWHEEL when Shift is held."""
+
+    def _reload_for_linux(self):
+        fake_evdev = SimpleNamespace(
+            ecodes=_FakeLinuxEcodes,
+            UInput=_FakeLinuxUInput,
+            InputDevice=Mock(name="InputDevice"),
+        )
+        with (
+            patch.object(sys, "platform", "linux"),
+            patch.dict(sys.modules, {"evdev": fake_evdev}),
+        ):
+            sys.modules.pop("core.mouse_hook_linux", None)
+            if hasattr(core, "mouse_hook_linux"):
+                delattr(core, "mouse_hook_linux")
+            importlib.import_module("core.mouse_hook_linux")
+            importlib.reload(mouse_hook)
+
+        def cleanup():
+            sys.modules.pop("core.mouse_hook_linux", None)
+            if hasattr(core, "mouse_hook_linux"):
+                delattr(core, "mouse_hook_linux")
+            importlib.reload(mouse_hook)
+
+        self.addCleanup(cleanup)
+        return mouse_hook
+
+    def _make_keyboard(self, *, path="/dev/input/event5", active_keys=()):
+        ecodes = _FakeLinuxEcodes
+        return _FakeEvdevDevice(
+            name="Fake Keyboard",
+            path=path,
+            vendor=0x1234,
+            capabilities={
+                ecodes.EV_KEY: [
+                    ecodes.KEY_LEFTSHIFT,
+                    ecodes.KEY_RIGHTSHIFT,
+                ],
+            },
+            active_keys=active_keys,
+        )
+
+    def _install_hook(self, module, *, keyboards, mouse_hi_res=False):
+        ecodes = module._ecodes
+        rel_caps = [ecodes.REL_X, ecodes.REL_Y, ecodes.REL_WHEEL, ecodes.REL_HWHEEL]
+        if mouse_hi_res:
+            rel_caps.extend([ecodes.REL_WHEEL_HI_RES, ecodes.REL_HWHEEL_HI_RES])
+        mouse = _FakeEvdevDevice(
+            name="MX Master 3S",
+            path="/dev/input/event1",
+            vendor=module._LOGI_VENDOR,
+            capabilities={
+                ecodes.EV_REL: rel_caps,
+                ecodes.EV_KEY: [
+                    ecodes.BTN_LEFT,
+                    ecodes.BTN_RIGHT,
+                    ecodes.BTN_MIDDLE,
+                ],
+            },
+        )
+        devices_by_path = {kb.path: kb for kb in keyboards}
+        devices_by_path[mouse.path] = mouse
+        fake_evdev_mod = SimpleNamespace(
+            list_devices=lambda: list(devices_by_path)
+        )
+
+        def fake_input_device(path):
+            return devices_by_path[path]
+
+        hook = module.MouseHook()
+        hook._evdev_device = mouse
+        hook._uinput = _FakeLinuxUInput()
+        hook._set_evdev_remap_ready(True)
+        patches = (
+            patch.object(module, "_evdev_mod", fake_evdev_mod),
+            patch.object(module, "_InputDevice", side_effect=fake_input_device),
+        )
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        return hook, mouse
+
+    def _make_rel_event(self, code, value):
+        return SimpleNamespace(type=_FakeLinuxEcodes.EV_REL, code=code, value=value)
+
+    def test_keyboard_devices_with_shift_are_opened(self):
+        module = self._reload_for_linux()
+        ecodes = module._ecodes
+        keyboard = self._make_keyboard()
+        non_keyboard = _FakeEvdevDevice(
+            name="Random Sensor",
+            path="/dev/input/event9",
+            vendor=0x0000,
+            capabilities={ecodes.EV_KEY: [ecodes.BTN_LEFT]},
+        )
+        hook, _ = self._install_hook(module, keyboards=[keyboard])
+        # Add the non-keyboard candidate alongside the keyboard.
+        fake_paths = {
+            "/dev/input/event5": keyboard,
+            "/dev/input/event9": non_keyboard,
+            "/dev/input/event1": hook._evdev_device,
+        }
+        with (
+            patch.object(
+                module, "_evdev_mod",
+                SimpleNamespace(list_devices=lambda: list(fake_paths)),
+            ),
+            patch.object(
+                module, "_InputDevice", side_effect=lambda p: fake_paths[p],
+            ),
+        ):
+            hook._ensure_keyboard_devices()
+
+        self.assertIn(keyboard, hook._keyboard_devices)
+        self.assertNotIn(non_keyboard, hook._keyboard_devices)
+        self.assertTrue(non_keyboard.close.called)
+
+    def test_shift_held_reflects_active_keys(self):
+        module = self._reload_for_linux()
+        ecodes = module._ecodes
+        keyboard = self._make_keyboard(active_keys=[ecodes.KEY_LEFTSHIFT])
+        hook, _ = self._install_hook(module, keyboards=[keyboard])
+        hook._ensure_keyboard_devices()
+
+        self.assertTrue(hook._shift_held())
+
+        keyboard.set_active_keys([])
+        self.assertFalse(hook._shift_held())
+
+        keyboard.set_active_keys([ecodes.KEY_RIGHTSHIFT])
+        self.assertTrue(hook._shift_held())
+
+    def test_rel_wheel_with_shift_translates_to_hwheel(self):
+        module = self._reload_for_linux()
+        ecodes = module._ecodes
+        keyboard = self._make_keyboard(active_keys=[ecodes.KEY_LEFTSHIFT])
+        hook, _ = self._install_hook(module, keyboards=[keyboard])
+        hook._ensure_keyboard_devices()
+
+        event = self._make_rel_event(ecodes.REL_WHEEL, 1)
+        hook._handle_rel(event)
+
+        hook._uinput.write.assert_called_once_with(
+            ecodes.EV_REL, ecodes.REL_HWHEEL, 1
+        )
+        hook._uinput.write_event.assert_not_called()
+
+    def test_rel_wheel_without_shift_passes_through(self):
+        module = self._reload_for_linux()
+        ecodes = module._ecodes
+        keyboard = self._make_keyboard(active_keys=[])
+        hook, _ = self._install_hook(module, keyboards=[keyboard])
+        hook._ensure_keyboard_devices()
+
+        event = self._make_rel_event(ecodes.REL_WHEEL, 1)
+        hook._handle_rel(event)
+
+        hook._uinput.write_event.assert_called_once_with(event)
+        hook._uinput.write.assert_not_called()
+
+    def test_invert_hscroll_flips_translated_direction(self):
+        module = self._reload_for_linux()
+        ecodes = module._ecodes
+        keyboard = self._make_keyboard(active_keys=[ecodes.KEY_LEFTSHIFT])
+        hook, _ = self._install_hook(module, keyboards=[keyboard])
+        hook.invert_hscroll = True
+        hook._ensure_keyboard_devices()
+
+        event = self._make_rel_event(ecodes.REL_WHEEL, 2)
+        hook._handle_rel(event)
+
+        hook._uinput.write.assert_called_once_with(
+            ecodes.EV_REL, ecodes.REL_HWHEEL, -2
+        )
+
+    def test_rel_wheel_hi_res_with_shift_is_suppressed(self):
+        module = self._reload_for_linux()
+        ecodes = module._ecodes
+        keyboard = self._make_keyboard(active_keys=[ecodes.KEY_LEFTSHIFT])
+        hook, _ = self._install_hook(module, keyboards=[keyboard], mouse_hi_res=True)
+        hook._ensure_keyboard_devices()
+
+        event = self._make_rel_event(ecodes.REL_WHEEL_HI_RES, 60)
+        hook._handle_rel(event)
+
+        hook._uinput.write.assert_not_called()
+        hook._uinput.write_event.assert_not_called()
+
+    def test_filtered_uinput_events_always_adds_rel_hwheel(self):
+        module = self._reload_for_linux()
+        ecodes = module._ecodes
+        hook = module.MouseHook()
+        dev_no_tilt = _FakeEvdevDevice(
+            name="Basic Mouse",
+            path="/dev/input/event2",
+            vendor=module._LOGI_VENDOR,
+            capabilities={
+                ecodes.EV_REL: [ecodes.REL_X, ecodes.REL_Y, ecodes.REL_WHEEL],
+                ecodes.EV_KEY: [ecodes.BTN_LEFT, ecodes.BTN_RIGHT, ecodes.BTN_MIDDLE],
+            },
+        )
+
+        events = hook._filtered_uinput_events(dev_no_tilt)
+
+        self.assertIn(ecodes.REL_HWHEEL, events[ecodes.EV_REL])
 
 
 @unittest.skipUnless(sys.platform == "darwin", "macOS-only tests")


### PR DESCRIPTION
## Summary

Hold Shift while turning the mouse wheel to scroll horizontally in every app — on macOS, Windows, and Linux. Each platform implements the translation in its own mouse hook so the behavior is consistent across the trio.

## Why

The OS doesn't translate Shift+wheel to horizontal scroll system-wide — only some apps (mostly browsers) do it themselves. With Mouser active, the user-expected "Shift+wheel = horizontal scroll" behavior is now consistent across every app.

## Behavior

- Only triggers on a real vertical wheel event with Shift held — a hardware horizontal tilt-wheel still goes through the existing `HSCROLL_LEFT/RIGHT` dispatch path untouched.
- Trackpad / continuous scroll events are not affected.
- Direction is controlled by the existing **Invert horizontal scroll** setting (`invert_hscroll`), so no new UI is required.

## Per-platform implementation

### macOS (`core/mouse_hook_macos.py`)

- New `_SHIFT_WHEEL_HSCROLL_MARKER` so the synthetic horizontal scroll we post passes through our own CGEventTap on re-entry without being reprocessed.
- New `_post_shift_hscroll_event` helper copies axis-1 (vertical) deltas onto axis-2 (horizontal), zeros axis-1, copies scroll/momentum phases, and strips the Shift modifier from the new event's flags so apps that already do their own Shift+scroll translation (browsers, NSScrollView) don't double-translate.

### Windows (`core/mouse_hook_windows.py`)

- New `WM_APP_INJECT_SHIFT_HSCROLL` deferred-injection message, mirroring the existing `WM_APP_INJECT_HSCROLL` invert path.
- `GetAsyncKeyState(VK_SHIFT)` is queried in the LL hook for every `WM_MOUSEWHEEL`; if Shift is held the original is blocked and a `MOUSEEVENTF_HWHEEL` is queued for the raw-input window thread to inject via `SendInput`.

### Linux (`core/mouse_hook_linux.py`)

- Opens keyboard evdev devices (read-only, no grab) on first use to query `active_keys()` for `KEY_LEFTSHIFT` / `KEY_RIGHTSHIFT`.
- In `_handle_rel`, when Shift is held during `REL_WHEEL`, writes a translated `REL_HWHEEL` on the virtual mouse and swallows the original vertical scroll; matching `REL_WHEEL_HI_RES` events are also suppressed so vertical scroll doesn't double-fire.
- The virtual uinput device always exposes `REL_HWHEEL` so the translation works even on basic mice without a tilt wheel.

## Test plan

- [x] `python -m py_compile main_qml.py core/*.py ui/*.py` — passes
- [x] `python -m unittest discover -s tests -p "test_*.py"` — 510 passed, 1 skipped (existing skip)
- [x] New `MacOSShiftWheelHScrollTests` (7 cases) — translation, Shift stripping, marker passthrough, no-Shift / tilt-wheel no-ops, `invert_hscroll` both directions.
- [x] New `LinuxShiftWheelHScrollTests` (7 cases) — keyboard discovery, `_shift_held` state, REL_WHEEL→REL_HWHEEL translation, passthrough without Shift, `invert_hscroll` direction, hi-res suppression, virtual-uinput REL_HWHEEL injection.
- [x] Manual macOS verification by the author: Shift+wheel scrolls horizontally system-wide; toggling **Invert horizontal scroll** flips the direction.
- [ ] Windows / Linux manual verification — the Windows hook lacks a unit-test harness in this repo (existing pattern), so the change is best confirmed on hardware before merging.

## Notes

- No config schema change.
- Keyboard discovery on Linux is one-shot and best-effort; if a keyboard is hot-plugged after start, it won't participate in Shift detection until the hook restarts. Acceptable for a first pass.
