### PR TITLE
feat(build): cross-platform build-and-install with Windows shell integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build/
 *.egg
 
 # IDE
-.vscode/
 .idea/
 .cursor/
 *.swp
@@ -36,6 +35,9 @@ Desktop.ini
 
 # Build artifacts
 build_icon.py
+
+# Local diagnostics (machine-specific install paths)
+tools/probe_frozen_qml.py
 
 # Shortcuts (user-specific paths)
 *.lnk

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build Mouser and Install",
+      "type": "shell",
+      "windows": {
+        "command": "python",
+        "args": ["${workspaceFolder}/scripts/build_and_install.py"]
+      },
+      "osx": {
+        "command": "python3",
+        "args": ["${workspaceFolder}/scripts/build_and_install.py"]
+      },
+      "linux": {
+        "command": "python3",
+        "args": ["${workspaceFolder}/scripts/build_and_install.py"]
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "focus": true,
+        "clear": true
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/main_qml.py
+++ b/main_qml.py
@@ -58,8 +58,12 @@ _t2 = _time.perf_counter()
 # Ensure PySide6 QML plugins are found
 import PySide6
 _pyside_dir = os.path.dirname(PySide6.__file__)
-os.environ.setdefault("QML2_IMPORT_PATH", os.path.join(_pyside_dir, "qml"))
-os.environ.setdefault("QT_PLUGIN_PATH", os.path.join(_pyside_dir, "plugins"))
+_qml_dir = os.path.join(_pyside_dir, "qml")
+_plugin_dir = os.path.join(_pyside_dir, "plugins")
+os.environ.setdefault("QML2_IMPORT_PATH", _qml_dir)
+os.environ.setdefault("QT_PLUGIN_PATH", _plugin_dir)
+QCoreApplication.addLibraryPath(_plugin_dir)
+QCoreApplication.addLibraryPath(_qml_dir)
 
 _t3 = _time.perf_counter()
 from core.config import load_config, save_config
@@ -1018,6 +1022,12 @@ def main():
 
     # ── QML Engine ─────────────────────────────────────────────
     qml_engine = QQmlApplicationEngine()
+
+    def _log_qml_warnings(warnings):
+        for warning in warnings:
+            print(f"[QML] {warning.toString()}")
+
+    qml_engine.warnings.connect(_log_qml_warnings)
     qml_engine.addImageProvider("appicons", AppIconProvider(ROOT))
     qml_engine.addImageProvider("systemicons", SystemIconProvider())
     qml_engine.rootContext().setContextProperty("backend", backend)

--- a/scripts/build_and_install.bat
+++ b/scripts/build_and_install.bat
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+cd /d "%~dp0\.."
+python "%~dp0build_and_install.py"
+if errorlevel 1 exit /b 1

--- a/scripts/build_and_install.py
+++ b/scripts/build_and_install.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Build Mouser and install it to the platform default location."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+MACOS_APP_NAME = "Mouser.app"
+WINDOWS_APP_DIR = "Mouser"
+DEFAULT_MACOS_INSTALL_DIR = Path("/Applications")
+
+
+def fail(message: str, *, code: int = 1) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_env_local() -> None:
+    env_file = ROOT / ".env.local"
+    if not env_file.is_file():
+        return
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        os.environ.setdefault(key, value)
+
+
+def resolve_command(candidate: str) -> Path | None:
+    path = Path(candidate)
+    if any(sep in candidate for sep in ("/", "\\", os.sep)) or path.suffix:
+        if not path.is_file():
+            return None
+        if sys.platform == "win32":
+            return path
+        return path if os.access(path, os.X_OK) else None
+    resolved = shutil.which(candidate)
+    return Path(resolved) if resolved else None
+
+
+def python_from_env_dir(env_dir: Path) -> Path | None:
+    for name in ("python3", "python"):
+        candidate = env_dir / "Scripts" / f"{name}.exe"
+        if candidate.is_file():
+            return candidate
+        candidate = env_dir / "bin" / name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def resolve_python() -> tuple[Path, str]:
+    override = os.environ.get("MOUSER_PYTHON")
+    if override:
+        resolved = resolve_command(override)
+        if resolved is None:
+            fail(f"MOUSER_PYTHON is set but is not executable: {override}")
+        return resolved, "MOUSER_PYTHON"
+
+    virtual_env = os.environ.get("VIRTUAL_ENV")
+    if virtual_env:
+        resolved = python_from_env_dir(Path(virtual_env))
+        if resolved is None:
+            fail(f"VIRTUAL_ENV is set but no executable Python was found in {virtual_env}")
+        return resolved, "VIRTUAL_ENV"
+
+    repo_venv = ROOT / ".venv"
+    if repo_venv.is_dir():
+        resolved = python_from_env_dir(repo_venv)
+        if resolved is None:
+            fail(
+                "Repository .venv exists but no executable Python was found in "
+                f"{repo_venv / ('Scripts' if sys.platform == 'win32' else 'bin')}"
+            )
+        return resolved, "repo .venv"
+
+    for name in ("python3", "python"):
+        resolved = resolve_command(name)
+        if resolved is not None:
+            return resolved, f"PATH {name}"
+
+    fail("No Python interpreter found. Create .venv or set MOUSER_PYTHON.")
+
+
+def run_command(
+    args: list[str | Path],
+    *,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    display = " ".join(str(arg) for arg in args)
+    print(f"+ {display}")
+    result = subprocess.run(
+        [str(arg) for arg in args],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        fail(f"Command failed ({result.returncode}): {display}")
+    return result
+
+
+def require_pyinstaller(python: Path, source: str) -> None:
+    probe = subprocess.run(
+        [str(python), "-c", "import PyInstaller"],
+        cwd=ROOT,
+        text=True,
+        check=False,
+    )
+    if probe.returncode == 0:
+        return
+    fail(
+        f"PyInstaller not installed in {python} (source: {source}). "
+        f"Install it with: {python} -m pip install -r {ROOT / 'requirements.txt'}"
+    )
+
+
+def log_python_provenance(python: Path, source: str) -> None:
+    version = subprocess.check_output(
+        [str(python), "-c", "import platform; print(platform.python_version())"],
+        cwd=ROOT,
+        text=True,
+    ).strip()
+    machine = subprocess.check_output(
+        [str(python), "-c", "import platform; print(platform.machine() or 'unknown')"],
+        cwd=ROOT,
+        text=True,
+    ).strip()
+    pyinstaller_version = subprocess.check_output(
+        [str(python), "-c", "import PyInstaller; print(PyInstaller.__version__)"],
+        cwd=ROOT,
+        text=True,
+    ).strip()
+    print(f"Using Python: {python} (source: {source})")
+    print(f"Python version: {version} ({machine})")
+    print(f"PyInstaller version: {pyinstaller_version}")
+
+
+def resolve_install_dir(default: Path | None = None) -> Path:
+    override = os.environ.get("MOUSER_INSTALL_DIR")
+    if override:
+        return Path(override).expanduser()
+    if default is not None:
+        return default
+    if sys.platform == "win32":
+        from scripts.windows_install import default_install_root
+
+        return default_install_root()
+    fail("No install directory configured for this platform.")
+
+
+def replace_tree(source: Path, destination: Path) -> None:
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, destination)
+
+
+def resolve_macos_sign_identity() -> str:
+    configured = os.environ.get("MOUSER_SIGN_IDENTITY")
+    if configured:
+        return configured
+
+    team_id = os.environ.get("MOUSER_TEAM_ID", "").strip()
+    if not team_id:
+        fail(
+            "Set MOUSER_SIGN_IDENTITY or MOUSER_TEAM_ID for macOS code signing."
+        )
+    try:
+        output = subprocess.check_output(
+            ["security", "find-identity", "-v", "-p", "codesigning"],
+            cwd=ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        fail(
+            f"No codesigning identity found for team {team_id}. "
+            "Set MOUSER_SIGN_IDENTITY or MOUSER_TEAM_ID."
+        )
+
+    for line in output.splitlines():
+        if f"({team_id})" not in line:
+            continue
+        match = re.search(r"\b([A-F0-9]{40})\b", line)
+        if match:
+            return match.group(1)
+        break
+
+    fail(
+        f"No codesigning identity found for team {team_id}. "
+        "Set MOUSER_SIGN_IDENTITY or MOUSER_TEAM_ID."
+    )
+
+
+def build_and_install_macos() -> None:
+    build_output = ROOT / "dist" / MACOS_APP_NAME
+    install_dir = resolve_install_dir(DEFAULT_MACOS_INSTALL_DIR)
+    install_path = install_dir / MACOS_APP_NAME
+
+    sign_identity = resolve_macos_sign_identity()
+    env = os.environ.copy()
+    env["MOUSER_SIGN_IDENTITY"] = sign_identity
+
+    print(f"Building signed macOS app (identity: {sign_identity})")
+    run_command(["/bin/zsh", ROOT / "build_macos_app.sh"], env=env)
+
+    if not build_output.is_dir():
+        fail(f"Build output not found: {build_output}")
+
+    print(f"Installing to {install_path}")
+    replace_tree(build_output, install_path)
+
+    if shutil.which("codesign"):
+        run_command(
+            ["codesign", "--verify", "--deep", "--strict", "--verbose=2", install_path]
+        )
+
+    print(f"Installed: {install_path}")
+
+
+def build_and_install_windows() -> None:
+    from scripts.windows_install import (
+        cleanup_all_windows_installs,
+        default_install_root,
+        finalize_windows_install,
+        permission_hint,
+        remove_legacy_local_install,
+        replace_tree,
+        resolve_install_scope,
+    )
+
+    print("[*] Cleaning previous Windows installs...")
+    cleanup_all_windows_installs()
+
+    build_output = ROOT / "dist" / WINDOWS_APP_DIR
+    scope = resolve_install_scope()
+    install_path = (
+        Path(os.environ["MOUSER_INSTALL_DIR"]).expanduser()
+        if os.environ.get("MOUSER_INSTALL_DIR")
+        else default_install_root(scope)
+    )
+
+    python, source = resolve_python()
+
+    print("[*] Installing requirements...")
+    run_command([python, "-m", "pip", "install", "-r", ROOT / "requirements.txt"])
+
+    require_pyinstaller(python, source)
+    log_python_provenance(python, source)
+
+    print("[*] Verifying hidapi import...")
+    probe = subprocess.run(
+        [str(python), "-c", "import hid; print('[*] hidapi:', hid.__file__)"],
+        cwd=ROOT,
+        text=True,
+        check=False,
+    )
+    if probe.returncode != 0:
+        fail(
+            "hidapi is not importable. The packaged app would not detect Logitech devices."
+        )
+
+    if build_output.exists():
+        print(f"[*] Removing previous {build_output}...")
+        shutil.rmtree(build_output)
+
+    print("[*] Building with PyInstaller...")
+    env = os.environ.copy()
+    env.setdefault("PYTHONHASHSEED", "0")
+    run_command(
+        [python, "-m", "PyInstaller", ROOT / "Mouser.spec", "--noconfirm"],
+        env=env,
+    )
+
+    exe_path = build_output / "Mouser.exe"
+    internal_dir = build_output / "_internal"
+    if not exe_path.is_file() or not internal_dir.is_dir():
+        fail(f"Build output is incomplete: {build_output}")
+
+    print(f"Installing to {install_path} ({scope} scope)")
+    try:
+        replace_tree(build_output, install_path)
+    except PermissionError as exc:
+        fail(f"{permission_hint(scope)} ({exc})")
+
+    installed_exe = install_path / "Mouser.exe"
+    if not installed_exe.is_file():
+        fail(f"Install verification failed: {installed_exe}")
+
+    remove_legacy_local_install(active_scope=scope)
+    shell = finalize_windows_install(install_path, scope=scope)
+
+    print(f"Installed: {shell['install_root']}")
+    print(f"Start Menu: {shell['start_menu_shortcut']}")
+    print(f"Uninstall: {shell['uninstall_script']}")
+
+
+def main() -> None:
+    load_env_local()
+
+    if sys.platform == "darwin":
+        build_and_install_macos()
+        return
+    if sys.platform == "win32":
+        build_and_install_windows()
+        return
+
+    fail(
+        "Unsupported platform for build-and-install. "
+        "Use build_macos_app.sh, build.bat, or Mouser-linux.spec on this system."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_and_install_macos_app.sh
+++ b/scripts/build_and_install_macos_app.sh
@@ -1,0 +1,12 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "ERROR: This wrapper must be run on macOS. Use scripts/build_and_install.py instead." >&2
+  exit 1
+fi
+
+exec python3 "$ROOT_DIR/scripts/build_and_install.py"

--- a/scripts/install_from_dist.py
+++ b/scripts/install_from_dist.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Install an existing dist/Mouser build without rebuilding."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.windows_install import (
+    default_install_root,
+    finalize_windows_install,
+    replace_tree,
+    resolve_install_scope,
+)
+
+
+def main() -> None:
+    if sys.platform != "win32":
+        raise SystemExit("install_from_dist.py is Windows-only")
+
+    build_output = ROOT / "dist" / "Mouser"
+    scope = resolve_install_scope()
+    install_path = (
+        Path(os.environ["MOUSER_INSTALL_DIR"]).expanduser()
+        if os.environ.get("MOUSER_INSTALL_DIR")
+        else default_install_root(scope)
+    )
+
+    print(f"Installing {build_output} -> {install_path} ({scope} scope)")
+    replace_tree(build_output, install_path)
+    shell = finalize_windows_install(install_path, scope=scope)
+    print(f"Installed: {shell['install_root']}")
+    print(f"Start Menu: {shell['start_menu_shortcut']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/windows_install.py
+++ b/scripts/windows_install.py
@@ -1,0 +1,334 @@
+"""Register a built Mouser folder as a normal Windows application install."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from core.update_installer import APP_ID
+from core.version import APP_VERSION
+
+WINDOWS_APP_DIR = "Mouser"
+UNINSTALL_KEY_NAME = APP_ID
+UNINSTALL_SCRIPT_NAME = "Uninstall Mouser.cmd"
+
+
+def _escape_ps(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def resolve_install_scope() -> str:
+    configured = (os.environ.get("MOUSER_INSTALL_SCOPE") or "").strip().lower()
+    if configured:
+        if configured not in {"machine", "user"}:
+            raise ValueError(
+                f"Unsupported MOUSER_INSTALL_SCOPE: {configured!r} "
+                "(expected 'machine' or 'user')"
+            )
+        return configured
+    if _can_install_machine():
+        return "machine"
+    print(
+        "[!] Program Files is not writable from this shell; "
+        "using per-user install scope."
+    )
+    print("    Re-run as administrator for a machine-wide install.")
+    return "user"
+
+
+def _can_install_machine() -> bool:
+    program_files = Path(os.environ.get("ProgramFiles", r"C:\Program Files"))
+    probe = program_files / ".mouser-install-probe"
+    try:
+        probe.mkdir(exist_ok=True)
+        probe.rmdir()
+        return True
+    except OSError:
+        return False
+
+
+def _join_win_path(base: str, *parts: str) -> Path:
+    """Join Windows install path segments consistently on every platform."""
+    return Path(os.path.normpath(os.path.join(base, *parts)))
+
+
+def default_install_root(scope: str | None = None) -> Path:
+    scope = scope or resolve_install_scope()
+    if scope == "user":
+        base = os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local"))
+        return _join_win_path(base, "Programs", WINDOWS_APP_DIR)
+    program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
+    return _join_win_path(program_files, WINDOWS_APP_DIR)
+
+
+def start_menu_dir(scope: str) -> Path:
+    if scope == "machine":
+        base = os.environ.get("ProgramData", r"C:\ProgramData")
+    else:
+        base = os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming"))
+    return Path(base) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+
+
+def start_menu_shortcut_path(scope: str) -> Path:
+    return start_menu_dir(scope) / "Mouser.lnk"
+
+
+def uninstall_registry_root(scope: str):
+    import winreg
+
+    hive = winreg.HKEY_LOCAL_MACHINE if scope == "machine" else winreg.HKEY_CURRENT_USER
+    return hive, rf"Software\Microsoft\Windows\CurrentVersion\Uninstall\{UNINSTALL_KEY_NAME}"
+
+
+def run_powershell(command: str) -> None:
+    result = subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            command,
+        ],
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"PowerShell command failed ({result.returncode})")
+
+
+def create_shortcut(shortcut_path: Path, target: Path, working_dir: Path) -> None:
+    shortcut_path.parent.mkdir(parents=True, exist_ok=True)
+    command = (
+        "$shell = New-Object -ComObject WScript.Shell; "
+        f"$shortcut = $shell.CreateShortcut('{_escape_ps(str(shortcut_path))}'); "
+        f"$shortcut.TargetPath = '{_escape_ps(str(target))}'; "
+        f"$shortcut.WorkingDirectory = '{_escape_ps(str(working_dir))}'; "
+        f"$shortcut.IconLocation = '{_escape_ps(str(target))},0'; "
+        "$shortcut.Save()"
+    )
+    run_powershell(command)
+
+
+def write_uninstall_script(install_root: Path, scope: str) -> Path:
+    script_path = install_root / UNINSTALL_SCRIPT_NAME
+    shortcut = start_menu_shortcut_path(scope)
+    hive_name = "HKLM" if scope == "machine" else "HKCU"
+    content = f"""@echo off
+setlocal EnableExtensions
+set "ROOT=%~dp0"
+if "%ROOT:~-1%"=="\\" set "ROOT=%ROOT:~0,-1%"
+
+del /f /q "{shortcut}" 2>nul
+reg delete "{hive_name}\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{UNINSTALL_KEY_NAME}" /f 2>nul
+
+start "" /min cmd /c "ping -n 3 127.0.0.1>nul & rd /s /q \"%ROOT%\""
+exit /b 0
+"""
+    script_path.write_text(content, encoding="utf-8", newline="\r\n")
+    return script_path
+
+
+def register_uninstall_entry(
+    install_root: Path,
+    *,
+    scope: str,
+    version: str,
+    uninstall_command: Path,
+) -> None:
+    import winreg
+
+    hive, key_path = uninstall_registry_root(scope)
+    exe = install_root / "Mouser.exe"
+    with winreg.CreateKey(hive, key_path) as key:
+        winreg.SetValueEx(key, "DisplayName", 0, winreg.REG_SZ, "Mouser")
+        winreg.SetValueEx(key, "DisplayIcon", 0, winreg.REG_SZ, str(exe))
+        winreg.SetValueEx(key, "DisplayVersion", 0, winreg.REG_SZ, version)
+        winreg.SetValueEx(key, "InstallLocation", 0, winreg.REG_SZ, str(install_root))
+        winreg.SetValueEx(
+            key,
+            "UninstallString",
+            0,
+            winreg.REG_SZ,
+            f'"{uninstall_command}"',
+        )
+        winreg.SetValueEx(key, "Publisher", 0, winreg.REG_SZ, "Tom Badash")
+        winreg.SetValueEx(key, "NoModify", 0, winreg.REG_DWORD, 1)
+        winreg.SetValueEx(key, "NoRepair", 0, winreg.REG_DWORD, 1)
+
+
+def finalize_windows_install(install_root: Path, *, scope: str | None = None) -> dict[str, Path]:
+    if sys.platform != "win32":
+        raise RuntimeError("finalize_windows_install is Windows-only")
+
+    scope = scope or resolve_install_scope()
+    install_root = install_root.resolve()
+    exe = install_root / "Mouser.exe"
+    if not exe.is_file():
+        raise FileNotFoundError(f"Missing executable: {exe}")
+    if not (install_root / "_internal").is_dir():
+        raise FileNotFoundError(f"Missing runtime folder: {install_root / '_internal'}")
+
+    uninstall_script = write_uninstall_script(install_root, scope)
+    shortcut_path = start_menu_shortcut_path(scope)
+    create_shortcut(shortcut_path, exe, install_root)
+    register_uninstall_entry(
+        install_root,
+        scope=scope,
+        version=APP_VERSION,
+        uninstall_command=uninstall_script,
+    )
+    return {
+        "install_root": install_root,
+        "start_menu_shortcut": shortcut_path,
+        "uninstall_script": uninstall_script,
+    }
+
+
+def stop_running_mouser_instances() -> None:
+    if sys.platform != "win32":
+        return
+    result = subprocess.run(
+        [
+            "taskkill",
+            "/IM",
+            "Mouser.exe",
+            "/F",
+            "/T",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        print("[*] Stopped running Mouser instance(s) before install")
+        time.sleep(1)
+
+
+def _remove_uninstall_registry(scope: str) -> None:
+    if sys.platform != "win32":
+        return
+    import winreg
+
+    hive, key_path = uninstall_registry_root(scope)
+    try:
+        winreg.DeleteKey(hive, key_path)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
+def _remove_install_tree(path: Path) -> bool:
+    if not path.exists():
+        return True
+    try:
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+        return True
+    except OSError as exc:
+        print(f"[!] Could not remove {path}: {exc}")
+        return False
+
+
+def _remove_staging_artifacts(parent: Path, app_dir: str = WINDOWS_APP_DIR) -> None:
+    if not parent.is_dir():
+        return
+    prefix = f".{app_dir}."
+    for entry in parent.iterdir():
+        if entry.name.startswith(prefix) and (
+            ".staging-" in entry.name or ".backup-" in entry.name
+        ):
+            _remove_install_tree(entry)
+
+
+def remove_install_artifacts(scope: str) -> None:
+    """Remove one install scope: app folder, Start Menu shortcut, uninstall key."""
+    if sys.platform != "win32":
+        return
+    root = default_install_root(scope)
+    shortcut = start_menu_shortcut_path(scope)
+    if shortcut.exists():
+        shortcut.unlink()
+    _remove_uninstall_registry(scope)
+    _remove_install_tree(root)
+    if scope == "machine":
+        _remove_staging_artifacts(Path(os.environ.get("ProgramFiles", r"C:\Program Files")))
+
+
+def remove_stale_install_artifacts(active_scope: str) -> None:
+    """Drop shortcuts/registry/install dirs from every scope except the active one."""
+    for scope in ("user", "machine"):
+        if scope != active_scope:
+            remove_install_artifacts(scope)
+
+
+def cleanup_all_windows_installs() -> None:
+    """Remove every Mouser Windows install artifact (both scopes + staging folders)."""
+    if sys.platform != "win32":
+        return
+    stop_running_mouser_instances()
+    for scope in ("user", "machine"):
+        remove_install_artifacts(scope)
+    _remove_staging_artifacts(Path(os.environ.get("ProgramFiles", r"C:\Program Files")))
+
+
+def replace_tree(source: Path, destination: Path) -> None:
+    source = source.resolve()
+    destination = destination.resolve()
+    if not source.is_dir():
+        raise FileNotFoundError(f"Build output not found: {source}")
+
+    stop_running_mouser_instances()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _remove_staging_artifacts(destination.parent)
+
+    staging = destination.with_name(f".{destination.name}.staging-{os.getpid()}")
+    backup = destination.with_name(f".{destination.name}.backup-{int(time.time())}")
+
+    if staging.exists():
+        shutil.rmtree(staging, ignore_errors=True)
+    shutil.copytree(source, staging)
+
+    if destination.exists():
+        try:
+            if destination.is_dir():
+                destination.rename(backup)
+            else:
+                destination.unlink()
+        except OSError:
+            shutil.rmtree(destination, ignore_errors=True)
+
+    try:
+        staging.rename(destination)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not activate install at {destination}. "
+            f"A complete copy is at {staging}. Close Mouser and retry."
+        ) from exc
+
+    if backup.exists():
+        shutil.rmtree(backup, ignore_errors=True)
+
+
+def permission_hint(scope: str) -> str:
+    if scope == "machine":
+        return (
+            "Could not write to Program Files. Re-run the build task in an "
+            "elevated terminal (Run as administrator), or set "
+            "MOUSER_INSTALL_SCOPE=user for a per-user install."
+        )
+    return "Could not write to the selected install location."
+
+
+def remove_legacy_local_install(*, active_scope: str | None = None) -> None:
+    """Remove install artifacts from scopes other than the one just installed."""
+    scope = active_scope or resolve_install_scope()
+    print(f"[*] Removing stale install artifacts (keeping {scope} scope)")
+    remove_stale_install_artifacts(scope)

--- a/tests/test_build_and_install.py
+++ b/tests/test_build_and_install.py
@@ -1,0 +1,200 @@
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import build_and_install as installer
+from scripts import windows_install
+
+
+def normalize_path(path: Path) -> str:
+    return os.path.normpath(str(path)).replace("\\", "/")
+
+
+class BuildAndInstallTests(unittest.TestCase):
+    def test_resolve_macos_sign_identity_requires_team_or_identity(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(SystemExit):
+                installer.resolve_macos_sign_identity()
+
+    def test_load_env_local_sets_defaults_without_overriding(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env_file = root / ".env.local"
+            env_file.write_text(
+                'export MOUSER_INSTALL_DIR="/tmp/custom"\n'
+                'MOUSER_TEAM_ID="TEAM123"\n',
+                encoding="utf-8",
+            )
+            with mock.patch.object(installer, "ROOT", root):
+                with mock.patch.dict(
+                    os.environ,
+                    {"MOUSER_INSTALL_DIR": "/existing"},
+                    clear=False,
+                ):
+                    installer.load_env_local()
+                    self.assertEqual(os.environ["MOUSER_INSTALL_DIR"], "/existing")
+                    self.assertEqual(os.environ["MOUSER_TEAM_ID"], "TEAM123")
+
+    def test_resolve_install_dir_honors_override(self):
+        with mock.patch.dict(os.environ, {"MOUSER_INSTALL_DIR": "~/Apps/Mouser"}, clear=False):
+            resolved = installer.resolve_install_dir(Path("/Applications"))
+        self.assertEqual(resolved, Path("~/Apps/Mouser").expanduser())
+
+    def test_python_from_env_dir_prefers_windows_scripts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_dir = Path(tmp)
+            scripts = env_dir / "Scripts"
+            scripts.mkdir()
+            python_exe = scripts / "python.exe"
+            python_exe.write_text("stub", encoding="utf-8")
+            self.assertEqual(installer.python_from_env_dir(env_dir), python_exe)
+
+    def test_python_from_env_dir_falls_back_to_unix_bin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_dir = Path(tmp)
+            bin_dir = env_dir / "bin"
+            bin_dir.mkdir()
+            python3 = bin_dir / "python3"
+            python3.write_text("#!/bin/sh\n", encoding="utf-8")
+            python3.chmod(python3.stat().st_mode | stat.S_IXUSR)
+            self.assertEqual(installer.python_from_env_dir(env_dir), python3)
+
+    def test_resolve_python_prefers_mouser_python(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            custom = Path(tmp) / "python3"
+            custom.write_text("#!/bin/sh\n", encoding="utf-8")
+            custom.chmod(custom.stat().st_mode | stat.S_IXUSR)
+            with mock.patch.dict(os.environ, {"MOUSER_PYTHON": str(custom)}, clear=False):
+                resolved, source = installer.resolve_python()
+            self.assertEqual(resolved, custom)
+            self.assertEqual(source, "MOUSER_PYTHON")
+
+    def test_default_macos_install_dir(self):
+        self.assertEqual(
+            installer.DEFAULT_MACOS_INSTALL_DIR,
+            Path("/Applications"),
+        )
+
+    def test_main_rejects_unsupported_platform(self):
+        with mock.patch.object(installer.sys, "platform", "linux"):
+            with self.assertRaises(SystemExit) as ctx:
+                installer.main()
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_build_and_install_windows_verifies_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dist = root / "dist" / installer.WINDOWS_APP_DIR
+            dist.mkdir(parents=True)
+            (dist / "Mouser.exe").write_text("exe", encoding="utf-8")
+            (dist / "_internal").mkdir()
+
+            install_root = root / "install"
+            python = root / "python"
+            python.write_text("#!/bin/sh\n", encoding="utf-8")
+            python.chmod(python.stat().st_mode | stat.S_IXUSR)
+
+            def fake_run_command(args, **kwargs):
+                if "PyInstaller" in [str(arg) for arg in args]:
+                    dist.mkdir(parents=True, exist_ok=True)
+                    (dist / "Mouser.exe").write_text("exe", encoding="utf-8")
+                    (dist / "_internal").mkdir(exist_ok=True)
+
+            def fake_run(args, **kwargs):
+                if args[:3] == [str(python), "-c", "import hid; print('[*] hidapi:', hid.__file__)"]:
+                    return mock.Mock(returncode=0)
+                raise AssertionError(f"unexpected subprocess.run: {args}")
+
+            def fake_finalize(install_root, *, scope=None):
+                script = install_root / windows_install.UNINSTALL_SCRIPT_NAME
+                script.write_text("@echo off\r\n", encoding="utf-8")
+                return {
+                    "install_root": install_root,
+                    "start_menu_shortcut": install_root / "Mouser.lnk",
+                    "uninstall_script": script,
+                }
+
+            with mock.patch.object(installer, "ROOT", root):
+                with mock.patch.dict(
+                    os.environ,
+                    {"MOUSER_INSTALL_DIR": str(install_root), "MOUSER_INSTALL_SCOPE": "user"},
+                    clear=False,
+                ):
+                    with mock.patch.object(
+                        installer,
+                        "resolve_python",
+                        return_value=(python, "test"),
+                    ):
+                        with mock.patch.object(installer, "require_pyinstaller"):
+                            with mock.patch.object(installer, "log_python_provenance"):
+                                with mock.patch.object(
+                                    installer,
+                                    "run_command",
+                                    side_effect=fake_run_command,
+                                ):
+                                    with mock.patch(
+                                        "scripts.build_and_install.subprocess.run",
+                                        side_effect=fake_run,
+                                    ):
+                                        with mock.patch.object(
+                                            windows_install,
+                                            "cleanup_all_windows_installs",
+                                        ):
+                                            with mock.patch.object(
+                                                windows_install,
+                                                "stop_running_mouser_instances",
+                                            ):
+                                                with mock.patch.object(
+                                                    windows_install,
+                                                    "finalize_windows_install",
+                                                    side_effect=fake_finalize,
+                                                ):
+                                                    installer.build_and_install_windows()
+
+            self.assertTrue((install_root / "Mouser.exe").is_file())
+            self.assertTrue((install_root / "_internal").is_dir())
+            self.assertTrue((install_root / windows_install.UNINSTALL_SCRIPT_NAME).is_file())
+
+
+class WindowsInstallTests(unittest.TestCase):
+    def test_default_install_root_uses_program_files_for_machine_scope(self):
+        with mock.patch.dict(
+            os.environ,
+            {"ProgramFiles": r"C:\Program Files", "MOUSER_INSTALL_SCOPE": "machine"},
+            clear=False,
+        ):
+            self.assertEqual(
+                normalize_path(windows_install.default_install_root()),
+                normalize_path(Path(r"C:\Program Files\Mouser")),
+            )
+
+    def test_default_install_root_uses_local_programs_for_user_scope(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "LOCALAPPDATA": r"C:\Users\example\AppData\Local",
+                "MOUSER_INSTALL_SCOPE": "user",
+            },
+            clear=False,
+        ):
+            self.assertEqual(
+                normalize_path(windows_install.default_install_root()),
+                normalize_path(Path(r"C:\Users\example\AppData\Local\Programs\Mouser")),
+            )
+
+    def test_resolve_install_scope_falls_back_when_program_files_not_writable(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch.object(windows_install, "_can_install_machine", return_value=False):
+                self.assertEqual(windows_install.resolve_install_scope(), "user")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -247,15 +247,20 @@ ApplicationWindow {
             }
         }
 
-        StackLayout {
-            id: contentStack
+        Item {
+            id: pageHost
             Layout.fillWidth: true
             Layout.fillHeight: true
-            currentIndex: root.currentPage
 
-            MousePage {}
+            MousePage {
+                anchors.fill: parent
+                visible: root.currentPage === 0
+            }
+
             Loader {
+                anchors.fill: parent
                 active: root.currentPage === 1 || item
+                visible: root.currentPage === 1
                 source: "ScrollPage.qml"
             }
         }
@@ -376,6 +381,10 @@ ApplicationWindow {
                     color: closeAboutMouse.containsMouse
                            ? Qt.rgba(1, 1, 1, uiState.darkMode ? 0.08 : 0.65)
                            : "transparent"
+
+                    Accessible.role: Accessible.Button
+                    Accessible.name: lm.strings["dialog.close"] || "Close"
+                    Accessible.onPressAction: aboutDialog.close()
 
                     AppIcon {
                         anchors.centerIn: parent

--- a/ui/qml/MousePage.qml
+++ b/ui/qml/MousePage.qml
@@ -698,18 +698,21 @@ Item {
         // ── Right panel: mouse image + hotspots + picker ─────
         // ══════════════════════════════════════════════════════
         ScrollView {
+            id: mousePageScroll
             width: parent.width - leftPanel.width
             height: parent.height
-            contentWidth: availableWidth
             clip: true
+            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+            contentWidth: availableWidth
 
             Flickable {
+                contentWidth: mousePageScroll.availableWidth
                 contentHeight: rightCol.implicitHeight + 32
                 boundsBehavior: Flickable.StopAtBounds
 
                 Column {
                     id: rightCol
-                    width: parent.width
+                    width: mousePageScroll.availableWidth
                     spacing: 0
 
                     // ── Header ────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `scripts/build_and_install.py` as the shared macOS/Windows build-and-install entry point (PyInstaller build, install to platform default location).
- Add `scripts/windows_install.py` to register Windows installs like a normal app: Start Menu shortcut, Apps & Features uninstall key, and an uninstall script.
- Add a macOS install helper and VS Code build task; signing requires explicit `MOUSER_SIGN_IDENTITY` or `MOUSER_TEAM_ID` (or gitignored `.env.local`) — no hardcoded Apple team ID defaults.
- Extend the VS Code default build task to run the Python entry point on Windows, macOS, and Linux.
- Fix packaged QML on Windows: replace `StackLayout` sizing that left the main page blank, tighten `ScrollView` widths in `MousePage.qml`, register Qt plugin/QML library paths in `main_qml.py`, and log QML warnings to the app log.

## Why

Windows releases ship as a portable PyInstaller folder (`Mouser.exe` + `_internal/`). Building from the repo previously had no equivalent to the macOS install helper, and the frozen Windows UI could render an empty main panel even though the sidebar loaded. This brings Windows dev install behavior in line with the official bundle layout, fixes the blank content area, and keeps signing configuration out of committed scripts.

## Windows install behavior

- **Default scope:** machine (`C:\Program Files\Mouser`) when the shell can write there; otherwise per-user (`%LOCALAPPDATA%\Programs\Mouser`).
- **Overrides:** `MOUSER_INSTALL_DIR`, `MOUSER_INSTALL_SCOPE=machine|user`.
- **Cleanup:** removes stale installs/shortcuts from the other scope before installing so duplicate Start Menu entries do not accumulate.
- **Helpers:** `scripts/build_and_install.bat` wrapper; `scripts/install_from_dist.py` to install an existing `dist/Mouser` without rebuilding.

## macOS behavior

- `scripts/build_and_install_macos_app.sh` becomes a thin wrapper around the Python entry point.
- Signing requires explicit `MOUSER_SIGN_IDENTITY` or `MOUSER_TEAM_ID` (or values from gitignored `.env.local`).

## Test plan

- [x] `python -m unittest tests.test_build_and_install` — 12 tests pass (Windows + Linux CI).
- [x] Full PyInstaller build + user-scope install on Windows 11; Start Menu shortcut launches a complete bundle (1619 files under `_internal`).
- [x] Verified installed `Main.qml` contains `pageHost` layout fix; QML log no longer reports `ReferenceError: s is not defined`.
- [ ] macOS: `python3 scripts/build_and_install.py` with signing env set — build + `/Applications` install.
- [ ] Windows machine-scope install from an elevated shell.

## Notes

- Local-only QML probe tooling is gitignored (`tools/probe_frozen_qml.py`); not part of this PR.
- `.env.local` remains gitignored for per-developer signing/install overrides.