### PR TITLE
feat: Add support for Logitech MX Anywhere 2

### DIFF
--- a/core/device_layouts.py
+++ b/core/device_layouts.py
@@ -224,6 +224,7 @@ _FAMILY_FALLBACKS = {
     "mx_master_3": "mx_master",
     "mx_master_2s": "mx_master",
     "mx_anywhere_2s": "mx_anywhere",
+    "mx_anywhere_2": "mx_anywhere",
     "mx_anywhere_3s": "mx_anywhere",
     "mx_anywhere_3": "mx_anywhere",
 }

--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -274,6 +274,20 @@ LOGI_DEVICE_SPECS = (
         "supported_buttons": MX_ANYWHERE_BUTTONS,
         "dpi_max": 4000,
     },
+    {
+        "key": "mx_anywhere_2",
+        "display_name": "MX Anywhere 2",
+        "product_ids": (0xB013, 0xB018, 0xB01F),
+        "aliases": (
+            "Wireless Mobile Mouse MX Anywhere 2",
+            "MX Anywhere 2",
+            "MX Anywhere 2 for Mac",
+        ),
+        "ui_layout": "mx_anywhere_2s",
+        "image_asset": "logitech-mice/mx_anywhere_2s/mouse.png",
+        "supported_buttons": MX_ANYWHERE_BUTTONS,
+        "dpi_max": 1600,
+    },
     # -- M650 Signature family ------------------------------------------------
     # Compact wireless mouse (middle, back, forward buttons). Connects via Logi
     # Bolt receiver or Bluetooth LE. HID++ reports device name "Signature M650".
@@ -401,6 +415,7 @@ LOGI_DEVICE_SPECS = (
         "dpi_max": 12000,
     },
 )
+
 
 
 LOGI_DEVICE_LAYOUTS = {

--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -277,8 +277,9 @@ LOGI_DEVICE_SPECS = (
     {
         "key": "mx_anywhere_2",
         "display_name": "MX Anywhere 2",
-        "product_ids": (0xB013, 0xB018, 0xB01F),
+        "product_ids": (0xB013, 0xB01F),
         "aliases": (
+            "Wireless Mouse MX Anywhere 2",
             "Wireless Mobile Mouse MX Anywhere 2",
             "MX Anywhere 2",
             "MX Anywhere 2 for Mac",
@@ -286,6 +287,7 @@ LOGI_DEVICE_SPECS = (
         "ui_layout": "mx_anywhere_2s",
         "image_asset": "logitech-mice/mx_anywhere_2s/mouse.png",
         "supported_buttons": MX_ANYWHERE_BUTTONS,
+        "dpi_min": 400,
         "dpi_max": 1600,
     },
     # -- M650 Signature family ------------------------------------------------

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -180,6 +180,53 @@ class LogiDeviceRegistryTests(unittest.TestCase):
             "logitech-mice/mx_anywhere_3s/mouse.png",
         )
 
+    def test_mx_anywhere_2_retained_pids_use_shared_layout_and_metadata(self):
+        expected_buttons = (
+            "middle",
+            "gesture",
+            "gesture_left",
+            "gesture_right",
+            "gesture_up",
+            "gesture_down",
+            "xbutton1",
+            "xbutton2",
+            "hscroll_left",
+            "hscroll_right",
+        )
+
+        for product_id in (0xB013, 0xB01F):
+            with self.subTest(product_id=f"0x{product_id:04X}"):
+                info = build_connected_device_info(product_id=product_id)
+                layout = get_device_layout(info.ui_layout)
+
+                self.assertEqual(info.key, "mx_anywhere_2")
+                self.assertEqual(info.display_name, "MX Anywhere 2")
+                self.assertEqual(info.ui_layout, "mx_anywhere_2s")
+                self.assertEqual(
+                    info.image_asset,
+                    "logitech-mice/mx_anywhere_2s/mouse.png",
+                )
+                self.assertEqual(layout["key"], "mx_anywhere_2s")
+                self.assertTrue(layout["interactive"])
+                self.assertEqual(info.supported_buttons, expected_buttons)
+                self.assertEqual((info.dpi_min, info.dpi_max), (400, 1600))
+                self.assertEqual(clamp_dpi(200, info), 400)
+                self.assertEqual(clamp_dpi(1601, info), 1600)
+
+    def test_mx_anywhere_2_receiver_name_resolves_with_shared_receiver_pid(self):
+        # 0xC52B identifies a shared Unifying receiver; HID++ supplies the
+        # connected mouse name that must select the MX Anywhere 2 catalog entry.
+        info = build_connected_device_info(
+            product_id=0xC52B,
+            product_name="Wireless Mouse MX Anywhere 2",
+            transport="USB receiver",
+        )
+
+        self.assertEqual(info.key, "mx_anywhere_2")
+        self.assertEqual(info.ui_layout, "mx_anywhere_2s")
+        self.assertEqual(info.product_id, 0xC52B)
+        self.assertEqual(info.product_name, "Wireless Mouse MX Anywhere 2")
+
     def test_exact_mx_anywhere_button_sets_include_expected_controls(self):
         anywhere_2s = get_buttons_for_layout("mx_anywhere_2s")
         anywhere_3 = get_buttons_for_layout("mx_anywhere_3")


### PR DESCRIPTION
This PR adds support for the Logitech MX Anywhere 2 mouse (specifically product ID `0xB01F` over Bluetooth on macOS, as well as unifying receiver product IDs `0xB013` and `0xB018`). It maps it to reuse the `mx_anywhere_2s` layout and assets since they share the same physical button layout.