### PR TITLE
Docs: is_process_trusted() silently returns True on framework load failure — behavior undocumented

### DIFF
--- a/core/accessibility.py
+++ b/core/accessibility.py
@@ -76,6 +76,14 @@ def _create_prompt_options(app_services, core_foundation):
 
 
 def is_process_trusted(prompt: bool = False) -> bool:
+    """Check whether the current process is trusted for accessibility.
+
+    On macOS, this checks the system accessibility trust status. On other
+    platforms, or if the macOS frameworks cannot be loaded, returns ``True``
+    so the application does not block on permission checks that are not
+    applicable or cannot be performed. Exceptions during the trust check
+    also result in ``True`` to prevent the application from blocking.
+    """
     frameworks = _load_frameworks()
     if not frameworks:
         return True


### PR DESCRIPTION
## Problem

The function is_process_trusted() is the public API callers use to decide whether to show accessibility permission prompts. Both the _load_frameworks and the main try/except paths return True on failure (lines ~43, ~95), meaning callers will believe accessibility is granted when ctypes loading or the trust check itself throws. This "fail open" design is intentional (so the app doesn't block on non-macOS platforms or broken frameworks), but it is not documented anywhere. A maintainer debugging a user report of "Mouser said permissions were fine but hooks don't work" has no indication that this is the cause. The module docstring and function docstring are both missing.


**Severity**: `medium`
**File**: `core/accessibility.py`

## Solution

Add a docstring to is_process_trusted:


## Changes

- `core/accessibility.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
