### PR TITLE
chore(build): enforce env-only code signing with a repo-wide guard test

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,24 @@
+# Copy this file to .env.local and fill in your values.
+# .env.local is gitignored and must NEVER be committed -- it carries
+# machine-specific signing identities and install paths.
+#
+# Build/install scripts that support .env.local load it automatically
+# (values already present in the environment take precedence). For
+# scripts that don't, export these variables in your shell instead.
+
+# -- macOS code signing (set exactly one of the two) -------------------
+# Your Apple Developer Team ID (10 characters). The build resolves the
+# first matching codesigning identity in your keychain.
+#MOUSER_TEAM_ID=
+
+# Or pin an exact codesigning identity (SHA-1 hash form preferred; list
+# yours with: security find-identity -v -p codesigning).
+#MOUSER_SIGN_IDENTITY=
+
+# -- Optional overrides ------------------------------------------------
+# Install destination (default: /Applications on macOS, per-user app
+# directory on Windows).
+#MOUSER_INSTALL_DIR=
+
+# Python interpreter used for the build (default: .venv, then PATH).
+#MOUSER_PYTHON=

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,24 +1,17 @@
-# Copy this file to .env.local and fill in your values.
-# .env.local is gitignored and must NEVER be committed -- it carries
-# machine-specific signing identities and install paths.
+# Copy this file to .env.local if you want a local place to keep your
+# build values.
 #
-# Build/install scripts that support .env.local load it automatically
-# (values already present in the environment take precedence). For
-# scripts that don't, export these variables in your shell instead.
+# .env.local is gitignored and must NEVER be committed.
+#
+# Current build scripts do not auto-load .env.local uniformly. Export
+# these variables in your shell, or source the file yourself before
+# running a workflow that reads them.
 
-# -- macOS code signing (set exactly one of the two) -------------------
-# Your Apple Developer Team ID (10 characters). The build resolves the
-# first matching codesigning identity in your keychain.
-#MOUSER_TEAM_ID=
-
-# Or pin an exact codesigning identity (SHA-1 hash form preferred; list
+# -- macOS code signing ------------------------------------------------
+# Pin an exact codesigning identity (SHA-1 hash form preferred; list
 # yours with: security find-identity -v -p codesigning).
 #MOUSER_SIGN_IDENTITY=
 
 # -- Optional overrides ------------------------------------------------
-# Install destination (default: /Applications on macOS, per-user app
-# directory on Windows).
-#MOUSER_INSTALL_DIR=
-
 # Python interpreter used for the build (default: .venv, then PATH).
 #MOUSER_PYTHON=

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ build/
 .envrc
 .env
 .env.*
+!.env.local.example
 *.local.json
 
 # OS

--- a/tests/test_no_hardcoded_signing_secrets.py
+++ b/tests/test_no_hardcoded_signing_secrets.py
@@ -17,12 +17,16 @@ ROOT = Path(__file__).resolve().parents[1]
 # Built at runtime so this file never contains the literal itself.
 _PREVIOUSLY_LEAKED_TEAM_ID = "MVDT65" + "NPA4"
 
-# Shell parameter expansion with a non-empty default, e.g. ${MOUSER_TEAM_ID:-ABC123}.
-_SHELL_DEFAULT = re.compile(r"\$\{MOUSER_(?:TEAM_ID|SIGN_IDENTITY):-[^}]+\}")
+# Shell parameter expansion with a non-empty default, e.g.
+# ${MOUSER_TEAM_ID:-ABC123}, ${MOUSER_TEAM_ID-ABC123}, or ${MOUSER_TEAM_ID:=ABC123}.
+_SHELL_DEFAULT = re.compile(
+    r"\$\{MOUSER_(?:TEAM_ID|SIGN_IDENTITY)(?::?[-=])[^}]+\}"
+)
 
