### PR TITLE
fix(app-detection): match macOS nested app identities

### DIFF
--- a/core/app_detector.py
+++ b/core/app_detector.py
@@ -12,7 +12,7 @@ import sys
 import threading
 import time
 
-AppIdentity = str | tuple[str, ...]
+AppIdentity = tuple[str, ...]
 
 
 def _path_from_nsurl(url) -> str | None:
@@ -236,24 +236,24 @@ if sys.platform == "win32":
         user32.EnumWindows(WNDENUMPROC(_enum_cb), 0)
         return result[0]
 
-    def _get_foreground_app_identity() -> str | None:
-        """Return the foreground app path on Windows, or None."""
+    def _get_foreground_app_identity() -> AppIdentity:
+        """Return the foreground app path on Windows, or an empty tuple."""
         hwnd = user32.GetForegroundWindow()
         if not hwnd:
-            return None
+            return ()
         pid = wt.DWORD()
         user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
         if pid.value == 0:
-            return None
+            return ()
         exe_path = _path_from_pid(pid.value)
         if not exe_path:
-            return None
+            return ()
         exe_lower = os.path.basename(exe_path).lower()
         if exe_lower == "applicationframehost.exe":
             real = _resolve_uwp_child(hwnd)
-            # If we can't resolve the real app (e.g. fullscreen UWP),
-            # return None so the detector keeps the last known profile.
-            return real
+            # If we can't resolve the real app (e.g. fullscreen UWP), return
+            # an empty tuple so the detector keeps the last known profile.
+            return (real,) if real else ()
         if exe_lower == "explorer.exe":
             wc = _get_window_class(hwnd)
             if wc not in _EXPLORER_CLASSES:
@@ -261,10 +261,10 @@ if sys.platform == "win32":
                 print(f"[AppDetect] FG: explorer.exe class={wc} title='{title}'")
                 real = _resolve_uwp_child(hwnd)
                 if real:
-                    return real
+                    return (real,)
                 real = _find_uwp_app_global()
-                return real  # None keeps last profile
-        return exe_path
+                return (real,) if real else ()
+        return (exe_path,)
 
 elif sys.platform == "darwin":
     try:
@@ -283,17 +283,16 @@ elif sys.platform == "darwin":
         return wrapper
 
     @_autoreleased
-    def _get_foreground_app_identity() -> tuple[str, ...] | None:
+    def _get_foreground_app_identity() -> AppIdentity:
         """Return stable frontmost app identities on macOS."""
         try:
             from AppKit import NSWorkspace
             app = NSWorkspace.sharedWorkspace().frontmostApplication()
             if app is None:
-                return None
-            identities = _macos_running_app_identities(app)
-            return identities or None
+                return ()
+            return _macos_running_app_identities(app)
         except Exception:
-            return None
+            return ()
 
 elif sys.platform == "linux":
     import subprocess as _subprocess
@@ -333,40 +332,44 @@ elif sys.platform == "linux":
             pass
         return None
 
-    def _get_foreground_app_identity() -> str | None:
+    def _get_foreground_app_identity() -> AppIdentity:
         """Return the foreground app executable path on Linux."""
         if _WAYLAND:
             if _KDE:
                 exe = _get_foreground_kdotool()
                 if exe:
-                    return exe
+                    return (exe,)
                 # Fall back to xdotool so XWayland apps still work when
                 # kdotool is unavailable or cannot resolve the active window.
-                return _get_foreground_xdotool()
+                exe = _get_foreground_xdotool()
+                return (exe,) if exe else ()
             # GNOME / other Wayland compositors: not yet supported
-            return None
-        return _get_foreground_xdotool()
+            return ()
+        exe = _get_foreground_xdotool()
+        return (exe,) if exe else ()
 
 else:
-    def _get_foreground_app_identity() -> str | None:
-        return None
+    def _get_foreground_app_identity() -> AppIdentity:
+        return ()
 
 
-def get_foreground_app_identity() -> AppIdentity | None:
+def get_foreground_app_identity() -> AppIdentity:
     """
     Return the foreground app identity used for profile matching.
 
-    Most platforms return one stable identifier. macOS may return an ordered
-    tuple, from the most-specific nested app identity to broader host app
-    identities, so embedded app windows can match their own profile first and
-    fall back to the host app profile.
+    An empty tuple means no foreground app could be resolved. Most platforms
+    return a single-item tuple. macOS may return an ordered tuple, from the
+    most-specific nested app identity to broader host app identities, so
+    embedded app windows can match their own profile first and fall back to the
+    host app profile.
     """
     return _get_foreground_app_identity()
 
 
-def get_foreground_exe() -> AppIdentity | None:
+def get_foreground_exe() -> str | None:
     """Compatibility wrapper for callers/tests using the historical name."""
-    return get_foreground_app_identity()
+    identities = get_foreground_app_identity()
+    return identities[0] if identities else None
 
 
 class AppDetector:
@@ -378,7 +381,7 @@ class AppDetector:
     def __init__(self, on_change, interval: float = 0.3):
         self._on_change = on_change
         self._interval = interval
-        self._last_app_identity_key: tuple[str | None, ...] | None = None
+        self._last_app_identity: AppIdentity | None = None
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -399,13 +402,8 @@ class AppDetector:
         while not self._stop.is_set():
             try:
                 app_identity = get_foreground_app_identity()
-                key = (
-                    tuple(app_identity)
-                    if isinstance(app_identity, (list, tuple))
-                    else (app_identity,)
-                )
-                if app_identity and key != self._last_app_identity_key:
-                    self._last_app_identity_key = key
+                if app_identity and app_identity != self._last_app_identity:
+                    self._last_app_identity = app_identity
                     self._on_change(app_identity)
             except Exception:
                 pass

--- a/core/app_detector.py
+++ b/core/app_detector.py
@@ -238,7 +238,7 @@ if sys.platform == "win32":
         user32.EnumWindows(WNDENUMPROC(_enum_cb), 0)
         return result[0]
 
-    def _get_foreground_app_identity() -> tuple[str, ...]:
+    def get_foreground_app_identity() -> tuple[str, ...]:
         """Return the foreground app path on Windows, or an empty tuple."""
         hwnd = user32.GetForegroundWindow()
         if not hwnd:
@@ -285,7 +285,7 @@ elif sys.platform == "darwin":
         return wrapper
 
     @_autoreleased
-    def _get_foreground_app_identity() -> tuple[str, ...]:
+    def get_foreground_app_identity() -> tuple[str, ...]:
         """Return stable frontmost app identities on macOS."""
         try:
             from AppKit import NSWorkspace
@@ -334,7 +334,7 @@ elif sys.platform == "linux":
             pass
         return None
 
-    def _get_foreground_app_identity() -> tuple[str, ...]:
+    def get_foreground_app_identity() -> tuple[str, ...]:
         """Return the foreground app executable path on Linux."""
         if _WAYLAND:
             if _KDE:
