### PR TITLE
feat(devices): add Logitech G502 family to the device catalog

### DIFF
--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -227,7 +227,7 @@ LOGI_DEVICE_SPECS = (
     {
         "key": "g502_x",
         "display_name": "G502 X",
-        "product_ids": (0xC099, 0xC098, 0x409F),
+        "product_ids": (0xC099, 0xC098, 0xC095, 0x409F, 0x4099),
         "aliases": (
             "G502 X Gaming Mouse",
             "G502 X LIGHTSPEED",

--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -27,6 +27,21 @@ MX_ANYWHERE_SMARTSHIFT_BUTTONS = (
     "mode_shift",
 )
 
+# G502 family (G-series gaming mice). These run onboard profiles and do not
+# expose REPROG_CONTROLS_V4 (0x1B04), so HID++ button diversion -- gesture,
+# mode_shift, dpi_switch -- is unavailable. The buttons below are the ones the
+# firmware emits as standard OS events in its default profile: middle click,
+# back/forward side buttons, and wheel tilt left/right. The DPI up/down and
+# sniper buttons are consumed onboard and never reach the OS. ADJUSTABLE_DPI
+# (0x2201) is exposed, so the DPI slider works.
+G502_BUTTONS = (
+    "middle",
+    "xbutton1",
+    "xbutton2",
+    "hscroll_left",
+    "hscroll_right",
+)
+
 
 def _hotspot(
     button_key: str,
@@ -177,10 +192,91 @@ LOGI_DEVICE_SPECS = (
         "supported_buttons": MX_ANYWHERE_BUTTONS,
         "dpi_max": 4000,
     },
+    # -- G502 family ----------------------------------------------------------
+    # Product IDs verified against Solaar's device descriptors. Wireless
+    # variants list both the wired USB PID and the Lightspeed receiver WPID.
+    {
+        "key": "g502_hero",
+        "display_name": "G502 HERO",
+        "product_ids": (0xC08B,),
+        "aliases": (
+            "G502 HERO Gaming Mouse",
+            "G502 SE HERO Gaming Mouse",
+            "G502 HERO SE",
+        ),
+        "ui_layout": "g502",
+        "image_asset": "icons/mouse-simple.svg",
+        "supported_buttons": G502_BUTTONS,
+        "dpi_min": 100,
+        "dpi_max": 25600,
+    },
+    {
+        "key": "g502_lightspeed",
+        "display_name": "G502 LIGHTSPEED",
+        "product_ids": (0xC08D, 0x407F),
+        "aliases": (
+            "G502 LIGHTSPEED Wireless Gaming Mouse",
+            "G502 Lightspeed Gaming Mouse",
+        ),
+        "ui_layout": "g502",
+        "image_asset": "icons/mouse-simple.svg",
+        "supported_buttons": G502_BUTTONS,
+        "dpi_min": 100,
+        "dpi_max": 25600,
+    },
+    {
+        "key": "g502_x",
+        "display_name": "G502 X",
+        "product_ids": (0xC099, 0xC098, 0x409F),
+        "aliases": (
+            "G502 X Gaming Mouse",
+            "G502 X LIGHTSPEED",
+            "G502 X PLUS",
+        ),
+        "ui_layout": "g502",
+        "image_asset": "icons/mouse-simple.svg",
+        "supported_buttons": G502_BUTTONS,
+        "dpi_min": 100,
+        "dpi_max": 25600,
+    },
+    {
+        "key": "g502",
+        "display_name": "G502",
+        "product_ids": (0xC07D, 0xC332),
+        "aliases": (
+            "G502 Gaming Mouse",
+            "Tunable FPS Gaming Mouse G502",
+            "G502 Proteus Spectrum",
+            "G502 Proteus Core",
+        ),
+        "ui_layout": "g502",
+        "image_asset": "icons/mouse-simple.svg",
+        "supported_buttons": G502_BUTTONS,
+        "dpi_min": 200,
+        "dpi_max": 12000,
+    },
 )
 
 
 LOGI_DEVICE_LAYOUTS = {
+    # Shared placeholder for the G502 family: no device art has been
+    # contributed yet, so the page shows the generic silhouette with the
+    # G502 button list instead of an interactive hotspot diagram.
+    "g502": {
+        "key": "g502",
+        "label": "G502 family",
+        "image_asset": "icons/mouse-simple.svg",
+        "image_width": 220,
+        "image_height": 220,
+        "interactive": False,
+        "manual_selectable": False,
+        "note": (
+            "G502 buttons are remapped at the OS level. DPI up/down and the "
+            "sniper button are handled by the mouse's onboard profile and "
+            "cannot be remapped here yet."
+        ),
+        "hotspots": [],
+    },
     "mx_master_4": _layout(
         "mx_master_4",
         "MX Master 4",

--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -269,7 +269,10 @@ LOGI_DEVICE_LAYOUTS = {
         "image_width": 220,
         "image_height": 220,
         "interactive": False,
-        "manual_selectable": False,
+        # Manual-selectable so G502 owners whose device connects with an
+        # unrecognized PID/name (e.g. via a receiver) can still pick the
+        # right button set from the layout dropdown.
+        "manual_selectable": True,
         "note": (
             "G502 buttons are remapped at the OS level. DPI up/down and the "
             "sniper button are handled by the mouse's onboard profile and "

--- a/tests/test_device_layouts.py
+++ b/tests/test_device_layouts.py
@@ -13,10 +13,13 @@ class DeviceLayoutTests(unittest.TestCase):
             with self.subTest(device=device.key, ui_layout=device.ui_layout):
                 layout = get_device_layout(device.ui_layout)
 
-                if device.ui_layout == "generic_mouse":
-                    self.assertFalse(layout["interactive"])
-                else:
+                # Layouts with hotspot art must be interactive; placeholder
+                # layouts (device cataloged before artwork is contributed,
+                # per CONTRIBUTING_DEVICES.md step 3b) must not be.
+                if layout["hotspots"]:
                     self.assertTrue(layout["interactive"])
+                else:
+                    self.assertFalse(layout["interactive"])
                 self.assertEqual(layout["key"], device.ui_layout)
                 self.assertTrue((image_root / layout["image_asset"]).is_file())
 

--- a/tests/test_device_layouts.py
+++ b/tests/test_device_layouts.py
@@ -85,6 +85,14 @@ class DeviceLayoutTests(unittest.TestCase):
         self.assertIn({"key": "mx_anywhere", "label": "MX Anywhere family"}, choices)
         self.assertIn({"key": "mx_vertical", "label": "MX Vertical family"}, choices)
 
+    def test_manual_choices_include_gaming_family_layouts(self):
+        # G502 has no MX-style family fallback, so its layout must be
+        # manually selectable for owners whose device connects with an
+        # unrecognized PID/name.
+        choices = get_manual_layout_choices()
+
+        self.assertIn({"key": "g502", "label": "G502 family"}, choices)
+
     def test_manual_choices_do_not_duplicate_layout_keys(self):
         keys = [choice["key"] for choice in get_manual_layout_choices() if choice["key"]]
 

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -234,6 +234,14 @@ class LogiDeviceRegistryTests(unittest.TestCase):
         self.assertIsNotNone(device)
         self.assertEqual(device.key, "g502_x")
 
+    def test_resolve_g502_x_plus_by_product_id(self):
+        for product_id in (0xC095, 0x4099):
+            with self.subTest(product_id=f"0x{product_id:04X}"):
+                device = resolve_device(product_id=product_id)
+
+                self.assertIsNotNone(device)
+                self.assertEqual(device.key, "g502_x")
+
     def test_resolve_g502_proteus_by_reported_name(self):
         device = resolve_device(product_name="Tunable FPS Gaming Mouse G502")
 

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -213,6 +213,67 @@ class LogiDeviceRegistryTests(unittest.TestCase):
                 self.assertEqual(info.image_asset, "icons/mouse-simple.svg")
                 self.assertEqual(info.supported_buttons, ("middle", "xbutton1", "xbutton2"))
 
+    def test_resolve_g502_hero_by_product_id(self):
+        device = resolve_device(product_id=0xC08B)
+
+        self.assertIsNotNone(device)
+        self.assertEqual(device.key, "g502_hero")
+        self.assertEqual(device.ui_layout, "g502")
+
+    def test_resolve_g502_lightspeed_by_receiver_wpid(self):
+        for product_id in (0xC08D, 0x407F):
+            with self.subTest(product_id=f"0x{product_id:04X}"):
+                device = resolve_device(product_id=product_id)
+
+                self.assertIsNotNone(device)
+                self.assertEqual(device.key, "g502_lightspeed")
+
+    def test_resolve_g502_x_plus_by_alias(self):
+        device = resolve_device(product_name="G502 X PLUS")
+
+        self.assertIsNotNone(device)
+        self.assertEqual(device.key, "g502_x")
+
+    def test_resolve_g502_proteus_by_reported_name(self):
+        device = resolve_device(product_name="Tunable FPS Gaming Mouse G502")
+
+        self.assertIsNotNone(device)
+        self.assertEqual(device.key, "g502")
+
+    def test_g502_buttons_are_os_level_only(self):
+        buttons = get_buttons_for_layout("g502")
+
+        self.assertIn("middle", buttons)
+        self.assertIn("xbutton1", buttons)
+        self.assertIn("xbutton2", buttons)
+        self.assertIn("hscroll_left", buttons)
+        self.assertIn("hscroll_right", buttons)
+        # No REPROG_CONTROLS_V4 on G-series onboard-profile mice, so no
+        # HID++-gated buttons may be offered.
+        self.assertNotIn("gesture", buttons)
+        self.assertNotIn("mode_shift", buttons)
+        self.assertNotIn("dpi_switch", buttons)
+
+    def test_g502_layout_is_placeholder_not_generic(self):
+        layout = get_device_layout("g502")
+
+        self.assertEqual(layout["key"], "g502")
+        self.assertFalse(layout["interactive"])
+        self.assertEqual(layout["hotspots"], [])
+
+    def test_build_g502_hero_connected_info(self):
+        info = build_connected_device_info(
+            product_id=0xC08B,
+            product_name="G502 HERO Gaming Mouse",
+            transport="usb",
+        )
+
+        self.assertEqual(info.key, "g502_hero")
+        self.assertEqual(info.display_name, "G502 HERO")
+        self.assertEqual(info.ui_layout, "g502")
+        self.assertEqual(clamp_dpi(50000, info), 25600)
+        self.assertEqual(clamp_dpi(50, info), 100)
+
     def test_known_device_layout_metadata_is_valid(self):
         for device in iter_known_devices():
             with self.subTest(device=device.key):


### PR DESCRIPTION
## Summary

- Catalog four G502 variants with product IDs verified against Solaar's device descriptors:
  - **G502 HERO / SE HERO** -- USB `0xC08B`
  - **G502 LIGHTSPEED** -- USB `0xC08D`, Lightspeed receiver WPID `0x407F`
  - **G502 X / X LIGHTSPEED / X PLUS** -- `0xC099` / `0xC098` / WPID `0x409F`
  - **G502 (Proteus Core / Spectrum)** -- `0xC07D` / `0xC332`
- New `G502_BUTTONS` set: middle, back/forward, wheel tilt left/right.
- Non-interactive `g502` placeholder layout (no device art contributed yet) with a user-facing note; the layout invariant test is relaxed to "interactive iff hotspots exist", matching what CONTRIBUTING_DEVICES.md step 3b already documents.

## Why no HID++ buttons or gestures

G-series gaming mice run onboard profiles and do not expose `REPROG_CONTROLS_V4` (0x1B04) -- confirmed in Solaar feature dumps for `C08B` and `C07D` -- so button diversion (gesture / mode_shift / dpi_switch) is impossible. Only the buttons the default onboard profile emits as standard OS events are offered. DPI up/down and the sniper button are consumed onboard and never reach the OS. `ADJUSTABLE_DPI` (0x2201) **is** exposed, so the DPI slider works, with per-sensor clamp ranges (100-25600 HERO/X, 200-12000 Proteus).

## Test plan

- [x] 7 new tests: PID resolution for each variant (incl. receiver WPID), alias resolution (`G502 X PLUS`, `Tunable FPS Gaming Mouse G502`), OS-level-only button gating, placeholder layout fallback, DPI clamping.
- [x] Full `pytest tests/ -q` on this branch: 502 passed, 1 skipped, 200 subtests passed.
- [ ] On-hardware verification welcome from G502 owners -- a Settings -> Debug -> "Copy device info" dump in this PR thread would let us confirm the reprog/feature assumptions per variant.