-# Python env lookup with a non-empty default, e.g. os.environ.get("MOUSER_TEAM_ID", "ABC").
+# Python env lookup with a non-empty default, e.g. os.environ.get("MOUSER_TEAM_ID", "ABC"),
+# os.getenv("MOUSER_TEAM_ID", "ABC"), or env.get("MOUSER_TEAM_ID", "ABC").
 _PYTHON_DEFAULT = re.compile(
-    r"""environ\.get\(\s*["']MOUSER_(?:TEAM_ID|SIGN_IDENTITY)["']\s*,\s*["'][^"']+["']"""
+    r"""(?:os\.getenv|(?:[A-Za-z_][A-Za-z0-9_]*\.)?environ\.get|[A-Za-z_][A-Za-z0-9_\.]*\.get)\(\s*["']MOUSER_(?:TEAM_ID|SIGN_IDENTITY)["']\s*,\s*["'][^"']+["']"""
 )
 
 # A literal SHA-1 codesigning identity (uppercase 40 hex chars).
@@ -92,6 +96,26 @@ class NoHardcodedSigningSecretsTests(unittest.TestCase):
             lambda line: _PYTHON_DEFAULT.search(line),
             "Python fallback default for MOUSER_TEAM_ID/MOUSER_SIGN_IDENTITY",
         )