@@ -351,27 +351,8 @@ elif sys.platform == "linux":
         return _single_identity(exe)
 
 else:
-    def _get_foreground_app_identity() -> tuple[str, ...]:
+    def get_foreground_app_identity() -> tuple[str, ...]:
         return ()
-
-
-def get_foreground_app_identity() -> tuple[str, ...]:
-    """
-    Return the foreground app identity used for profile matching.
-
-    An empty tuple means no foreground app could be resolved. Most platforms
-    return a single-item tuple. macOS may return an ordered tuple, from the
-    most-specific nested app identity to broader host app identities, so
-    embedded app windows can match their own profile first and fall back to the
-    host app profile.
-    """
-    return _get_foreground_app_identity()
-
-
-def get_foreground_exe() -> str | None:
-    """Compatibility wrapper for callers/tests using the historical name."""
-    identities = get_foreground_app_identity()
-    return identities[0] if identities else None
 
 
 class AppDetector:

--- a/core/app_detector.py
+++ b/core/app_detector.py
@@ -12,6 +12,8 @@ import sys
 import threading
 import time
 
+AppIdentity = str | tuple[str, ...]
+
 
 def _path_from_nsurl(url) -> str | None:
     if url is None:
@@ -32,19 +34,38 @@ def _call_ns_method(obj, name: str):
         return None
 
 
-def _outer_macos_app_bundle(path: str | None) -> str | None:
-    """Return the outermost .app bundle for a path inside a macOS app."""
+def _dedupe_keep_order(values) -> tuple[str, ...]:
+    result = []
+    seen = set()
+    for value in values:
+        if value is None:
+            continue
+        text = str(value)
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(text)
+    return tuple(result)
+
+
+def _macos_app_bundles_in_path(path: str | None) -> tuple[str, ...]:
+    """Return containing .app bundles ordered inner-most to outer-most."""
     if not path:
-        return None
+        return ()
 
     normalized = os.path.abspath(path)
     parts = normalized.split(os.sep)
+    bundles = []
     for idx, part in enumerate(parts):
         if part.endswith(".app"):
             if normalized.startswith(os.sep):
-                return os.path.join(os.sep, *parts[1:idx + 1])
-            return os.path.join(*parts[:idx + 1])
-    return normalized if normalized.endswith(".app") else None
+                bundles.append(os.path.join(os.sep, *parts[1:idx + 1]))
+            else:
+                bundles.append(os.path.join(*parts[:idx + 1]))
+    return tuple(reversed(bundles))
 
 
 @functools.lru_cache(maxsize=256)
@@ -61,33 +82,40 @@ def _read_macos_bundle_identifier(app_path: str | None) -> str | None:
         return None
 
 
-def _macos_running_app_identity(app) -> str | None:
-    """Return the profile-matching identity for an NSRunningApplication."""
+def _macos_running_app_identities(app) -> tuple[str, ...]:
+    """Return profile-matching identities, ordered most-specific first."""
     bundle_path = _path_from_nsurl(_call_ns_method(app, "bundleURL"))
-    outer_bundle_path = _outer_macos_app_bundle(bundle_path)
-    outer_ident = _read_macos_bundle_identifier(outer_bundle_path)
-    if outer_ident:
-        return outer_ident
-
-    ident = _call_ns_method(app, "bundleIdentifier")
-    if ident:
-        return str(ident)
-
     executable_path = _path_from_nsurl(_call_ns_method(app, "executableURL"))
-    outer_executable_bundle = _outer_macos_app_bundle(executable_path)
-    outer_executable_ident = _read_macos_bundle_identifier(outer_executable_bundle)
-    if outer_executable_ident:
-        return outer_executable_ident
-    if outer_executable_bundle:
-        return outer_executable_bundle
-    if executable_path:
-        return os.path.basename(executable_path)
+    ident = _call_ns_method(app, "bundleIdentifier")
     localized_name = _call_ns_method(app, "localizedName")
-    return str(localized_name) if localized_name else None
+
+    identities = []
+    if ident:
+        identities.append(str(ident))
+
+    bundles = _dedupe_keep_order([
+        *_macos_app_bundles_in_path(bundle_path),
+        *_macos_app_bundles_in_path(executable_path),
+    ])
+    for app_path in bundles:
+        bundle_ident = _read_macos_bundle_identifier(app_path)
+        if bundle_ident:
+            identities.append(bundle_ident)
+        identities.append(app_path)
+        identities.append(os.path.basename(app_path))
+        identities.append(os.path.splitext(os.path.basename(app_path))[0])
+
+    if executable_path:
+        identities.append(executable_path)
+        identities.append(os.path.basename(executable_path))
+    if localized_name:
+        identities.append(str(localized_name))
+
+    return _dedupe_keep_order(identities)
 
 
 # ==================================================================
-# Platform-specific get_foreground_exe()
+# Platform-specific foreground app identity resolution
 # ==================================================================
 
 if sys.platform == "win32":
@@ -208,7 +236,7 @@ if sys.platform == "win32":
         user32.EnumWindows(WNDENUMPROC(_enum_cb), 0)
         return result[0]
 
-    def get_foreground_exe() -> str | None:
+    def _get_foreground_app_identity() -> str | None:
         """Return the foreground app path on Windows, or None."""
         hwnd = user32.GetForegroundWindow()
         if not hwnd:
@@ -255,14 +283,15 @@ elif sys.platform == "darwin":
         return wrapper
 
     @_autoreleased
-    def get_foreground_exe() -> str | None:
-        """Return a stable app identifier for the frontmost app on macOS."""
+    def _get_foreground_app_identity() -> tuple[str, ...] | None:
+        """Return stable frontmost app identities on macOS."""
         try:
             from AppKit import NSWorkspace
             app = NSWorkspace.sharedWorkspace().frontmostApplication()
             if app is None:
                 return None
-            return _macos_running_app_identity(app)
+            identities = _macos_running_app_identities(app)
+            return identities or None
         except Exception:
             return None
 
@@ -304,7 +333,7 @@ elif sys.platform == "linux":
             pass
         return None
 
-    def get_foreground_exe() -> str | None:
+    def _get_foreground_app_identity() -> str | None:
         """Return the foreground app executable path on Linux."""
         if _WAYLAND:
             if _KDE:
@@ -319,20 +348,37 @@ elif sys.platform == "linux":
         return _get_foreground_xdotool()
 
 else:
-    def get_foreground_exe() -> str | None:
+    def _get_foreground_app_identity() -> str | None:
         return None
