### PR TITLE
fix: avoid background HID polling resetting system idle timers

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -4,6 +4,7 @@ current configuration.  Sits between the hook layer and the UI.
 Supports per-application auto-switching of profiles.
 """
 
+import sys
 import threading
 import time
 from core.mouse_hook import MouseHook, MouseEvent
@@ -27,6 +28,48 @@ from core.logi_devices import clamp_dpi
 HSCROLL_ACTION_COOLDOWN_S = 0.35
 HSCROLL_VOLUME_COOLDOWN_S = 0.06
 _VOLUME_ACTIONS = {"volume_up", "volume_down"}
+BACKGROUND_BATTERY_POLL_INTERVAL_S = 1800
+BACKGROUND_SMART_SHIFT_POLL_INTERVAL_S = 300
+BACKGROUND_HID_POLL_IDLE_GRACE_S = 60.0
+BACKGROUND_HID_POLL_EVENT_FUZZ_S = 2.0
+
+
+def _system_idle_seconds():
+    """Return seconds since the last user input when the platform exposes it."""
+    if sys.platform == "darwin":
+        try:
+            import Quartz
+            state = getattr(Quartz, "kCGEventSourceStateCombinedSessionState", 0)
+            any_event = getattr(Quartz, "kCGAnyInputEventType", 0xFFFFFFFF)
+            return float(Quartz.CGEventSourceSecondsSinceLastEventType(
+                state, any_event
+            ))
+        except Exception:
+            return None
+
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            class LASTINPUTINFO(ctypes.Structure):
+                _fields_ = [
+                    ("cbSize", ctypes.c_uint),
+                    ("dwTime", ctypes.c_uint),
+                ]
+
+            last_input = LASTINPUTINFO()
+            last_input.cbSize = ctypes.sizeof(LASTINPUTINFO)
+            if not ctypes.windll.user32.GetLastInputInfo(
+                ctypes.byref(last_input)
+            ):
+                return None
+            tick_count = ctypes.windll.kernel32.GetTickCount()
+            elapsed_ms = (tick_count - last_input.dwTime) & 0xFFFFFFFF
+            return elapsed_ms / 1000.0
+        except Exception:
+            return None
+
+    return None
 
 
 class Engine:
@@ -59,6 +102,8 @@ class Engine:
         )
         self._battery_poll_stop = threading.Event()
         self._battery_poll_thread = None          # track the poller thread
+        self._last_background_hid_poll_at = None
+        self._frontend_visible = False
         self._last_connection_state = bool(self._hid_runtime_state().input_ready)
         self._last_hid_features_ready = bool(self.hid_features_ready)
         self._hid_replay_requested_this_launch = False
@@ -635,10 +680,37 @@ class Engine:
         if hid_features_ready and hid_features_changed:
             self._request_saved_settings_replay()
 
+    def _background_hid_poll_allowed(self, now):
+        if not self._frontend_visible:
+            return False
+        idle_seconds = _system_idle_seconds()
+        if idle_seconds is None:
+            return True
+        if idle_seconds >= BACKGROUND_HID_POLL_IDLE_GRACE_S:
+            return False
+
+        last_poll_at = self._last_background_hid_poll_at
+        if last_poll_at is None:
+            return True
+
+        seconds_since_poll = max(0.0, now - last_poll_at)
+        if seconds_since_poll <= BACKGROUND_HID_POLL_EVENT_FUZZ_S:
+            return True
+
+        return idle_seconds < (
+            seconds_since_poll - BACKGROUND_HID_POLL_EVENT_FUZZ_S
+        )
+
+    def _record_background_hid_poll(self, now):
+        self._last_background_hid_poll_at = now
+
+    def set_frontend_visible(self, visible):
+        self._frontend_visible = bool(visible)
+
     def _battery_poll_loop(self, stop_event):
         """Read battery and smart shift mode periodically until disconnected."""
-        _battery_poll_interval = 300   # seconds between battery reads
-        _ss_poll_interval = 15         # seconds between scroll-mode reads
+        _battery_poll_interval = BACKGROUND_BATTERY_POLL_INTERVAL_S
+        _ss_poll_interval = BACKGROUND_SMART_SHIFT_POLL_INTERVAL_S
         _last_battery = time.time() - _battery_poll_interval  # fire immediately
         _last_ss = time.time() - _ss_poll_interval            # fire immediately
         _last_ss_mode = None
@@ -647,8 +719,12 @@ class Engine:
             now = time.time()
             hg = self.hook._hid_gesture
             if hg and hg.connected_device is not None:
-                if now - _last_battery >= _battery_poll_interval:
+                if (
+                    now - _last_battery >= _battery_poll_interval
+                    and self._background_hid_poll_allowed(now)
+                ):
                     _last_battery = now
+                    self._record_background_hid_poll(now)
                     level = hg.read_battery()
                     if stop_event.is_set():
                         return
@@ -662,8 +738,10 @@ class Engine:
                     not self._replay_inflight
                     and now - _last_ss >= _ss_poll_interval
                     and hg.smart_shift_supported
+                    and self._background_hid_poll_allowed(now)
                 ):
                     _last_ss = now
+                    self._record_background_hid_poll(now)
                     ss_mode = hg.read_smart_shift()
                     if stop_event.is_set():
                         return

--- a/main_qml.py
+++ b/main_qml.py
@@ -1150,8 +1150,11 @@ def main():
 
     def _on_window_visibility_changed(visibility):
         # QWindow.Visibility: Hidden = 0; any other value (Windowed,
-        # Maximized, FullScreen, Minimized) means there is an on-screen
-        # window. macOS Cmd+Tab / Mission Control / Dock representation
+        # Maximized, FullScreen, Minimized) means there is a window surface.
+        # Background HID polling is only useful while the settings window is
+        # actually visible enough to show refreshed battery / SmartShift state.
+        #
+        # macOS Cmd+Tab / Mission Control / Dock representation
         # depends on the activation policy, which we toggle to mirror
         # whether a window is currently shown:
         #   shown  → Regular   (real foreground app)
@@ -1162,20 +1165,26 @@ def main():
         # `_set_macos_activation_policy` is idempotent, so the storm of
         # visibilityChanged emits during a window state transition
         # collapses to at most one AppKit round-trip per direction.
-        is_visible = visibility != QWindow.Visibility.Hidden
-        _set_macos_activation_policy(regular=is_visible)
-        if is_visible:
+        has_window_surface = visibility != QWindow.Visibility.Hidden
+        frontend_visible = visibility not in (
+            QWindow.Visibility.Hidden,
+            QWindow.Visibility.Minimized,
+        )
+        engine.set_frontend_visible(frontend_visible)
+        if sys.platform != "darwin":
+            return
+        _set_macos_activation_policy(regular=has_window_surface)
+        if has_window_surface:
             # Window just became visible -- bring the app forward so the
             # user actually sees it (covers initial launch + tray clicks).
             _activate_macos_window()
 
+    root_window.visibilityChanged.connect(_on_window_visibility_changed)
+    # The window was created before this handler was connected, so its initial
+    # visibility transition may already have fired with no listener. Reconcile
+    # the engine's frontend-visible flag now.
+    _on_window_visibility_changed(root_window.visibility())
     if sys.platform == "darwin":
-        root_window.visibilityChanged.connect(_on_window_visibility_changed)
-        # The window was created visible (QML `visible: !launchHidden`) before
-        # this handler was connected, so its initial visibility transition has
-        # already fired with no listener. Reconcile the activation policy now
-        # so the Dock tile shows on a `--show-window` / non-hidden start.
-        _on_window_visibility_changed(root_window.visibility())
         global _MACOS_QUIT_FILTER
         _MACOS_QUIT_FILTER = _MacOSQuitToTrayFilter(root_window, app)
         app.installEventFilter(_MACOS_QUIT_FILTER)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -496,6 +496,7 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
 
     def test_battery_poll_skips_smart_shift_reads_while_replay_is_inflight(self):
         engine = self._make_engine()
+        engine.set_frontend_visible(True)
         stop_event = Mock()
         stop_event.is_set.return_value = False
         stop_event.wait.return_value = True
@@ -511,6 +512,76 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
 
         engine.hook._hid_gesture.read_battery.assert_called_once_with()
         engine.hook._hid_gesture.read_smart_shift.assert_not_called()
+
+    def test_battery_poll_skips_background_hid_reads_while_frontend_hidden(self):
+        engine = self._make_engine()
+        stop_event = Mock()
+        stop_event.is_set.return_value = False
+        stop_event.wait.return_value = True
+        engine.hook._hid_gesture = SimpleNamespace(
+            connected_device=SimpleNamespace(name="MX Master 3S"),
+            smart_shift_supported=True,
+            read_battery=Mock(return_value=None),
+            read_smart_shift=Mock(return_value={
+                "mode": "ratchet",
+                "enabled": False,
+                "threshold": 25,
+            }),
+        )
+
+        engine._battery_poll_loop(stop_event)
+
+        engine.hook._hid_gesture.read_battery.assert_not_called()
+        engine.hook._hid_gesture.read_smart_shift.assert_not_called()
+
+    def test_battery_poll_skips_background_hid_reads_while_system_idle(self):
+        engine = self._make_engine()
+        engine.set_frontend_visible(True)
+        stop_event = Mock()
+        stop_event.is_set.return_value = False
+        stop_event.wait.return_value = True
+        engine.hook._hid_gesture = SimpleNamespace(
+            connected_device=SimpleNamespace(name="MX Master 3S"),
+            smart_shift_supported=True,
+            read_battery=Mock(return_value=None),
+            read_smart_shift=Mock(return_value={
+                "mode": "ratchet",
+                "enabled": False,
+                "threshold": 25,
+            }),
+        )
+
+        with patch("core.engine._system_idle_seconds", return_value=120.0):
+            engine._battery_poll_loop(stop_event)
+
+        engine.hook._hid_gesture.read_battery.assert_not_called()
+        engine.hook._hid_gesture.read_smart_shift.assert_not_called()
+
+    def test_battery_poll_does_not_repeat_without_user_activity_after_poll(self):
+        engine = self._make_engine()
+        engine.set_frontend_visible(True)
+        stop_event = Mock()
+        stop_event.is_set.return_value = False
+        stop_event.wait.side_effect = [False, False, True]
+        engine.hook._hid_gesture = SimpleNamespace(
+            connected_device=SimpleNamespace(name="MX Master 3S"),
+            smart_shift_supported=True,
+            read_battery=Mock(return_value=None),
+            read_smart_shift=Mock(return_value=None),
+        )
+
+        with (
+            patch("core.engine.time.time", side_effect=[
+                0.0, 0.0, 0.0, 5.0, 300.0, 300.0,
+            ]),
+            patch("core.engine._system_idle_seconds", side_effect=[
+                0.0, 0.0, 300.0,
+            ]),
+        ):
+            engine._battery_poll_loop(stop_event)
+
+        engine.hook._hid_gesture.read_battery.assert_called_once_with()
+        engine.hook._hid_gesture.read_smart_shift.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This changes Mouser's background HID polling so it no longer keeps resetting the OS idle timer while the app is hidden or the user is inactive.

The issue appears to come from periodic HID++ reads, especially SmartShift polling, being interpreted by the OS as user activity. That prevents display timeout and system sleep even when the mouse and keyboard are untouched.

## Changes

- Gate background battery / SmartShift HID reads behind frontend visibility.
- Skip background HID polling once the system has been idle for a grace period.
- Avoid repeated background polls unless there has been real user activity since the last poll.
- Increase background polling intervals to reduce unnecessary HID traffic.
- Track QML window visibility, including minimized state, and pass it to the engine.
- Add tests covering hidden frontend, idle system state, and repeated polling without user activity.


## Related

Related to #178.

The discussion there identified periodic HID++ reads, especially SmartShift polling, as a likely cause of the OS idle timer being reset while Mouser runs in the background. This PR makes those background reads visibility- and idle-aware, and I manually verified the macOS sleep behavior after building the updated app locally.