+
+    def test_shell_guard_covers_common_default_variants(self):
+        examples = (
+            "${MOUSER_TEAM_ID:-ABC123}",
+            "${MOUSER_TEAM_ID-ABC123}",
+            "${MOUSER_SIGN_IDENTITY:=ABC123}",
+        )
+        for example in examples:
+            with self.subTest(example=example):
+                self.assertIsNotNone(_SHELL_DEFAULT.search(example))
+
+    def test_python_guard_covers_common_default_variants(self):
+        examples = (
+            'os.environ.get("MOUSER_TEAM_ID", "ABC123")',
+            'os.getenv("MOUSER_SIGN_IDENTITY", "ABC123")',
+            'env.get("MOUSER_TEAM_ID", "ABC123")',
+        )
+        for example in examples:
+            with self.subTest(example=example):
+                self.assertIsNotNone(_PYTHON_DEFAULT.search(example))
 
     def test_no_literal_codesigning_identity_hashes(self):
         self._scan(

--- a/tests/test_no_hardcoded_signing_secrets.py
+++ b/tests/test_no_hardcoded_signing_secrets.py
@@ -1,0 +1,120 @@
+"""Repo-wide guard: code-signing identities must only come from the environment.
+
+These tests scan every git-tracked text file so that a hardcoded Apple Team
+ID, a codesigning identity hash, or a baked-in fallback default can never be
+reintroduced. Signing configuration belongs in .env.local (gitignored) or the
+caller's environment.
+"""
+
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Built at runtime so this file never contains the literal itself.
+_PREVIOUSLY_LEAKED_TEAM_ID = "MVDT65" + "NPA4"
+
+# Shell parameter expansion with a non-empty default, e.g. ${MOUSER_TEAM_ID:-ABC123}.
+_SHELL_DEFAULT = re.compile(r"\$\{MOUSER_(?:TEAM_ID|SIGN_IDENTITY):-[^}]+\}")
+
+# Python env lookup with a non-empty default, e.g. os.environ.get("MOUSER_TEAM_ID", "ABC").
+_PYTHON_DEFAULT = re.compile(
+    r"""environ\.get\(\s*["']MOUSER_(?:TEAM_ID|SIGN_IDENTITY)["']\s*,\s*["'][^"']+["']"""
+)
+
+# A literal SHA-1 codesigning identity (uppercase 40 hex chars).
+_IDENTITY_HASH = re.compile(r"\b[A-F0-9]{40}\b")
+
+
+def _tracked_text_files() -> list[Path]:
+    output = subprocess.check_output(
+        ["git", "ls-files", "-z"], cwd=ROOT, text=True
+    )
+    files = []
+    for rel in output.split("\0"):
+        if not rel:
+            continue
+        path = ROOT / rel
+        if path.is_file():
+            files.append(path)
+    return files
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None  # binary or unreadable: not a place secrets hide as text
+
+
+class NoHardcodedSigningSecretsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.files = _tracked_text_files()
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            raise unittest.SkipTest("git not available; cannot enumerate tracked files")
+
+    def _scan(self, predicate, description: str) -> None:
+        offenders = []
+        for path in self.files:
+            if path == Path(__file__).resolve():
+                continue
+            text = _read_text(path)
+            if text is None:
+                continue
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if predicate(line):
+                    offenders.append(f"{path.relative_to(ROOT)}:{lineno}: {line.strip()}")
+        self.assertEqual(
+            offenders,
+            [],
+            f"{description} found in tracked files:\n" + "\n".join(offenders),
+        )
+
+    def test_no_leaked_team_id_literal(self):
+        self._scan(
+            lambda line: _PREVIOUSLY_LEAKED_TEAM_ID in line,
+            "Hardcoded Apple Team ID",
+        )
+
+    def test_no_shell_fallback_defaults_for_signing_vars(self):
+        self._scan(
+            lambda line: _SHELL_DEFAULT.search(line),
+            "Shell fallback default for MOUSER_TEAM_ID/MOUSER_SIGN_IDENTITY",
+        )
+
+    def test_no_python_fallback_defaults_for_signing_vars(self):
+        self._scan(
+            lambda line: _PYTHON_DEFAULT.search(line),
+            "Python fallback default for MOUSER_TEAM_ID/MOUSER_SIGN_IDENTITY",
+        )
+
+    def test_no_literal_codesigning_identity_hashes(self):
+        self._scan(
+            lambda line: _IDENTITY_HASH.search(line),
+            "Literal codesigning identity hash (uppercase 40-hex)",
+        )
+
+    def test_env_local_is_gitignored_and_example_is_not(self):
+        for name in (".env.local", ".env"):
+            ignored = subprocess.run(
+                ["git", "check-ignore", "-q", name],
+                cwd=ROOT,
+            )
+            self.assertEqual(ignored.returncode, 0, f"{name} must be gitignored")
+
+        example = subprocess.run(
+            ["git", "check-ignore", "-q", ".env.local.example"],
+            cwd=ROOT,
+        )
+        self.assertNotEqual(
+            example.returncode, 0, ".env.local.example must be tracked, not ignored"
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())


### PR DESCRIPTION
## Summary

- Add `.env.local.example` documenting the signing/install environment variables (`MOUSER_SIGN_IDENTITY`, `MOUSER_TEAM_ID`, `MOUSER_INSTALL_DIR`, `MOUSER_PYTHON`), kept tracked via a `.gitignore` negation while `.env*` itself stays ignored.
- Add `tests/test_no_hardcoded_signing_secrets.py`: a repo-wide guard that scans every git-tracked text file and fails if a hardcoded Apple team ID, a literal 40-hex codesigning identity, or a shell/Python fallback default for the signing env vars is ever reintroduced -- and verifies `.env.local` stays gitignored.

## Why

#201 removed a hardcoded signing team default and was closed into #202, but nothing structurally prevents the same class of leak from coming back in a future build-script change. This makes the policy executable: signing configuration can only come from the caller's environment or a gitignored `.env.local`, enforced by CI on every PR.

The guard test builds the previously-leaked team ID at runtime from fragments, so the banned literal never appears in the repo -- including in the test itself.

## Test plan

- [x] `pytest tests/test_no_hardcoded_signing_secrets.py -q` -- 5 passed.
- [x] Full `pytest tests/ -q` on this branch: 500 passed, 1 skipped, 170 subtests passed.
- [x] Verified the guard catches each violation class by temporarily planting a team-ID literal, a `${MOUSER_TEAM_ID:-X}` shell default, and an `environ.get("MOUSER_SIGN_IDENTITY", "X")` default.
- [x] `.env.local.example` is tracked; `.env.local` / `.env` are ignored (`git check-ignore`).