+
+
+def get_foreground_app_identity() -> AppIdentity | None:
+    """
+    Return the foreground app identity used for profile matching.
+
+    Most platforms return one stable identifier. macOS may return an ordered
+    tuple, from the most-specific nested app identity to broader host app
+    identities, so embedded app windows can match their own profile first and
+    fall back to the host app profile.
+    """
+    return _get_foreground_app_identity()
+
+
+def get_foreground_exe() -> AppIdentity | None:
+    """Compatibility wrapper for callers/tests using the historical name."""
+    return get_foreground_app_identity()
 
 
 class AppDetector:
     """
     Polls the foreground window every *interval* seconds.
-    Calls ``on_change(exe_name: str)`` when the foreground app changes.
+    Calls ``on_change(app_identity)`` when the foreground app changes.
     """
 
     def __init__(self, on_change, interval: float = 0.3):
         self._on_change = on_change
         self._interval = interval
-        self._last_exe: str | None = None
+        self._last_app_identity_key: tuple[str | None, ...] | None = None
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -352,10 +398,15 @@ class AppDetector:
     def _poll(self):
         while not self._stop.is_set():
             try:
-                exe = get_foreground_exe()
-                if exe and exe != self._last_exe:
-                    self._last_exe = exe
-                    self._on_change(exe)
+                app_identity = get_foreground_app_identity()
+                key = (
+                    tuple(app_identity)
+                    if isinstance(app_identity, (list, tuple))
+                    else (app_identity,)
+                )
+                if app_identity and key != self._last_app_identity_key:
+                    self._last_app_identity_key = key
+                    self._on_change(app_identity)
             except Exception:
                 pass
             self._stop.wait(self._interval)

--- a/core/app_detector.py
+++ b/core/app_detector.py
@@ -5,10 +5,85 @@ Windows: GetForegroundWindow + QueryFullProcessImageNameW (with UWP resolution).
 macOS:   NSWorkspace.sharedWorkspace().frontmostApplication().
 """
 
+import functools
 import os
+import plistlib
 import sys
 import threading
 import time
+
+
+def _path_from_nsurl(url) -> str | None:
+    if url is None:
+        return None
+    try:
+        path_attr = getattr(url, "path", None)
+        path = path_attr() if callable(path_attr) else path_attr
+        return str(path) if path else None
+    except Exception:
+        return None
+
+
+def _call_ns_method(obj, name: str):
+    try:
+        attr = getattr(obj, name, None)
+        return attr() if callable(attr) else attr
+    except Exception:
+        return None
+
+
+def _outer_macos_app_bundle(path: str | None) -> str | None:
+    """Return the outermost .app bundle for a path inside a macOS app."""
+    if not path:
+        return None
+
+    normalized = os.path.abspath(path)
+    parts = normalized.split(os.sep)
+    for idx, part in enumerate(parts):
+        if part.endswith(".app"):
+            if normalized.startswith(os.sep):
+                return os.path.join(os.sep, *parts[1:idx + 1])
+            return os.path.join(*parts[:idx + 1])
+    return normalized if normalized.endswith(".app") else None
+
+
+@functools.lru_cache(maxsize=256)
+def _read_macos_bundle_identifier(app_path: str | None) -> str | None:
+    if not app_path:
+        return None
+    info_path = os.path.join(app_path, "Contents", "Info.plist")
+    try:
+        with open(info_path, "rb") as f:
+            info = plistlib.load(f)
+        ident = info.get("CFBundleIdentifier")
+        return str(ident) if ident else None
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _macos_running_app_identity(app) -> str | None:
+    """Return the profile-matching identity for an NSRunningApplication."""
+    bundle_path = _path_from_nsurl(_call_ns_method(app, "bundleURL"))
+    outer_bundle_path = _outer_macos_app_bundle(bundle_path)
+    outer_ident = _read_macos_bundle_identifier(outer_bundle_path)
+    if outer_ident:
+        return outer_ident
+
+    ident = _call_ns_method(app, "bundleIdentifier")
+    if ident:
+        return str(ident)
+
+    executable_path = _path_from_nsurl(_call_ns_method(app, "executableURL"))
+    outer_executable_bundle = _outer_macos_app_bundle(executable_path)
+    outer_executable_ident = _read_macos_bundle_identifier(outer_executable_bundle)
+    if outer_executable_ident:
+        return outer_executable_ident
+    if outer_executable_bundle:
+        return outer_executable_bundle
+    if executable_path:
+        return os.path.basename(executable_path)
+    localized_name = _call_ns_method(app, "localizedName")
+    return str(localized_name) if localized_name else None
 
 
 # ==================================================================
@@ -164,8 +239,6 @@ if sys.platform == "win32":
         return exe_path
 
 elif sys.platform == "darwin":
-    import functools
-
     try:
         import objc as _objc
     except ImportError as exc:
@@ -189,13 +262,7 @@ elif sys.platform == "darwin":
             app = NSWorkspace.sharedWorkspace().frontmostApplication()
             if app is None:
                 return None
-            ident = app.bundleIdentifier()
-            if ident:
-                return ident
-            url = app.executableURL()
-            if url:
-                return os.path.basename(url.path())
-            return app.localizedName()
+            return _macos_running_app_identity(app)
         except Exception:
             return None
 

--- a/core/app_detector.py
+++ b/core/app_detector.py
@@ -12,8 +12,6 @@ import sys
 import threading
 import time
 
-AppIdentity = tuple[str, ...]
-
 
 def _path_from_nsurl(url) -> str | None:
     if url is None:
@@ -49,6 +47,10 @@ def _dedupe_keep_order(values) -> tuple[str, ...]:
         seen.add(key)
         result.append(text)
     return tuple(result)
+
+
+def _single_identity(value: str | None) -> tuple[str, ...]:
+    return (value,) if value else ()
 
 
 def _macos_app_bundles_in_path(path: str | None) -> tuple[str, ...]:
@@ -236,7 +238,7 @@ if sys.platform == "win32":
         user32.EnumWindows(WNDENUMPROC(_enum_cb), 0)
         return result[0]
 
-    def _get_foreground_app_identity() -> AppIdentity:
+    def _get_foreground_app_identity() -> tuple[str, ...]:
         """Return the foreground app path on Windows, or an empty tuple."""
         hwnd = user32.GetForegroundWindow()
         if not hwnd:
@@ -253,7 +255,7 @@ if sys.platform == "win32":
             real = _resolve_uwp_child(hwnd)
             # If we can't resolve the real app (e.g. fullscreen UWP), return
             # an empty tuple so the detector keeps the last known profile.
-            return (real,) if real else ()
+            return _single_identity(real)
         if exe_lower == "explorer.exe":
             wc = _get_window_class(hwnd)
             if wc not in _EXPLORER_CLASSES:
@@ -261,10 +263,10 @@ if sys.platform == "win32":
                 print(f"[AppDetect] FG: explorer.exe class={wc} title='{title}'")
                 real = _resolve_uwp_child(hwnd)
                 if real:
-                    return (real,)
+                    return _single_identity(real)
                 real = _find_uwp_app_global()
-                return (real,) if real else ()
-        return (exe_path,)
+                return _single_identity(real)
+        return _single_identity(exe_path)
 
 elif sys.platform == "darwin":
     try:
@@ -283,7 +285,7 @@ elif sys.platform == "darwin":
         return wrapper
 
     @_autoreleased
-    def _get_foreground_app_identity() -> AppIdentity:
+    def _get_foreground_app_identity() -> tuple[str, ...]:
         """Return stable frontmost app identities on macOS."""
         try:
             from AppKit import NSWorkspace
@@ -332,28 +334,28 @@ elif sys.platform == "linux":
             pass
         return None
 
-    def _get_foreground_app_identity() -> AppIdentity:
+    def _get_foreground_app_identity() -> tuple[str, ...]:
         """Return the foreground app executable path on Linux."""
         if _WAYLAND:
             if _KDE:
                 exe = _get_foreground_kdotool()
                 if exe:
-                    return (exe,)
+                    return _single_identity(exe)
                 # Fall back to xdotool so XWayland apps still work when
                 # kdotool is unavailable or cannot resolve the active window.
                 exe = _get_foreground_xdotool()
-                return (exe,) if exe else ()
+                return _single_identity(exe)
             # GNOME / other Wayland compositors: not yet supported
             return ()
         exe = _get_foreground_xdotool()
-        return (exe,) if exe else ()
+        return _single_identity(exe)
 
 else:
-    def _get_foreground_app_identity() -> AppIdentity:
+    def _get_foreground_app_identity() -> tuple[str, ...]:
         return ()
 
 
-def get_foreground_app_identity() -> AppIdentity:
+def get_foreground_app_identity() -> tuple[str, ...]:
     """
     Return the foreground app identity used for profile matching.
 
