### PR TITLE
chore(build): drop hardcoded macOS signing team default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build/
 *.egg
 
 # IDE
-.vscode/
 .idea/
 .cursor/
 *.swp
@@ -36,6 +35,9 @@ Desktop.ini
 
 # Build artifacts
 build_icon.py
+
+# Local diagnostics (machine-specific install paths)
+tools/probe_frozen_qml.py
 
 # Shortcuts (user-specific paths)
 *.lnk

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build Mouser → Applications (signed)",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/build_and_install_macos_app.sh",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "focus": true,
+        "clear": true
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/scripts/build_and_install_macos_app.sh
+++ b/scripts/build_and_install_macos_app.sh
@@ -1,0 +1,72 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+APP_NAME="Mouser.app"
+BUILD_OUTPUT="$ROOT_DIR/dist/$APP_NAME"
+INSTALL_DIR="${MOUSER_INSTALL_DIR:-/Applications}"
+INSTALL_PATH="$INSTALL_DIR/$APP_NAME"
+ENV_LOCAL="$ROOT_DIR/.env.local"
+
+if [[ -f "$ENV_LOCAL" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_LOCAL"
+  set +a
+fi
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+resolve_sign_identity() {
+  if [[ -n "${MOUSER_SIGN_IDENTITY:-}" ]]; then
+    echo "$MOUSER_SIGN_IDENTITY"
+    return
+  fi
+
+  local team_id="${MOUSER_TEAM_ID:-}"
+  if [[ -z "$team_id" ]]; then
+    fail "Set MOUSER_SIGN_IDENTITY or MOUSER_TEAM_ID for macOS code signing."
+  fi
+  local line sha1
+
+  line="$(security find-identity -v -p codesigning 2>/dev/null \
+    | grep "(${team_id})" \
+    | head -1)" || true
+
+  if [[ -z "$line" ]]; then
+    fail "No codesigning identity found for team ${team_id}. Set MOUSER_SIGN_IDENTITY or MOUSER_TEAM_ID."
+  fi
+
+  sha1="${line#*) }"
+  sha1="${sha1%% *}"
+  [[ "$sha1" =~ ^[A-F0-9]{40}$ ]] || fail "Could not parse codesigning identity for team ${team_id}."
+
+  echo "$sha1"
+}
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  fail "This script must be run on macOS."
+fi
+
+SIGN_IDENTITY="$(resolve_sign_identity)"
+export MOUSER_SIGN_IDENTITY="$SIGN_IDENTITY"
+
+echo "Building signed macOS app (identity: ${SIGN_IDENTITY})"
+"$ROOT_DIR/build_macos_app.sh"
+
+[[ -d "$BUILD_OUTPUT" ]] || fail "Build output not found: $BUILD_OUTPUT"
+
+echo "Installing to ${INSTALL_PATH}"
+mkdir -p "$INSTALL_DIR"
+rm -rf "$INSTALL_PATH"
+ditto "$BUILD_OUTPUT" "$INSTALL_PATH"
+
+if command -v codesign >/dev/null 2>&1; then
+  codesign --verify --deep --strict --verbose=2 "$INSTALL_PATH"
+fi
+
+echo "Installed: ${INSTALL_PATH}"


### PR DESCRIPTION
## Summary

- Remove the hardcoded Apple team ID fallback from \scripts/build_and_install_macos_app.sh\.
- macOS install builds now require an explicit \MOUSER_SIGN_IDENTITY\ or \MOUSER_TEAM_ID\ (or values from a gitignored \.env.local\).
- Gitignore local QML probe tooling that defaults to machine-specific install paths.

## Why

The install script shipped a developer-specific signing team ID as the default. That is local configuration, not something that belongs in the shared repo.

## Test plan

- [ ] On macOS with \MOUSER_SIGN_IDENTITY\ set: \./scripts/build_and_install_macos_app.sh\ still builds and installs.
- [ ] With neither \MOUSER_SIGN_IDENTITY\ nor \MOUSER_TEAM_ID\ set: script fails fast with a clear error.
- [ ] \.env.local\ remains gitignored (\.env.*\ in \.gitignore\).