### PR TITLE
feat(catalog): add Logitech M650 Signature support

### DIFF
--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -42,6 +42,15 @@ G502_BUTTONS = (
     "hscroll_right",
 )
 
+# M650 Signature family: no horizontal scroll, no mode-shift, no dedicated gesture button.
+# Exposes a Virtual Gesture Button (CID 0x00D7) via REPROG_CONTROLS_V4 but no physical
+# gesture key. Middle click, back, and forward side buttons are the configurable controls.
+M650_BUTTONS = (
+    "middle",
+    "xbutton1",
+    "xbutton2",
+)
+
 
 def _hotspot(
     button_key: str,
@@ -192,6 +201,34 @@ LOGI_DEVICE_SPECS = (
         "supported_buttons": MX_ANYWHERE_BUTTONS,
         "dpi_max": 4000,
     },
+    # -- M650 Signature family ------------------------------------------------
+    # Compact wireless mouse (middle, back, forward buttons). Connects via Logi
+    # Bolt receiver or Bluetooth LE. HID++ reports device name "Signature M650".
+    # Confirmed via live HID++ probe: REPROG_CONTROLS_V4 (slot 2 on Bolt receiver),
+    # LOWRES_WHEEL, ADJUSTABLE_DPI (200–4000 DPI), UNIFIED_BATTERY.
+    # Bluetooth LE product ID not yet confirmed; product_ids left empty so
+    # name-based matching ("Signature M650" / "Logi M650") handles detection.
+    {
+        "key": "m650",
+        "display_name": "M650 Signature",
+        "product_ids": (),
+        "aliases": (
+            "Signature M650",
+            "Logi M650",
+            "M650",
+            "M650 Signature",
+            "Logitech M650 Signature",
+            "M650 L",
+            "M650 L Signature",
+            "Signature M650 L",
+            "M650 Signature for Business",
+        ),
+        "ui_layout": "m650",
+        "image_asset": "icons/mouse-simple.svg",
+        "supported_buttons": M650_BUTTONS,
+        "dpi_min": 200,
+        "dpi_max": 4000,
+    },
     # -- G502 family ----------------------------------------------------------
     # Product IDs verified against Solaar's device descriptors. Wireless
     # variants list both the wired USB PID and the Lightspeed receiver WPID.
@@ -259,6 +296,23 @@ LOGI_DEVICE_SPECS = (
 
 
 LOGI_DEVICE_LAYOUTS = {
+    # M650 Signature: no device art yet; shows generic silhouette with the
+    # three-button layout. Interactive hotspot diagram can be added once
+    # mouse artwork is sourced and product_ids are confirmed.
+    "m650": {
+        "key": "m650",
+        "label": "M650 Signature",
+        "image_asset": "icons/mouse-simple.svg",
+        "image_width": 220,
+        "image_height": 220,
+        "interactive": False,
+        "manual_selectable": True,
+        "note": (
+            "M650 Signature — middle click, back, and forward side buttons "
+            "are all configurable. No gesture button or horizontal scroll."
+        ),
+        "hotspots": [],
+    },
     # Shared placeholder for the G502 family: no device art has been
     # contributed yet, so the page shows the generic silhouette with the
     # G502 button list instead of an interactive hotspot diagram.

--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -206,15 +206,17 @@ LOGI_DEVICE_SPECS = (
     # Bolt receiver or Bluetooth LE. HID++ reports device name "Signature M650".
     # Confirmed via live HID++ probe: REPROG_CONTROLS_V4 (slot 2 on Bolt receiver),
     # LOWRES_WHEEL, ADJUSTABLE_DPI (200–4000 DPI), UNIFIED_BATTERY.
-    # Bluetooth LE product ID not yet confirmed; product_ids left empty so
-    # name-based matching ("Signature M650" / "Logi M650") handles detection.
+    # Bluetooth LE product ID confirmed in issue #215 as 0xB02A; keep the
+    # common HID/OS name variants as fallbacks because some platforms only
+    # surface the product string.
     {
         "key": "m650",
         "display_name": "M650 Signature",
-        "product_ids": (),
+        "product_ids": (0xB02A,),
         "aliases": (
             "Signature M650",
             "Logi M650",
+            "Logitech Signature M650",
             "M650",
             "M650 Signature",
             "Logitech M650 Signature",

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -85,6 +85,47 @@ class LogiDeviceRegistryTests(unittest.TestCase):
                     "logitech-mice/mx_anywhere_3/mouse.png",
                 )
 
+    def test_resolve_m650_by_bluetooth_pid(self):
+        device = resolve_device(product_id=0xB02A)
+
+        self.assertIsNotNone(device)
+        self.assertEqual(device.key, "m650")
+        self.assertEqual(device.ui_layout, "m650")
+
+    def test_resolve_m650_by_common_name_variants(self):
+        for product_name in (
+            "Signature M650",
+            "Logi M650",
+            "Logitech Signature M650",
+        ):
+            with self.subTest(product_name=product_name):
+                device = resolve_device(product_name=product_name)
+
+                self.assertIsNotNone(device)
+                self.assertEqual(device.key, "m650")
+                self.assertEqual(device.ui_layout, "m650")
+
+    def test_build_m650_connected_device_info_uses_catalog_layout_and_buttons(self):
+        info = build_connected_device_info(
+            product_id=0xB02A,
+            product_name="Signature M650",
+            reprog_controls=[
+                {"cid": 0x0052},
+                {"cid": 0x0053},
+                {"cid": 0x0056},
+                {"cid": 0x00D7},
+            ],
+            gesture_cids=(0x00D7,),
+        )
+
+        self.assertEqual(info.key, "m650")
+        self.assertEqual(info.display_name, "M650 Signature")
+        self.assertEqual(info.ui_layout, "m650")
+        self.assertEqual(info.image_asset, "icons/mouse-simple.svg")
+        self.assertEqual(info.supported_buttons, ("middle", "xbutton1", "xbutton2"))
+        self.assertEqual(info.dpi_min, 200)
+        self.assertEqual(info.dpi_max, 4000)
+
     def test_mx_anywhere_3s_uses_exact_catalog_layout(self):
         info = build_connected_device_info(product_id=0xB037)
 


### PR DESCRIPTION
Device confirmed via live HID++ probe on Logi Bolt receiver (slot 2):
- REPROG_CONTROLS_V4 (0x1B04) at feature index 0x08
- LOWRES_WHEEL (0x2110) at 0x0B
- ADJUSTABLE_DPI (0x2201) at 0x0C, range 200–4000 DPI
- UNIFIED_BATTERY (0x1004) at 0x07
- Virtual Gesture Button (CID 0x00D7) — diverted, no physical key
- Three configurable controls: middle (0x0052), back (0x0053), forward (0x0056)
- HID++ device name: "Signature M650" (Bolt) / "Logi M650" (macOS)

Adds catalog entry for the M650 Signature family with:
- Aliases covering all known name variants from HID++ and OS HID layer
- Non-interactive layout using generic mouse SVG (no device artwork yet)
- Empty product_ids (Bluetooth LE PID not yet confirmed; name-matching covers Bolt)
- dpi_min/max set to 200/4000 to match hardware-reported bounds