@@ -381,7 +383,7 @@ class AppDetector:
     def __init__(self, on_change, interval: float = 0.3):
         self._on_change = on_change
         self._interval = interval
-        self._last_app_identity: AppIdentity | None = None
+        self._last_app_identity: tuple[str, ...] | None = None
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 

--- a/core/config.py
+++ b/core/config.py
@@ -11,7 +11,7 @@ import tempfile
 from urllib.parse import quote
 from core import app_catalog
 
-AppIdentity = str | list[str] | tuple[str, ...]
+AppIdentity = tuple[str, ...]
 
 if sys.platform == "darwin":
     CONFIG_DIR = os.path.join(os.path.expanduser("~"), "Library", "Application Support", "Mouser")
@@ -246,7 +246,7 @@ def resolve_app_for_config(spec: str):
     return app_catalog.resolve_app_spec(spec)
 
 
-def _identity_specs(app_identity: AppIdentity | None) -> list[str]:
+def _identity_specs(app_identity: AppIdentity | str | list[str] | None) -> list[str]:
     if not app_identity:
         return []
     if isinstance(app_identity, str):
@@ -281,8 +281,8 @@ def get_profile_for_app_identity(cfg, app_identity: AppIdentity | None) -> str:
     """
     Return the profile name that matches an app identity, or 'default'.
 
-    ``app_identity`` may be a single identifier/path or an ordered list of
-    identifiers. Ordered identities are matched most-specific first, allowing a
+    ``app_identity`` is an ordered tuple of identifiers. Identifiers are matched
+    most-specific first, allowing a
     nested app profile to win before falling back to its host app profile.
     """
     identities = _identity_specs(app_identity)

--- a/core/config.py
+++ b/core/config.py
@@ -11,6 +11,8 @@ import tempfile
 from urllib.parse import quote
 from core import app_catalog
 
+AppIdentity = str | list[str] | tuple[str, ...]
+
 if sys.platform == "darwin":
     CONFIG_DIR = os.path.join(os.path.expanduser("~"), "Library", "Application Support", "Mouser")
 elif sys.platform == "linux":
@@ -244,7 +246,28 @@ def resolve_app_for_config(spec: str):
     return app_catalog.resolve_app_spec(spec)
 
 
-def _app_identity_aliases(spec: str):
+def _identity_specs(app_identity: AppIdentity | None) -> list[str]:
+    if not app_identity:
+        return []
+    if isinstance(app_identity, str):
+        candidates = [app_identity]
+    elif isinstance(app_identity, (list, tuple)):
+        candidates = [str(item) for item in app_identity if item]
+    else:
+        candidates = [str(app_identity)]
+
+    result = []
+    seen = set()
+    for candidate in candidates:
+        key = candidate.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(candidate)
+    return result
+
+
+def _app_identity_aliases(spec: str) -> set[str]:
     if not spec:
         return set()
     entry = resolve_app_for_config(spec)
@@ -254,16 +277,40 @@ def _app_identity_aliases(spec: str):
     return {alias.casefold() for alias in aliases if alias}
 
 
-def get_profile_for_app(cfg, exe_name):
-    """Return the profile name that matches the given executable, or 'default'."""
-    if not exe_name:
+def get_profile_for_app_identity(cfg, app_identity: AppIdentity | None) -> str:
+    """
+    Return the profile name that matches an app identity, or 'default'.
+
+    ``app_identity`` may be a single identifier/path or an ordered list of
+    identifiers. Ordered identities are matched most-specific first, allowing a
+    nested app profile to win before falling back to its host app profile.
+    """
+    identities = _identity_specs(app_identity)
+    if not identities:
         return "default"
-    aliases = _app_identity_aliases(exe_name)
-    for pname, pdata in cfg.get("profiles", {}).items():
-        for app in pdata.get("apps", []):
-            if aliases & _app_identity_aliases(app):
-                return pname
+
+    alias_cache = {}
+
+    def aliases_for(spec: str) -> set[str]:
+        key = spec.casefold()
+        if key not in alias_cache:
+            alias_cache[key] = _app_identity_aliases(spec)
+        return alias_cache[key]
+
+    profiles = list(cfg.get("profiles", {}).items())
+    for identity in identities:
+        aliases = aliases_for(identity)
+        for pname, pdata in profiles:
+            for app in pdata.get("apps", []):
+                for app_spec in _identity_specs(app):
+                    if aliases & aliases_for(app_spec):
+                        return pname
     return "default"
+
+
+def get_profile_for_app(cfg, exe_name):
+    """Compatibility wrapper for the historical executable-name API."""
+    return get_profile_for_app_identity(cfg, exe_name)
 
 
 def _migrate(cfg):

--- a/core/config.py
+++ b/core/config.py
@@ -244,23 +244,27 @@ def resolve_app_for_config(spec: str):
     return app_catalog.resolve_app_spec(spec)
 
 
-def _identity_specs(app_identity: str | tuple[str, ...] | None) -> list[str]:
-    if not app_identity:
-        return []
-    if isinstance(app_identity, str):
-        candidates = [app_identity]
-    else:
-        candidates = [str(item) for item in app_identity if item]
-
+def _dedupe_specs(candidates) -> list[str]:
     result = []
     seen = set()
     for candidate in candidates:
+        if not candidate:
+            continue
+        candidate = str(candidate)
         key = candidate.casefold()
         if key in seen:
             continue
         seen.add(key)
         result.append(candidate)
     return result
+
+
+def _identity_specs(app_identity: tuple[str, ...] | None) -> list[str]:
+    return _dedupe_specs(app_identity or ())
+
+
+def _configured_app_specs(app_spec: str | None) -> list[str]:
+    return _dedupe_specs((app_spec,) if app_spec else ())
 
 
 def _app_identity_aliases(spec: str) -> set[str]:
@@ -298,7 +302,7 @@ def get_profile_for_app_identity(cfg, app_identity: tuple[str, ...] | None) -> s
         aliases = aliases_for(identity)
         for pname, pdata in profiles:
             for app in pdata.get("apps", []):
-                for app_spec in _identity_specs(app):
+                for app_spec in _configured_app_specs(app):
                     if aliases & aliases_for(app_spec):
                         return pname
     return "default"

--- a/core/config.py
+++ b/core/config.py
@@ -11,8 +11,6 @@ import tempfile
 from urllib.parse import quote
 from core import app_catalog
 
-AppIdentity = tuple[str, ...]
-
 if sys.platform == "darwin":
     CONFIG_DIR = os.path.join(os.path.expanduser("~"), "Library", "Application Support", "Mouser")
 elif sys.platform == "linux":
@@ -246,15 +244,13 @@ def resolve_app_for_config(spec: str):
     return app_catalog.resolve_app_spec(spec)
 
 
-def _identity_specs(app_identity: AppIdentity | str | list[str] | None) -> list[str]:
+def _identity_specs(app_identity: str | tuple[str, ...] | None) -> list[str]:
     if not app_identity:
         return []
     if isinstance(app_identity, str):
         candidates = [app_identity]
-    elif isinstance(app_identity, (list, tuple)):
-        candidates = [str(item) for item in app_identity if item]
     else:
-        candidates = [str(app_identity)]
+        candidates = [str(item) for item in app_identity if item]
 
     result = []
     seen = set()
@@ -277,13 +273,13 @@ def _app_identity_aliases(spec: str) -> set[str]:
     return {alias.casefold() for alias in aliases if alias}
 
 
-def get_profile_for_app_identity(cfg, app_identity: AppIdentity | None) -> str:
+def get_profile_for_app_identity(cfg, app_identity: tuple[str, ...] | None) -> str:
     """
     Return the profile name that matches an app identity, or 'default'.
 
     ``app_identity`` is an ordered tuple of identifiers. Identifiers are matched
-    most-specific first, allowing a
-    nested app profile to win before falling back to its host app profile.
+    most-specific first, allowing a nested app profile to win before falling
+    back to its host app profile.
     """
     identities = _identity_specs(app_identity)
     if not identities:
@@ -306,11 +302,6 @@ def get_profile_for_app_identity(cfg, app_identity: AppIdentity | None) -> str:
                     if aliases & aliases_for(app_spec):
                         return pname
     return "default"
-
-
-def get_profile_for_app(cfg, exe_name):
-    """Compatibility wrapper for the historical executable-name API."""
-    return get_profile_for_app_identity(cfg, exe_name)
 
 
 def _migrate(cfg):

--- a/core/config.py
+++ b/core/config.py
@@ -244,15 +244,24 @@ def resolve_app_for_config(spec: str):
     return app_catalog.resolve_app_spec(spec)
 
 
+def _app_identity_aliases(spec: str):
+    if not spec:
+        return set()
+    entry = resolve_app_for_config(spec)
+    if not entry:
+        return {spec.casefold()}
+    aliases = [entry.get("id", ""), *entry.get("aliases", [])]
+    return {alias.casefold() for alias in aliases if alias}
+
+
 def get_profile_for_app(cfg, exe_name):
     """Return the profile name that matches the given executable, or 'default'."""
     if not exe_name:
         return "default"
-    entry = resolve_app_for_config(exe_name)
-    aliases = {a.lower() for a in ([entry["id"]] + entry.get("aliases", []))} if entry else {exe_name.lower()}
+    aliases = _app_identity_aliases(exe_name)
     for pname, pdata in cfg.get("profiles", {}).items():
         for app in pdata.get("apps", []):
-            if app.lower() in aliases:
+            if aliases & _app_identity_aliases(app):
                 return pname
     return "default"
 

--- a/core/engine.py
+++ b/core/engine.py
@@ -385,10 +385,7 @@ class Engine:
         target = get_profile_for_app_identity(self.cfg, app_identity)
         if target == self._current_profile:
             return
-        if isinstance(app_identity, (list, tuple)):
-            app_label = app_identity[0] if app_identity else ""
-        else:
-            app_label = app_identity
+        app_label = app_identity[0] if app_identity else ""
         print(f"[Engine] App changed to {app_label} -> profile '{target}'")
         self._switch_profile(target)
 

--- a/core/engine.py
+++ b/core/engine.py
@@ -12,7 +12,7 @@ from core.key_simulator import (
     inject_mouse_down, inject_mouse_up,
 )
 from core.config import (
-    load_config, get_active_mappings, get_profile_for_app,
+    load_config, get_active_mappings, get_profile_for_app_identity,
     BUTTON_TO_EVENTS, GESTURE_DIRECTION_BUTTONS, save_config,
 )
 from core.app_detector import AppDetector
@@ -380,12 +380,16 @@ class Engine:
     # ------------------------------------------------------------------
     # Per-app auto-switching
     # ------------------------------------------------------------------
-    def _on_app_change(self, exe_name: str):
+    def _on_app_change(self, app_identity):
         """Called by AppDetector when foreground window changes."""
-        target = get_profile_for_app(self.cfg, exe_name)
+        target = get_profile_for_app_identity(self.cfg, app_identity)
         if target == self._current_profile:
             return
-        print(f"[Engine] App changed to {exe_name} -> profile '{target}'")
+        if isinstance(app_identity, (list, tuple)):
+            app_label = app_identity[0] if app_identity else ""
+        else:
+            app_label = app_identity
+        print(f"[Engine] App changed to {app_label} -> profile '{target}'")
         self._switch_profile(target)
 
     def _switch_profile(self, profile_name: str):

--- a/core/engine.py
+++ b/core/engine.py
@@ -380,7 +380,7 @@ class Engine:
     # ------------------------------------------------------------------
     # Per-app auto-switching
     # ------------------------------------------------------------------
-    def _on_app_change(self, app_identity):
+    def _on_app_change(self, app_identity: tuple[str, ...]):
         """Called by AppDetector when foreground window changes."""
         target = get_profile_for_app_identity(self.cfg, app_identity)
         if target == self._current_profile:

--- a/tests/test_app_detector.py
+++ b/tests/test_app_detector.py
@@ -6,35 +6,33 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-with (
-    patch.object(sys, "platform", "linux"),
-    patch.dict(
-        os.environ,
-        {
-            "XDG_SESSION_TYPE": "x11",
-            "XDG_CURRENT_DESKTOP": "KDE",
-        },
-        clear=False,
-    ),
-):
-    from core import app_detector
+
+def _unload_app_detector():
+    sys.modules.pop("core.app_detector", None)
+    core_module = sys.modules.get("core")
+    if core_module is not None and hasattr(core_module, "app_detector"):
+        delattr(core_module, "app_detector")
+
+
+def _load_app_detector(platform: str, env: dict[str, str] | None = None):
+    _unload_app_detector()
+    with (
+        patch.object(sys, "platform", platform),
+        patch.dict(os.environ, env or {}, clear=False),
+    ):
+        return importlib.import_module("core.app_detector")
 
 
 class AppDetectorLinuxTests(unittest.TestCase):
     def _reload_for_linux(self, session_type: str, desktop: str):
-        with (
-            patch.object(sys, "platform", "linux"),
-            patch.dict(
-                os.environ,
-                {
-                    "XDG_SESSION_TYPE": session_type,
-                    "XDG_CURRENT_DESKTOP": desktop,
-                },
-                clear=False,
-            ),
-        ):
-            importlib.reload(app_detector)
-        return app_detector
+        self.addCleanup(_unload_app_detector)
+        return _load_app_detector(
+            "linux",
+            {
+                "XDG_SESSION_TYPE": session_type,
+                "XDG_CURRENT_DESKTOP": desktop,
+            },
+        )
 
     def test_kde_wayland_prefers_kdotool(self):
         module = self._reload_for_linux("wayland", "KDE")
@@ -72,13 +70,23 @@ class AppDetectorLinuxTests(unittest.TestCase):
 
 
 class AppDetectorMacOSTests(unittest.TestCase):
+    def setUp(self):
+        self.addCleanup(_unload_app_detector)
+        self.module = _load_app_detector(
+            "linux",
+            {
+                "XDG_SESSION_TYPE": "x11",
+                "XDG_CURRENT_DESKTOP": "KDE",
+            },
+        )
+
     def _write_bundle_info(self, app_path: str, bundle_id: str):
         info_dir = os.path.join(app_path, "Contents")
         os.makedirs(info_dir, exist_ok=True)
         with open(os.path.join(info_dir, "Info.plist"), "wb") as f:
             plistlib.dump({"CFBundleIdentifier": bundle_id}, f)
 
-    def test_nested_helper_bundle_resolves_to_outer_app_identity(self):
+    def test_nested_app_identities_include_inner_then_outer_app(self):
         class FakeURL:
             def __init__(self, path):
                 self._path = path
@@ -114,10 +122,19 @@ class AppDetectorMacOSTests(unittest.TestCase):
             self._write_bundle_info(helper_app, "com.example.Editor.helper")
 
             self.assertEqual(
-                app_detector._macos_running_app_identity(
+                self.module._macos_running_app_identities(
                     FakeRunningApplication(helper_app)
                 ),
-                "com.example.Editor",
+                (
+                    "com.example.Editor.helper",
+                    helper_app,
+                    "Editor Helper.app",
+                    "Editor Helper",
+                    "com.example.Editor",
+                    outer_app,
+                    "Editor.app",
+                    "Editor",
+                ),
             )
 
 

--- a/tests/test_app_detector.py
+++ b/tests/test_app_detector.py
@@ -1,10 +1,23 @@
 import importlib
 import os
+import plistlib
 import sys
+import tempfile
 import unittest
 from unittest.mock import patch
 
-from core import app_detector
+with (
+    patch.object(sys, "platform", "linux"),
+    patch.dict(
+        os.environ,
+        {
+            "XDG_SESSION_TYPE": "x11",
+            "XDG_CURRENT_DESKTOP": "KDE",
+        },
+        clear=False,
+    ),
+):
+    from core import app_detector
 
 
 class AppDetectorLinuxTests(unittest.TestCase):
@@ -21,7 +34,6 @@ class AppDetectorLinuxTests(unittest.TestCase):
             ),
         ):
             importlib.reload(app_detector)
-        self.addCleanup(importlib.reload, app_detector)
         return app_detector
 
     def test_kde_wayland_prefers_kdotool(self):
@@ -57,6 +69,56 @@ class AppDetectorLinuxTests(unittest.TestCase):
         with patch.object(module, "_get_foreground_xdotool", return_value="/tmp/x11-app") as xdotool:
             self.assertEqual(module.get_foreground_exe(), "/tmp/x11-app")
             xdotool.assert_called_once_with()
+
+
+class AppDetectorMacOSTests(unittest.TestCase):
+    def _write_bundle_info(self, app_path: str, bundle_id: str):
+        info_dir = os.path.join(app_path, "Contents")
+        os.makedirs(info_dir, exist_ok=True)
+        with open(os.path.join(info_dir, "Info.plist"), "wb") as f:
+            plistlib.dump({"CFBundleIdentifier": bundle_id}, f)
+
+    def test_nested_helper_bundle_resolves_to_outer_app_identity(self):
+        class FakeURL:
+            def __init__(self, path):
+                self._path = path
+
+            def path(self):
+                return self._path
+
+        class FakeRunningApplication:
+            def __init__(self, bundle_path):
+                self._bundle_path = bundle_path
+
+            def bundleURL(self):
+                return FakeURL(self._bundle_path)
+
+            def bundleIdentifier(self):
+                return "com.example.Editor.helper"
+
+            def executableURL(self):
+                return None
+
+            def localizedName(self):
+                return "Editor Helper"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            outer_app = os.path.join(tmp, "Editor.app")
+            helper_app = os.path.join(
+                outer_app,
+                "Contents",
+                "Frameworks",
+                "Editor Helper.app",
+            )
+            self._write_bundle_info(outer_app, "com.example.Editor")
+            self._write_bundle_info(helper_app, "com.example.Editor.helper")
+
+            self.assertEqual(
+                app_detector._macos_running_app_identity(
+                    FakeRunningApplication(helper_app)
+                ),
+                "com.example.Editor",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_app_detector.py
+++ b/tests/test_app_detector.py
@@ -42,7 +42,6 @@ class AppDetectorLinuxTests(unittest.TestCase):
             patch.object(module, "_get_foreground_xdotool", return_value="/tmp/x11-app") as xdotool,
         ):
             self.assertEqual(module.get_foreground_app_identity(), ("/tmp/kde-app",))
-            self.assertEqual(module.get_foreground_exe(), "/tmp/kde-app")
             xdotool.assert_not_called()
 
     def test_kde_wayland_falls_back_to_xdotool(self):
@@ -55,19 +54,11 @@ class AppDetectorLinuxTests(unittest.TestCase):
             self.assertEqual(module.get_foreground_app_identity(), ("/tmp/xwayland-app",))
             xdotool.assert_called_once_with()
 
-        with (
-            patch.object(module, "_get_foreground_kdotool", return_value=None),
-            patch.object(module, "_get_foreground_xdotool", return_value="/tmp/xwayland-app") as xdotool,
-        ):
-            self.assertEqual(module.get_foreground_exe(), "/tmp/xwayland-app")
-            xdotool.assert_called_once_with()
-
     def test_non_kde_wayland_returns_none(self):
         module = self._reload_for_linux("wayland", "GNOME")
 
         with patch.object(module, "_get_foreground_xdotool", return_value="/tmp/x11-app") as xdotool:
             self.assertEqual(module.get_foreground_app_identity(), ())
-            self.assertIsNone(module.get_foreground_exe())
             xdotool.assert_not_called()
 
     def test_x11_uses_xdotool(self):
@@ -75,10 +66,6 @@ class AppDetectorLinuxTests(unittest.TestCase):
 
         with patch.object(module, "_get_foreground_xdotool", return_value="/tmp/x11-app") as xdotool:
             self.assertEqual(module.get_foreground_app_identity(), ("/tmp/x11-app",))
-            xdotool.assert_called_once_with()
-
-        with patch.object(module, "_get_foreground_xdotool", return_value="/tmp/x11-app") as xdotool:
-            self.assertEqual(module.get_foreground_exe(), "/tmp/x11-app")
             xdotool.assert_called_once_with()
 
 

--- a/tests/test_app_detector.py
+++ b/tests/test_app_detector.py
@@ -41,11 +41,19 @@ class AppDetectorLinuxTests(unittest.TestCase):
             patch.object(module, "_get_foreground_kdotool", return_value="/tmp/kde-app"),
             patch.object(module, "_get_foreground_xdotool", return_value="/tmp/x11-app") as xdotool,
         ):
+            self.assertEqual(module.get_foreground_app_identity(), ("/tmp/kde-app",))
             self.assertEqual(module.get_foreground_exe(), "/tmp/kde-app")
             xdotool.assert_not_called()
 
     def test_kde_wayland_falls_back_to_xdotool(self):
         module = self._reload_for_linux("wayland", "KDE")
+
+        with (
+            patch.object(module, "_get_foreground_kdotool", return_value=None),
+            patch.object(module, "_get_foreground_xdotool", return_value="/tmp/xwayland-app") as xdotool,
+        ):
+            self.assertEqual(module.get_foreground_app_identity(), ("/tmp/xwayland-app",))
+            xdotool.assert_called_once_with()
 
         with (
             patch.object(module, "_get_foreground_kdotool", return_value=None),
@@ -58,11 +66,16 @@ class AppDetectorLinuxTests(unittest.TestCase):
         module = self._reload_for_linux("wayland", "GNOME")
 
         with patch.object(module, "_get_foreground_xdotool", return_value="/tmp/x11-app") as xdotool:
+            self.assertEqual(module.get_foreground_app_identity(), ())
             self.assertIsNone(module.get_foreground_exe())
             xdotool.assert_not_called()
 
     def test_x11_uses_xdotool(self):
         module = self._reload_for_linux("x11", "KDE")
+
+        with patch.object(module, "_get_foreground_xdotool", return_value="/tmp/x11-app") as xdotool:
+            self.assertEqual(module.get_foreground_app_identity(), ("/tmp/x11-app",))
+            xdotool.assert_called_once_with()
 
         with patch.object(module, "_get_foreground_xdotool", return_value="/tmp/x11-app") as xdotool:
             self.assertEqual(module.get_foreground_exe(), "/tmp/x11-app")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -402,6 +402,33 @@ class AppCatalogTests(unittest.TestCase):
                     "windowed",
                 )
 
+    def test_get_profile_for_app_prefers_specific_nested_identity(self):
+        cfg = {
+            "profiles": {
+                "default": {"apps": []},
+                "outer": {"apps": ["START"]},
+                "inner": {"apps": ["STGame"]},
+            }
+        }
+
+        self.assertEqual(
+            config.get_profile_for_app(cfg, ("STGame", "START")),
+            "inner",
+        )
+
+    def test_get_profile_for_app_falls_back_to_outer_nested_identity(self):
+        cfg = {
+            "profiles": {
+                "default": {"apps": []},
+                "outer": {"apps": ["START"]},
+            }
+        }
+
+        self.assertEqual(
+            config.get_profile_for_app(cfg, ("STGame", "START")),
+            "outer",
+        )
+
     def test_resolve_app_spec_for_windows_exe_path_uses_curated_label(self):
         app_path = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import json
 import ntpath
 import os
+import plistlib
 import tempfile
 import unittest
 from contextlib import contextmanager
@@ -376,6 +377,30 @@ class AppCatalogTests(unittest.TestCase):
                 config.get_profile_for_app(cfg, "com.microsoft.VSCodeInsiders"),
                 "code",
             )
+
+    def test_get_profile_for_app_matches_mac_app_path_to_runtime_bundle_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app_path = os.path.join(tmp, "Windowed.app")
+            contents = os.path.join(app_path, "Contents")
+            os.makedirs(contents)
+            with open(os.path.join(contents, "Info.plist"), "wb") as f:
+                plistlib.dump({"CFBundleIdentifier": "com.example.Windowed"}, f)
+
+            cfg = {
+                "profiles": {
+                    "default": {"apps": []},
+                    "windowed": {"apps": [app_path]},
+                }
+            }
+
+            with (
+                _platform_catalog("darwin"),
+                patch.object(app_catalog, "get_app_catalog", return_value=[]),
+            ):
+                self.assertEqual(
+                    config.get_profile_for_app(cfg, "com.example.Windowed"),
+                    "windowed",
+                )
 
     def test_resolve_app_spec_for_windows_exe_path_uses_curated_label(self):
         app_path = r"C:\Program Files\Google\Chrome\Application\chrome.exe"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -165,7 +165,7 @@ class ConfigMigrationTests(unittest.TestCase):
             "switch_scroll_mode",
         )
 
-    def test_get_profile_for_app_matches_aliases(self):
+    def test_get_profile_for_app_identity_matches_aliases(self):
         cfg = {
             "app_overrides": {},
             "profiles": {
@@ -183,11 +183,11 @@ class ConfigMigrationTests(unittest.TestCase):
             },
         ):
             self.assertEqual(
-                config.get_profile_for_app(cfg, "com.google.Chrome"),
+                config.get_profile_for_app_identity(cfg, ("com.google.Chrome",)),
                 "chrome",
             )
 
-    def test_get_profile_for_app_matches_linux_desktop_id_from_runtime_path(self):
+    def test_get_profile_for_app_identity_matches_linux_desktop_id_from_runtime_path(self):
         cfg = {
             "profiles": {
                 "default": {"apps": []},
@@ -209,11 +209,14 @@ class ConfigMigrationTests(unittest.TestCase):
             },
         ):
             self.assertEqual(
-                config.get_profile_for_app(cfg, "/usr/lib64/firefox/firefox"),
+                config.get_profile_for_app_identity(
+                    cfg,
+                    ("/usr/lib64/firefox/firefox",),
+                ),
                 "firefox",
             )
 
-    def test_get_profile_for_app_matches_linux_legacy_launcher_path(self):
+    def test_get_profile_for_app_identity_matches_linux_legacy_launcher_path(self):
         cfg = {
             "profiles": {
                 "default": {"apps": []},
@@ -235,7 +238,10 @@ class ConfigMigrationTests(unittest.TestCase):
             },
         ):
             self.assertEqual(
-                config.get_profile_for_app(cfg, "/usr/lib64/firefox/firefox"),
+                config.get_profile_for_app_identity(
+                    cfg,
+                    ("/usr/lib64/firefox/firefox",),
+                ),
                 "firefox",
             )
 
@@ -354,7 +360,7 @@ class AppCatalogTests(unittest.TestCase):
 
         self.assertEqual(resolved["id"], "com.example.electron")
 
-    def test_get_profile_for_app_matches_mac_bundle_identity(self):
+    def test_get_profile_for_app_identity_matches_mac_bundle_identity(self):
         cfg = {
             "profiles": {
                 "default": {"apps": []},
@@ -366,19 +372,25 @@ class AppCatalogTests(unittest.TestCase):
 
         with _platform_catalog("darwin"):
             self.assertEqual(
-                config.get_profile_for_app(cfg, "org.mozilla.firefox"),
+                config.get_profile_for_app_identity(cfg, ("org.mozilla.firefox",)),
                 "firefox",
             )
             self.assertEqual(
-                config.get_profile_for_app(cfg, "com.todesktop.230313mzl4w4u92"),
+                config.get_profile_for_app_identity(
+                    cfg,
+                    ("com.todesktop.230313mzl4w4u92",),
+                ),
                 "cursor",
             )
             self.assertEqual(
-                config.get_profile_for_app(cfg, "com.microsoft.VSCodeInsiders"),
+                config.get_profile_for_app_identity(
+                    cfg,
+                    ("com.microsoft.VSCodeInsiders",),
+                ),
                 "code",
             )
 
-    def test_get_profile_for_app_matches_mac_app_path_to_runtime_bundle_id(self):
+    def test_get_profile_for_app_identity_matches_mac_app_path_to_runtime_bundle_id(self):
         with tempfile.TemporaryDirectory() as tmp:
             app_path = os.path.join(tmp, "Windowed.app")
             contents = os.path.join(app_path, "Contents")
@@ -398,11 +410,14 @@ class AppCatalogTests(unittest.TestCase):
                 patch.object(app_catalog, "get_app_catalog", return_value=[]),
             ):
                 self.assertEqual(
-                    config.get_profile_for_app(cfg, "com.example.Windowed"),
+                    config.get_profile_for_app_identity(
+                        cfg,
+                        ("com.example.Windowed",),
+                    ),
                     "windowed",
                 )
 
-    def test_get_profile_for_app_prefers_specific_nested_identity(self):
+    def test_get_profile_for_app_identity_prefers_specific_nested_identity(self):
         cfg = {
             "profiles": {
                 "default": {"apps": []},
@@ -412,11 +427,11 @@ class AppCatalogTests(unittest.TestCase):
         }
 
         self.assertEqual(
-            config.get_profile_for_app(cfg, ("InnerTool", "OuterHost")),
+            config.get_profile_for_app_identity(cfg, ("InnerTool", "OuterHost")),
             "inner",
         )
 
-    def test_get_profile_for_app_falls_back_to_outer_nested_identity(self):
+    def test_get_profile_for_app_identity_falls_back_to_outer_nested_identity(self):
         cfg = {
             "profiles": {
                 "default": {"apps": []},
@@ -425,7 +440,7 @@ class AppCatalogTests(unittest.TestCase):
         }
 
         self.assertEqual(
-            config.get_profile_for_app(cfg, ("InnerTool", "OuterHost")),
+            config.get_profile_for_app_identity(cfg, ("InnerTool", "OuterHost")),
             "outer",
         )
 
@@ -453,7 +468,7 @@ class AppCatalogTests(unittest.TestCase):
         self.assertEqual(resolved["id"], "WindowsTerminal.exe")
         self.assertEqual(resolved["label"], "Windows Terminal")
 
-    def test_get_profile_for_app_matches_windows_full_path(self):
+    def test_get_profile_for_app_identity_matches_windows_full_path(self):
         cfg = {
             "app_overrides": {},
             "profiles": {
@@ -475,9 +490,11 @@ class AppCatalogTests(unittest.TestCase):
             },
         ):
             self.assertEqual(
-                config.get_profile_for_app(
+                config.get_profile_for_app_identity(
                     cfg,
-                    r"C:\\Users\\luca\\AppData\\Local\\Microsoft\\WindowsApps\\wt.exe",
+                    (
+                        r"C:\\Users\\luca\\AppData\\Local\\Microsoft\\WindowsApps\\wt.exe",
+                    ),
                 ),
                 "terminal",
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -406,13 +406,13 @@ class AppCatalogTests(unittest.TestCase):
         cfg = {
             "profiles": {
                 "default": {"apps": []},
-                "outer": {"apps": ["START"]},
-                "inner": {"apps": ["STGame"]},
+                "outer": {"apps": ["OuterHost"]},
+                "inner": {"apps": ["InnerTool"]},
             }
         }
 
         self.assertEqual(
-            config.get_profile_for_app(cfg, ("STGame", "START")),
+            config.get_profile_for_app(cfg, ("InnerTool", "OuterHost")),
             "inner",
         )
 
@@ -420,12 +420,12 @@ class AppCatalogTests(unittest.TestCase):
         cfg = {
             "profiles": {
                 "default": {"apps": []},
-                "outer": {"apps": ["START"]},
+                "outer": {"apps": ["OuterHost"]},
             }
         }
 
         self.assertEqual(
-            config.get_profile_for_app(cfg, ("STGame", "START")),
+            config.get_profile_for_app(cfg, ("InnerTool", "OuterHost")),
             "outer",
         )
 


### PR DESCRIPTION
Fix macOS per-app profile matching for apps that launch nested or helper app bundles.

Previously, Mouser matched the foreground macOS app using a single identifier. Some apps launch secondary `.app` bundles from inside the main application bundle, which caused profile matching to miss the configured host app profile. This PR changes foreground app detection to return an ordered tuple of app identities, from the most specific nested app to broader host app identities, so profile lookup can first match a nested app profile and then fall back to the host app profile.

## Changes

- Return ordered foreground app identities from macOS app detection.
- Include bundle identifiers, bundle paths, bundle names, executable paths, and localized names as matching candidates.
- Update profile lookup to match ordered identities and cache alias resolution per lookup.
- Remove legacy single-string foreground/profile matching APIs.
- Tighten typing around app identity handling.
- Improve app detector tests so platform-specific imports do not leak between tests.
- Add coverage for nested macOS app identity matching and fallback behavior.