### PR TITLE
Per-button slide gestures for mice without a dedicated gesture button (macOS)

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -42,15 +42,41 @@ GESTURE_DIRECTION_BUTTONS = (
     "gesture_down",
 )
 
+# Per-button slide gestures: each non-primary button (back/forward/middle) can
+# independently own a 4-direction gesture, driven by the macOS event tap
+# rather than the HID++ thumb gesture button above. Namespaced keys keep this
+# additive to GESTURE_DIRECTION_BUTTONS, which stays wired to the HID path.
+GESTURE_OWNERS = ("back", "forward", "middle")
+GESTURE_DIRECTIONS = ("left", "right", "up", "down")
+
+_GESTURE_OWNER_LABELS = {"back": "Back", "forward": "Forward", "middle": "Middle"}
+
+_PER_BUTTON_GESTURE_LABELS = {
+    f"gesture_{owner}_{direction}": f"{_GESTURE_OWNER_LABELS[owner]} gesture swipe {direction}"
+    for owner in GESTURE_OWNERS
+    for direction in GESTURE_DIRECTIONS
+}
+
+# The 12 namespaced keys, e.g. "gesture_back_left" .. "gesture_middle_down".
+PER_BUTTON_GESTURE_KEYS = tuple(_PER_BUTTON_GESTURE_LABELS)
+
+GESTURE_HOLD_FLOOR_MS_DEFAULT = 80
+
 PROFILE_BUTTON_NAMES = {
     **BUTTON_NAMES,
     "gesture_left":  "Gesture swipe left",
     "gesture_right": "Gesture swipe right",
     "gesture_up":    "Gesture swipe up",
     "gesture_down":  "Gesture swipe down",
+    **_PER_BUTTON_GESTURE_LABELS,
 }
 
-# Maps config button keys to the MouseEvent types they correspond to
+# Maps config button keys to the MouseEvent types they correspond to.
+# NOTE: the 12 namespaced gesture_<owner>_<direction> binding keys deliberately
+# have NO entry here. The event-tap kernel emits the generic gesture_swipe_<dir>
+# event tagged with raw_data["gesture_owner"], and engine._make_owner_gesture_handler
+# routes on that tag -- a namespaced "gesture_<owner>_swipe_<dir>" string is never
+# dispatched. Resolve these bindings via gesture_bindings_for(), not this map.
 BUTTON_TO_EVENTS = {
     "middle":        ("middle_down", "middle_up"),
     "gesture":       ("gesture_click",),
@@ -80,6 +106,7 @@ DEFAULT_CONFIG = {
                 "gesture_right": "none",
                 "gesture_up": "none",
                 "gesture_down": "none",
+                **{key: "none" for key in PER_BUTTON_GESTURE_KEYS},
                 "xbutton1": "alt_tab",
                 "xbutton2": "alt_tab",
                 "hscroll_left": "browser_back",
@@ -102,6 +129,7 @@ DEFAULT_CONFIG = {
         "gesture_deadzone": 40,
         "gesture_timeout_ms": 3000,
         "gesture_cooldown_ms": 500,
+        "gesture_hold_floor_ms": GESTURE_HOLD_FLOOR_MS_DEFAULT,
         "appearance_mode": "system",
         "debug_mode": False,
         "device_layout_overrides": {},
@@ -200,6 +228,28 @@ def get_active_mappings(cfg):
     profiles = cfg.get("profiles", {})
     profile = profiles.get(profile_name, profiles.get("default", {}))
     return profile.get("mappings", DEFAULT_CONFIG["profiles"]["default"]["mappings"])
+
+
+def gesture_owners(cfg):
+    """Buttons (back/forward/middle) with >=1 per-button gesture direction bound."""
+    mappings = get_active_mappings(cfg)
+    return {
+        owner
+        for owner in GESTURE_OWNERS
+        if any(
+            mappings.get(f"gesture_{owner}_{direction}", "none") != "none"
+            for direction in GESTURE_DIRECTIONS
+        )
+    }
+
+
+def gesture_bindings_for(cfg, owner):
+    """Return {swipe_left: action_id, swipe_right: ..., swipe_up: ..., swipe_down: ...}."""
+    mappings = get_active_mappings(cfg)
+    return {
+        f"swipe_{direction}": mappings.get(f"gesture_{owner}_{direction}", "none")
+        for direction in GESTURE_DIRECTIONS
+    }
 
 
 def set_mapping(cfg, button, action_id, profile=None):
@@ -339,6 +389,10 @@ def _migrate(cfg):
     cfg["settings"].setdefault("screenshot_directory", "")
     cfg["settings"].setdefault("check_for_updates", True)
     cfg["settings"].setdefault("update_check_state", {})
+    cfg["settings"].setdefault("gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT)
+    cfg["settings"]["gesture_hold_floor_ms"] = max(
+        0, int(cfg["settings"].get("gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT))
+    )
 
     # Always migrate old wmplayer.exe → Microsoft.Media.Player.exe in profile apps
     for pdata in cfg.get("profiles", {}).values():
@@ -346,6 +400,13 @@ def _migrate(cfg):
         for i, a in enumerate(apps):
             if a.lower() == "wmplayer.exe":
                 apps[i] = "Microsoft.Media.Player.exe"
+
+    # Always ensure the 12 namespaced per-button gesture keys exist ("none" =
+    # off) so pre-existing configs surface no owners without erroring.
+    for pdata in cfg.get("profiles", {}).values():
+        mappings = pdata.setdefault("mappings", {})
+        for key in PER_BUTTON_GESTURE_KEYS:
+            mappings.setdefault(key, "none")
 
     return cfg
 

--- a/core/engine.py
+++ b/core/engine.py
@@ -13,7 +13,9 @@ from core.key_simulator import (
 )
 from core.config import (
     load_config, get_active_mappings, get_profile_for_app,
-    BUTTON_TO_EVENTS, GESTURE_DIRECTION_BUTTONS, save_config,
+    BUTTON_TO_EVENTS, GESTURE_DIRECTION_BUTTONS, GESTURE_DIRECTIONS,
+    GESTURE_HOLD_FLOOR_MS_DEFAULT, gesture_owners, gesture_bindings_for,
+    save_config,
 )
 from core.app_detector import AppDetector
 from core.mouse_hook_types import HidRuntimeState
@@ -95,6 +97,27 @@ class Engine:
     # ------------------------------------------------------------------
     # Hook wiring
     # ------------------------------------------------------------------
+    def _active_gesture_owners(self, cfg, settings):
+        """Owners actually armed at the hook (finding #1): config-bound AND
+        the UI enable toggle (settings.gesture_owner_enabled) is on AND the
+        connected device can host a per-button gesture on that owner --
+        mirrors the capability check in ui.backend.gestureEligibleOwners.
+        Direction bindings themselves are left untouched in config; this only
+        narrows what gets passed to the hook as armed. No device connected
+        means arming is moot, so nothing is eligible."""
+        bound = gesture_owners(cfg)
+        if not bound:
+            return set()
+        device = getattr(self, "connected_device", None)
+        device_buttons = getattr(device, "supported_buttons", None) if device else None
+        if device_buttons is None:
+            return set()
+        enabled_flags = settings.get("gesture_owner_enabled", {})
+        return {
+            owner for owner in bound
+            if enabled_flags.get(owner, False) and f"gesture_{owner}_left" in device_buttons
+        }
+
     def _setup_hooks(self):
         """Register callbacks and block events for all mapped buttons."""
         mappings = get_active_mappings(self.cfg)
@@ -106,13 +129,16 @@ class Engine:
         if hasattr(self.hook, "ignore_trackpad"):
             self.hook.ignore_trackpad = settings.get("ignore_trackpad", True)
         self.hook.debug_mode = self._debug_events_enabled
+        owners = self._active_gesture_owners(self.cfg, settings)
         self.hook.configure_gestures(
-            enabled=any(mappings.get(key, "none") != "none"
-                        for key in GESTURE_DIRECTION_BUTTONS),
+            enabled=bool(owners) or any(mappings.get(key, "none") != "none"
+                                        for key in GESTURE_DIRECTION_BUTTONS),
             threshold=settings.get("gesture_threshold", 50),
             deadzone=settings.get("gesture_deadzone", 40),
             timeout_ms=settings.get("gesture_timeout_ms", 3000),
             cooldown_ms=settings.get("gesture_cooldown_ms", 500),
+            owners=owners,
+            hold_floor_ms=settings.get("gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT),
         )
         # Divert mode shift CID only when the device has the button and
         # at least one profile maps it to an action.  When no device is
@@ -166,36 +192,76 @@ class Engine:
                         else:
                             # Single-fire event (gesture, swipe) → full click
                             self.hook.register(evt_type, self._make_handler(action_id))
+                    elif btn_key in GESTURE_DIRECTION_BUTTONS:
+                        self.hook.register(evt_type, self._make_hid_gesture_handler(action_id))
                     else:
                         self.hook.register(evt_type, self._make_handler(action_id))
 
+        # Per-owner event-tap gestures (issue 004): the kernel tags the fired
+        # gesture with the active owner in raw_data rather than a namespaced
+        # event, so route (owner, direction) -> gesture_<owner>_<dir> here.
+        if owners:
+            owner_bindings = {owner: gesture_bindings_for(self.cfg, owner) for owner in owners}
+            for direction in GESTURE_DIRECTIONS:
+                self.hook.register(
+                    f"gesture_swipe_{direction}",
+                    self._make_owner_gesture_handler(owner_bindings, direction),
+                )
+
     def _make_handler(self, action_id):
         def handler(event):
-            try:
-                if self._enabled:
-                    self._emit_debug(
-                        f"Mapped {event.event_type} -> {action_id} "
-                        f"({self._action_label(action_id)})"
-                    )
-                    if event.event_type.startswith("gesture_"):
-                        self._emit_gesture_event({
-                            "type": "mapped",
-                            "event_name": event.event_type,
-                            "action_id": action_id,
-                            "action_label": self._action_label(action_id),
-                        })
-                    if action_id == "toggle_smart_shift":
-                        self._toggle_smart_shift()
-                    elif action_id == "switch_scroll_mode":
-                        self._switch_scroll_mode()
-                    elif action_id == "cycle_dpi":
-                        self._cycle_dpi()
-                    else:
-                        execute_action(action_id)
-            except Exception as exc:
-                print(f"[Engine] _make_handler EXCEPTION for {action_id}: {exc}")
-                import traceback; traceback.print_exc()
+            self._run_action(action_id, event)
         return handler
+
+    def _make_hid_gesture_handler(self, action_id):
+        """Like _make_handler, but yields to per-owner routing: a gesture_swipe_*
+        event tagged with a gesture_owner came from an event-tap owner gesture,
+        not the HID dedicated gesture button this handler is bound to."""
+        def handler(event):
+            raw = event.raw_data
+            if isinstance(raw, dict) and raw.get("gesture_owner") is not None:
+                return
+            self._run_action(action_id, event)
+        return handler
+
+    def _make_owner_gesture_handler(self, owner_bindings, direction):
+        field = f"swipe_{direction}"
+        def handler(event):
+            raw = event.raw_data
+            owner = raw.get("gesture_owner") if isinstance(raw, dict) else None
+            if owner is None:
+                return
+            action_id = owner_bindings.get(owner, {}).get(field, "none")
+            if action_id == "none":
+                return
+            self._run_action(action_id, event)
+        return handler
+
+    def _run_action(self, action_id, event):
+        try:
+            if self._enabled:
+                self._emit_debug(
+                    f"Mapped {event.event_type} -> {action_id} "
+                    f"({self._action_label(action_id)})"
+                )
+                if event.event_type.startswith("gesture_"):
+                    self._emit_gesture_event({
+                        "type": "mapped",
+                        "event_name": event.event_type,
+                        "action_id": action_id,
+                        "action_label": self._action_label(action_id),
+                    })
+                if action_id == "toggle_smart_shift":
+                    self._toggle_smart_shift()
+                elif action_id == "switch_scroll_mode":
+                    self._switch_scroll_mode()
+                elif action_id == "cycle_dpi":
+                    self._cycle_dpi()
+                else:
+                    execute_action(action_id)
+        except Exception as exc:
+            print(f"[Engine] _run_action EXCEPTION for {action_id}: {exc}")
+            import traceback; traceback.print_exc()
 
     def _make_mouse_down_handler(self, action_id):
         def _safety_release():
@@ -634,6 +700,15 @@ class Engine:
             self._battery_poll_thread.start()
         if hid_features_ready and hid_features_changed:
             self._request_saved_settings_replay()
+            # Device capabilities (supported_buttons) are only known once HID
+            # features are ready; the initial _setup_hooks ran with no device
+            # connected, so device-gated features (per-button gesture arming)
+            # computed empty. Re-wire now that the button set is known -- reset
+            # first (mirrors _switch_profile/reload_mappings) so handlers don't
+            # stack on reconnect.
+            with self._lock:
+                self.hook.reset_bindings()
+                self._setup_hooks()
 
     def _battery_poll_loop(self, stop_event):
         """Read battery and smart shift mode periodically until disconnected."""

--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -27,6 +27,27 @@ MX_ANYWHERE_SMARTSHIFT_BUTTONS = (
     "mode_shift",
 )
 
+# MX Anywhere 2S has no dedicated HID++ gesture button, so its slide gestures
+# are event-tap-driven and per-button (issue #002) rather than the shared
+# gesture/gesture_left/etc keys above. Extends (not replaces) the family
+# tuple: the legacy global gesture_* keys stay listed but remain inert at
+# runtime (narrowed away — no divertable HID gesture control on this mouse).
+MX_ANYWHERE_2S_BUTTONS = (
+    *MX_ANYWHERE_BUTTONS,
+    "gesture_back_left",
+    "gesture_back_right",
+    "gesture_back_up",
+    "gesture_back_down",
+    "gesture_forward_left",
+    "gesture_forward_right",
+    "gesture_forward_up",
+    "gesture_forward_down",
+    "gesture_middle_left",
+    "gesture_middle_right",
+    "gesture_middle_up",
+    "gesture_middle_down",
+)
+
 # G502 family (G-series gaming mice). These run onboard profiles and do not
 # expose REPROG_CONTROLS_V4 (0x1B04), so HID++ button diversion -- gesture,
 # mode_shift, dpi_switch -- is unavailable. The buttons below are the ones the
@@ -198,8 +219,11 @@ LOGI_DEVICE_SPECS = (
         ),
         "ui_layout": "mx_anywhere_2s",
         "image_asset": "logitech-mice/mx_anywhere_2s/mouse.png",
-        "supported_buttons": MX_ANYWHERE_BUTTONS,
+        "supported_buttons": MX_ANYWHERE_2S_BUTTONS,
         "dpi_max": 4000,
+        # No hardware gesture button — gestures are event-tap-driven per
+        # button (back/forward/middle), not the HID++ RawXY path.
+        "supports_event_tap_gestures": True,
     },
     # -- M650 Signature family ------------------------------------------------
     # Compact wireless mouse (middle, back, forward buttons). Connects via Logi

--- a/core/logi_devices.py
+++ b/core/logi_devices.py
@@ -75,6 +75,15 @@ _GESTURE_BUTTON_KEYS = (
     "gesture_up",
     "gesture_down",
 )
+# Per-button slide-gesture keys (event-tap path, issue #001/#002). Distinct
+# from the HID++ thumb-gesture keys above: gated on supports_event_tap_gestures
+# rather than a divertable RawXY control, so a mouse with no gesture button
+# (e.g. the MX Anywhere 2S) can still advertise them.
+_PER_BUTTON_GESTURE_DIRECTION_KEYS = tuple(
+    f"gesture_{owner}_{direction}"
+    for owner in ("back", "forward", "middle")
+    for direction in ("left", "right", "up", "down")
+)
 _CID_GATED_BUTTONS = {
     "mode_shift": 0x00C4,
     "dpi_switch": 0x00FD,
@@ -119,6 +128,7 @@ class LogiDeviceSpec:
     supported_buttons: tuple[str, ...] = DEFAULT_BUTTON_LAYOUT
     dpi_min: int = DEFAULT_DPI_MIN
     dpi_max: int = DEFAULT_DPI_MAX
+    supports_event_tap_gestures: bool = False
 
     def matches(self, product_id=None, product_name=None) -> bool:
         if product_id is not None and int(product_id) in self.product_ids:
@@ -286,6 +296,7 @@ class DeviceCapabilityInventory:
     divertable_gesture_cids: tuple[int, ...] = ()
     gesture_click: bool = False
     gesture_directions: bool = False
+    supports_event_tap_gestures: bool = False
     mode_shift: bool = False
     dpi_switch: bool = False
     hscroll_cids: tuple[int, ...] = ()
@@ -305,6 +316,9 @@ class DeviceCapabilityInventory:
             allowed.difference_update(
                 ("gesture_left", "gesture_right", "gesture_up", "gesture_down")
             )
+
+        if not self.supports_event_tap_gestures:
+            allowed.difference_update(_PER_BUTTON_GESTURE_DIRECTION_KEYS)
 
         if not self.mode_shift:
             allowed.discard("mode_shift")
@@ -338,6 +352,7 @@ class DeviceCapabilityInventory:
             ],
             "gesture_click": self.gesture_click,
             "gesture_directions": self.gesture_directions,
+            "supports_event_tap_gestures": self.supports_event_tap_gestures,
             "mode_shift": self.mode_shift,
             "dpi_switch": self.dpi_switch,
             "hscroll": bool(self.hscroll_cids),
@@ -671,6 +686,7 @@ def build_device_capability_inventory(
     gesture_rawxy_enabled=None,
     discovered_features=None,
     diagnostics=None,
+    supports_event_tap_gestures=False,
 ) -> DeviceCapabilityInventory:
     controls_by_cid = _control_by_cid(controls or ())
     feature_entries = _feature_entries(discovered_features)
@@ -718,6 +734,7 @@ def build_device_capability_inventory(
         divertable_gesture_cids=divertable_gesture_cids,
         gesture_click=gesture_click,
         gesture_directions=gesture_directions,
+        supports_event_tap_gestures=bool(supports_event_tap_gestures),
         mode_shift=bool(
             mode_shift_control and _control_is_divertable(mode_shift_control)
         ),
@@ -744,6 +761,7 @@ def derive_supported_buttons_from_reprog_controls(
     gesture_cids=None,
     active_gesture_cid=None,
     gesture_rawxy_enabled=None,
+    supports_event_tap_gestures=False,
 ) -> tuple[str, ...]:
     """Narrow HID++-gated buttons using discovered REPROG_V4 controls.
 
@@ -755,6 +773,7 @@ def derive_supported_buttons_from_reprog_controls(
         gesture_cids=gesture_cids,
         active_gesture_cid=active_gesture_cid,
         gesture_rawxy_enabled=gesture_rawxy_enabled,
+        supports_event_tap_gestures=supports_event_tap_gestures,
     )
     return inventory.supported_buttons(static_buttons)
 
@@ -810,6 +829,7 @@ def build_connected_device_info(
         gesture_rawxy_enabled=gesture_rawxy_enabled,
         discovered_features=discovered_features,
         diagnostics=diagnostics,
+        supports_event_tap_gestures=getattr(spec, "supports_event_tap_gestures", False),
     )
     if spec:
         resolved_gesture_cids = tuple(gesture_cids or spec.gesture_cids)

--- a/core/mouse_hook_base.py
+++ b/core/mouse_hook_base.py
@@ -12,6 +12,59 @@ except Exception:
 
 from core.mouse_hook_types import HidRuntimeState, MouseEvent, format_debug_details
 
+# Default hold floor (ms) below which an owner-button press is a click, not a
+# gesture (D4). Mirrors core.config GESTURE_HOLD_FLOOR_MS_DEFAULT.
+_GESTURE_HOLD_FLOOR_MS_DEFAULT = 80
+
+# Release-decision outcomes for an event-tap gesture-owner button.
+CLICK = "click"
+GESTURE = "gesture"
+
+
+def _gesture_direction(dx, dy, threshold, deadzone):
+    """Cardinal swipe direction for accumulated deltas, or None if none.
+
+    Pure mirror of BaseMouseHook._detect_gesture_event so the event-tap
+    on-release decision matches the live HID detector exactly.
+    """
+    abs_x = abs(dx)
+    abs_y = abs(dy)
+    dominant = max(abs_x, abs_y)
+    if dominant < threshold:
+        return None
+    cross_limit = max(deadzone, dominant * 0.35)
+    if abs_x > abs_y:
+        if abs_y > cross_limit:
+            return None
+        return MouseEvent.GESTURE_SWIPE_RIGHT if dx > 0 else MouseEvent.GESTURE_SWIPE_LEFT
+    if abs_x > cross_limit:
+        return None
+    return MouseEvent.GESTURE_SWIPE_DOWN if dy > 0 else MouseEvent.GESTURE_SWIPE_UP
+
+
+def decide_gesture(held_ms, dx, dy, hold_floor_ms, threshold, deadzone):
+    """Classify a gesture-owner button release as a click or a directional gesture.
+
+    Returns (CLICK, None) or (GESTURE, MouseEvent.GESTURE_SWIPE_*). Objc-free so
+    the CGEventTap handler and unit tests share one decision. A release is a
+    gesture only when held >= the floor AND the slide resolves to a direction;
+    everything else replays the button's normal click (dual-mode, D2/D4).
+    """
+    if held_ms < hold_floor_ms:
+        return CLICK, None
+    direction = _gesture_direction(dx, dy, threshold, deadzone)
+    if direction is None:
+        return CLICK, None
+    return GESTURE, direction
+
+
+def should_arm_gesture(gesture_active, btn_owner, owners):
+    """First-wins arming gate: arm an event-tap gesture only for an owner button
+    while no gesture (event-tap or HID) is already active; else pass it through."""
+    if btn_owner not in owners:
+        return False
+    return not gesture_active
+
 
 class BaseMouseHook:
     def __init__(self):
@@ -42,6 +95,8 @@ class BaseMouseHook:
         self._gesture_delta_y = 0.0
         self._gesture_cooldown_until = 0.0
         self._gesture_input_source = None
+        self._gesture_owners = set()
+        self._gesture_hold_floor_ms = _GESTURE_HOLD_FLOOR_MS_DEFAULT
         self._connected_device = None
         self._dispatch_queue = None
 
@@ -91,12 +146,19 @@ class BaseMouseHook:
         deadzone=40,
         timeout_ms=3000,
         cooldown_ms=500,
+        owners=None,
+        hold_floor_ms=None,
     ):
         self._gesture_direction_enabled = bool(enabled)
         self._gesture_threshold = float(max(5, threshold))
         self._gesture_deadzone = float(max(0, deadzone))
         self._gesture_timeout_ms = max(250, int(timeout_ms))
         self._gesture_cooldown_ms = max(0, int(cooldown_ms))
+        # Per-button event-tap gesture owners are independent of the HID
+        # direction feature above; issue 004 supplies both from config.
+        self._gesture_owners = set(owners) if owners else set()
+        if hold_floor_ms is not None:
+            self._gesture_hold_floor_ms = max(0, int(hold_floor_ms))
         if not self._gesture_direction_enabled:
             self._gesture_tracking = False
             self._gesture_triggered = False

--- a/core/mouse_hook_contract.py
+++ b/core/mouse_hook_contract.py
@@ -2,7 +2,7 @@
 Structural contract exposed by platform mouse hook implementations.
 """
 
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Any, Callable, Optional, Protocol, runtime_checkable
 
 from core.mouse_hook_types import HidRuntimeState
 
@@ -27,6 +27,8 @@ class MouseHookLike(Protocol):
         deadzone: int = 40,
         timeout_ms: int = 3000,
         cooldown_ms: int = 500,
+        owners: Optional[set] = None,
+        hold_floor_ms: Optional[int] = None,
     ) -> None: ...
     def set_connection_change_callback(self, cb: Callable[[bool], None]) -> None: ...
     def set_debug_callback(self, callback: Callable[[str], None]) -> None: ...

--- a/core/mouse_hook_macos.py
+++ b/core/mouse_hook_macos.py
@@ -8,7 +8,14 @@ import sys
 import threading
 import time
 
-from core.mouse_hook_base import BaseMouseHook, HidGestureListener
+from core.mouse_hook_base import (
+    CLICK,
+    GESTURE,
+    BaseMouseHook,
+    HidGestureListener,
+    decide_gesture,
+    should_arm_gesture,
+)
 from core.mouse_hook_types import MouseEvent
 
 try:
@@ -42,6 +49,8 @@ def _autoreleased(fn):
 _BTN_MIDDLE = 2
 _BTN_BACK = 3
 _BTN_FORWARD = 4
+# CGEvent button number -> per-button gesture owner name (core.config GESTURE_OWNERS).
+_BTN_TO_OWNER = {_BTN_BACK: "back", _BTN_FORWARD: "forward", _BTN_MIDDLE: "middle"}
 _SCROLL_INVERT_MARKER = 0x4D4F5553
 _INJECTED_EVENT_MARKER = 0x4D4F5554
 _kCGEventTapDisabledByTimeout = 0xFFFFFFFE
@@ -66,6 +75,11 @@ class MouseHook(BaseMouseHook):
         self._init_dispatch_queue(maxsize=512)
         self._dispatch_thread = None
         self._first_event_logged = False
+        # Active event-tap gesture (None = none). Set on an owner-button down,
+        # cleared on its up; scopes the deferred click + cursor freeze.
+        self._gesture_owner = None
+        self._gesture_owner_btn = None
+        self._gesture_press_at = 0.0
 
     def _negate_scroll_axis(self, cg_event, axis):
         for field_name in (
@@ -246,6 +260,102 @@ class MouseHook(BaseMouseHook):
             self._finish_gesture_tracking()
             return
 
+    def _reset_event_tap_gesture_state(self):
+        """Clear all armed-owner-gesture state (scopes the D8 cursor freeze
+        and the should_arm_gesture gate shared with the HID path)."""
+        self._gesture_active = False
+        self._gesture_owner = None
+        self._gesture_owner_btn = None
+        self._gesture_press_at = 0.0
+        self._gesture_triggered = False
+        self._finish_gesture_tracking()
+
+    def _abort_event_tap_gesture(self, reason):
+        """Give up an armed owner-button gesture without firing an event or
+        replaying a click. Used when the release is missed -- the move-swallow
+        timeout, a tap re-enable after CGEventTap was disabled by the system,
+        or stop() -- so the cursor freeze and should_arm_gesture never stick
+        forever (finding #2)."""
+        if self._gesture_owner is None:
+            return
+        owner = self._gesture_owner
+        self._emit_debug(f"Event-tap gesture aborted owner={owner} reason={reason}")
+        self._emit_gesture_event(
+            {"type": "aborted", "source": "event_tap", "owner": owner, "reason": reason}
+        )
+        self._reset_event_tap_gesture_state()
+
+    def _finish_event_tap_gesture(self, btn):
+        """Resolve an armed owner-button release: fire the tagged gesture event,
+        or replay the deferred normal click (dual-mode, D2/D4)."""
+        owner = self._gesture_owner
+        held_ms = (time.monotonic() - self._gesture_press_at) * 1000.0
+        decision, direction = decide_gesture(
+            held_ms,
+            self._gesture_delta_x,
+            self._gesture_delta_y,
+            self._gesture_hold_floor_ms,
+            self._gesture_threshold,
+            self._gesture_deadzone,
+        )
+        if decision == GESTURE:
+            self._gesture_triggered = True
+            # Tag the generic direction event with the active owner; issue 004
+            # routes (owner + direction) -> the namespaced gesture_<owner>_swipe_<dir>.
+            self._enqueue_dispatch_event(
+                MouseEvent(
+                    direction,
+                    {
+                        "delta_x": self._gesture_delta_x,
+                        "delta_y": self._gesture_delta_y,
+                        "source": "event_tap",
+                        "gesture_owner": owner,
+                    },
+                )
+            )
+            self._emit_debug(
+                f"Event-tap gesture fired owner={owner} dir={direction} "
+                f"held_ms={held_ms:.0f}"
+            )
+            self._emit_gesture_event(
+                {
+                    "type": "detected",
+                    "event_name": direction,
+                    "source": "event_tap",
+                    "owner": owner,
+                }
+            )
+        else:
+            self._emit_debug(f"Event-tap tap->click owner={owner} held_ms={held_ms:.0f}")
+            self._emit_gesture_event(
+                {"type": "button_up", "source": "event_tap", "owner": owner,
+                 "click_candidate": True}
+            )
+            # A tap fires the button's normal Mouser mapping (dispatch its
+            # DOWN+UP so the engine runs the mapped action), NOT a native
+            # replay -- macOS ignores raw button 4/3, so a native replay is a
+            # dead click. Falls through to nothing if the button is unmapped.
+            self._dispatch_owner_button_click(btn)
+
+        self._reset_event_tap_gesture_state()
+
+    # gesture-owner button number -> its normal (down, up) MouseEvent pair.
+    _OWNER_CLICK_EVENTS = {
+        _BTN_MIDDLE: (MouseEvent.MIDDLE_DOWN, MouseEvent.MIDDLE_UP),
+        _BTN_BACK: (MouseEvent.XBUTTON1_DOWN, MouseEvent.XBUTTON1_UP),
+        _BTN_FORWARD: (MouseEvent.XBUTTON2_DOWN, MouseEvent.XBUTTON2_UP),
+    }
+
+    def _dispatch_owner_button_click(self, btn):
+        """Tap of a gesture-owner button: dispatch its normal DOWN+UP events so
+        the engine fires the button's mapped action (dual-mode, option 1)."""
+        pair = self._OWNER_CLICK_EVENTS.get(btn)
+        if pair is None:
+            return
+        down, up = pair
+        self._enqueue_dispatch_event(MouseEvent(down))
+        self._enqueue_dispatch_event(MouseEvent(up))
+
     def _dispatch_worker(self):
         while self._running:
             try:
@@ -266,6 +376,10 @@ class MouseHook(BaseMouseHook):
                     f"(type=0x{event_type:X}), re-enabling",
                     flush=True,
                 )
+                # A pending owner-gesture release may have been dropped while
+                # the tap was disabled -- abort it rather than leave the
+                # cursor frozen (finding #2).
+                self._abort_event_tap_gesture("tap_disabled")
                 Quartz.CGEventTapEnable(self._tap, True)
                 return cg_event
 
@@ -286,12 +400,35 @@ class MouseHook(BaseMouseHook):
             mouse_event = None
             should_block = False
 
+            is_move = event_type in (
+                Quartz.kCGEventMouseMoved,
+                Quartz.kCGEventOtherMouseDragged,
+            )
+            if is_move and self._gesture_active and self._gesture_owner is not None:
+                # A missed button-up (tap disabled under load, device drops
+                # mid-hold) must not freeze the cursor forever (finding #2):
+                # abort and let this move through once the hold outlives the
+                # configured gesture timeout.
+                if (
+                    time.monotonic() - self._gesture_press_at
+                    > self._gesture_timeout_ms / 1000.0
+                ):
+                    self._abort_event_tap_gesture("timeout")
+                    # fall through -- do not swallow this move
+                else:
+                    # Event-tap owner gesture: accumulate for the on-release
+                    # decision and freeze the cursor (D8) by swallowing the
+                    # motion so no net pointer delta reaches the OS.
+                    self._gesture_delta_x += Quartz.CGEventGetIntegerValueField(
+                        cg_event, Quartz.kCGMouseEventDeltaX
+                    )
+                    self._gesture_delta_y += Quartz.CGEventGetIntegerValueField(
+                        cg_event, Quartz.kCGMouseEventDeltaY
+                    )
+                    return None
+
             if (
-                event_type
-                in (
-                    Quartz.kCGEventMouseMoved,
-                    Quartz.kCGEventOtherMouseDragged,
-                )
+                is_move
                 and self._gesture_direction_enabled
                 and self._gesture_active
             ):
@@ -335,6 +472,23 @@ class MouseHook(BaseMouseHook):
                         self._debug_callback(f"OtherMouseDown btn={btn}")
                     except Exception:
                         pass
+                owner = _BTN_TO_OWNER.get(btn)
+                if owner and should_arm_gesture(
+                    self._gesture_active, owner, self._gesture_owners
+                ):
+                    # Arm the gesture and DEFER this button's normal down; the
+                    # click is replayed on release iff it turns out to be a tap.
+                    self._gesture_active = True
+                    self._gesture_owner = owner
+                    self._gesture_owner_btn = btn
+                    self._gesture_triggered = False
+                    self._gesture_press_at = time.monotonic()
+                    self._start_gesture_tracking()
+                    self._emit_debug(f"Event-tap gesture armed owner={owner} btn={btn}")
+                    self._emit_gesture_event(
+                        {"type": "button_down", "source": "event_tap", "owner": owner}
+                    )
+                    return None
                 if btn == _BTN_MIDDLE:
                     mouse_event = MouseEvent(MouseEvent.MIDDLE_DOWN)
                     should_block = MouseEvent.MIDDLE_DOWN in self._blocked_events
@@ -354,6 +508,9 @@ class MouseHook(BaseMouseHook):
                         self._debug_callback(f"OtherMouseUp btn={btn}")
                     except Exception:
                         pass
+                if self._gesture_owner is not None and btn == self._gesture_owner_btn:
+                    self._finish_event_tap_gesture(btn)
+                    return None
                 if btn == _BTN_MIDDLE:
                     mouse_event = MouseEvent(MouseEvent.MIDDLE_UP)
                     should_block = MouseEvent.MIDDLE_UP in self._blocked_events
@@ -604,6 +761,7 @@ class MouseHook(BaseMouseHook):
     def stop(self):
         self._unregister_wake_observer()
         self._running = False
+        self._abort_event_tap_gesture("stop")
         self._stop_hid_listener()
         self._connected_device = None
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -50,6 +50,7 @@ class _FakeEngine:
         self.start_count = 0
         self.stop_count = 0
         self.start_error = None
+        self.reload_mappings_count = 0
 
     def set_profile_change_callback(self, cb):
         self.profile_callback = cb
@@ -82,6 +83,9 @@ class _FakeEngine:
 
     def stop(self):
         self.stop_count += 1
+
+    def reload_mappings(self):
+        self.reload_mappings_count += 1
 
 
 @unittest.skipIf(Backend is None, "PySide6 not installed in test environment")
@@ -1224,6 +1228,188 @@ class BackendDeviceLayoutTests(unittest.TestCase):
 
         create_profile.assert_not_called()
         self.assertIn("Profile already exists", status_messages)
+
+
+@unittest.skipIf(Backend is None, "PySide6 not installed in test environment")
+class BackendPerButtonGestureTests(unittest.TestCase):
+    """issue #006 -- per-button gesture toggle + namespaced binding get/set."""
+
+    def _make_backend(self, engine=None, cfg=None):
+        loaded_config = copy.deepcopy(cfg or DEFAULT_CONFIG)
+        with (
+            patch("ui.backend.load_config", return_value=loaded_config),
+            patch("ui.backend.save_config"),
+            patch("ui.backend.supports_login_startup", return_value=False),
+        ):
+            return Backend(engine=engine)
+
+    def _mx_anywhere_2s(self):
+        return SimpleNamespace(
+            key="mx_anywhere_2s",
+            display_name="MX Anywhere 2S",
+            dpi_min=200,
+            dpi_max=4000,
+            ui_layout="mx_anywhere_2s",
+            supported_buttons=(
+                "middle", "xbutton1", "xbutton2",
+                "gesture_forward_left", "gesture_forward_right",
+                "gesture_forward_up", "gesture_forward_down",
+            ),
+        )
+
+    def test_gesture_owner_for_button_maps_hotspot_keys_to_owners(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.gestureOwnerForButton("xbutton1"), "back")
+        self.assertEqual(backend.gestureOwnerForButton("xbutton2"), "forward")
+        self.assertEqual(backend.gestureOwnerForButton("middle"), "middle")
+        self.assertEqual(backend.gestureOwnerForButton("hscroll_left"), "")
+
+    def test_gesture_mode_off_by_default(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.gestureEnabledOwners, [])
+        bindings = backend.gestureOwnerBindings("default", "forward")
+        self.assertTrue(all(entry["actionId"] == "none" for entry in bindings))
+
+    def test_set_gesture_owner_enabled_persists_and_notifies(self):
+        backend = self._make_backend()
+        settings_changed = []
+        backend.settingsChanged.connect(lambda: settings_changed.append(True))
+
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setGestureOwnerEnabled("forward", True)
+
+        save_mock.assert_called_once()
+        self.assertEqual(backend.gestureEnabledOwners, ["forward"])
+        self.assertEqual(len(settings_changed), 1)
+
+    def test_set_gesture_owner_enabled_noop_when_unchanged(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("forward", True)
+
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setGestureOwnerEnabled("forward", True)
+
+        save_mock.assert_not_called()
+
+    def test_set_gesture_owner_enabled_rejects_unknown_owner(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config") as save_mock:
+            # "gesture" is the HID thumb button, not a per-button owner.
+            backend.setGestureOwnerEnabled("gesture", True)
+        save_mock.assert_not_called()
+        self.assertEqual(backend.gestureEnabledOwners, [])
+
+    def test_set_gesture_owner_enabled_reruns_engine_mapping_reload(self):
+        engine = _FakeEngine()
+        backend = self._make_backend(engine=engine)
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("middle", True)
+        self.assertEqual(engine.reload_mappings_count, 1)
+
+    def test_toggle_off_does_not_clear_direction_bindings(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("back", True)
+        with patch("core.config.save_config"):
+            backend.setGestureOwnerBinding("default", "back", "up", "mission_control")
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("back", False)
+
+        self.assertEqual(backend.gestureEnabledOwners, [])
+        bindings = {
+            entry["direction"]: entry["actionId"]
+            for entry in backend.gestureOwnerBindings("default", "back")
+        }
+        self.assertEqual(bindings["up"], "mission_control")
+
+    def test_toggle_off_does_not_touch_single_action_mapping(self):
+        backend = self._make_backend()
+
+        def xbutton1_action():
+            mappings = backend.getProfileMappings("default")
+            return next(m["actionId"] for m in mappings if m["key"] == "xbutton1")
+
+        original = xbutton1_action()
+        self.assertEqual(original, "alt_tab")  # DEFAULT_CONFIG value, sanity check
+
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("back", True)
+        with patch("core.config.save_config"):
+            backend.setGestureOwnerBinding("default", "back", "left", "browser_back")
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("back", False)
+
+        self.assertEqual(xbutton1_action(), original)
+
+    def test_set_and_get_gesture_owner_binding_round_trip(self):
+        backend = self._make_backend()
+        with patch("core.config.save_config"):
+            backend.setGestureOwnerBinding("default", "forward", "up", "mission_control")
+
+        bindings = {
+            entry["direction"]: entry["actionId"]
+            for entry in backend.gestureOwnerBindings("default", "forward")
+        }
+        self.assertEqual(bindings["up"], "mission_control")
+        self.assertEqual(bindings["left"], "none")
+        self.assertEqual(bindings["right"], "none")
+        self.assertEqual(bindings["down"], "none")
+
+    def test_set_gesture_owner_binding_rejects_unknown_owner_or_direction(self):
+        backend = self._make_backend()
+        with patch("core.config.save_config") as save_mock:
+            backend.setGestureOwnerBinding("default", "trigger", "up", "mission_control")
+            backend.setGestureOwnerBinding("default", "back", "diagonal", "mission_control")
+        save_mock.assert_not_called()
+
+    def test_gesture_owner_bindings_unknown_owner_returns_empty(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.gestureOwnerBindings("default", "trigger"), [])
+
+    def test_gesture_hold_floor_ms_default(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.gestureHoldFloorMs, 80)
+
+    def test_set_gesture_hold_floor_ms_clamps_and_persists(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setGestureHoldFloorMs(-25)
+        save_mock.assert_called_once()
+        self.assertEqual(backend.gestureHoldFloorMs, 0)
+
+    def test_set_gesture_hold_floor_ms_noop_when_unchanged(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setGestureHoldFloorMs(120)
+
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setGestureHoldFloorMs(120)
+        save_mock.assert_not_called()
+
+    def test_gesture_eligible_owners_defaults_permissive_without_device(self):
+        backend = self._make_backend()
+        self.assertEqual(set(backend.gestureEligibleOwners), {"back", "forward", "middle"})
+
+    def test_gesture_eligible_owners_narrowed_by_device_capability(self):
+        backend = self._make_backend(
+            engine=_FakeEngine(device_connected=True, connected_device=self._mx_anywhere_2s())
+        )
+        self.assertEqual(backend.gestureEligibleOwners, ["forward"])
+
+    def test_gesture_eligible_owners_empty_when_device_lacks_capability(self):
+        device = SimpleNamespace(
+            key="mx_master_3s",
+            display_name="MX Master 3S",
+            dpi_min=200,
+            dpi_max=8000,
+            ui_layout="mx_master_3s",
+            supported_buttons=("middle", "xbutton1", "xbutton2"),
+        )
+        backend = self._make_backend(
+            engine=_FakeEngine(device_connected=True, connected_device=device)
+        )
+        self.assertEqual(backend.gestureEligibleOwners, [])
 
 
 @unittest.skipIf(Backend is None, "PySide6 not installed in test environment")

--- a/tests/test_config_gestures.py
+++ b/tests/test_config_gestures.py
@@ -1,0 +1,153 @@
+import json
+import unittest
+
+from core import config
+
+
+def _cfg_with_mappings(mappings):
+    """A DEFAULT_CONFIG deep copy with extra mappings applied to the default profile."""
+    cfg = json.loads(json.dumps(config.DEFAULT_CONFIG))
+    cfg["profiles"]["default"]["mappings"].update(mappings)
+    return cfg
+
+
+class PerButtonGestureSchemaTests(unittest.TestCase):
+    def test_twelve_namespaced_keys_exist_and_validate(self):
+        self.assertEqual(len(config.PER_BUTTON_GESTURE_KEYS), 12)
+        for owner in ("back", "forward", "middle"):
+            for direction in ("left", "right", "up", "down"):
+                key = f"gesture_{owner}_{direction}"
+                with self.subTest(key=key):
+                    self.assertIn(key, config.PER_BUTTON_GESTURE_KEYS)
+                    self.assertIn(key, config.PROFILE_BUTTON_NAMES)
+                    # Deliberately NOT in BUTTON_TO_EVENTS: the kernel emits the
+                    # generic gesture_swipe_<dir> tagged with gesture_owner, so
+                    # a namespaced event string is never dispatched. These keys
+                    # resolve via gesture_bindings_for() instead.
+                    self.assertNotIn(key, config.BUTTON_TO_EVENTS)
+                    self.assertEqual(
+                        config.DEFAULT_CONFIG["profiles"]["default"]["mappings"][key],
+                        "none",
+                    )
+
+
+class GestureOwnersTests(unittest.TestCase):
+    def test_default_config_has_zero_gesture_owners(self):
+        cfg = _cfg_with_mappings({})
+        self.assertEqual(config.gesture_owners(cfg), set())
+
+    def test_one_bound_direction_marks_its_owner(self):
+        cfg = _cfg_with_mappings({"gesture_forward_up": "mission_control"})
+        self.assertEqual(config.gesture_owners(cfg), {"forward"})
+
+    def test_multiple_owners_bound_independently(self):
+        cfg = _cfg_with_mappings({
+            "gesture_back_left": "browser_back",
+            "gesture_middle_right": "browser_forward",
+        })
+        self.assertEqual(config.gesture_owners(cfg), {"back", "middle"})
+
+    def test_gesture_bindings_for_returns_swipe_keyed_dict(self):
+        cfg = _cfg_with_mappings({
+            "gesture_forward_up": "mission_control",
+            "gesture_forward_down": "app_expose",
+        })
+        self.assertEqual(
+            config.gesture_bindings_for(cfg, "forward"),
+            {
+                "swipe_left": "none",
+                "swipe_right": "none",
+                "swipe_up": "mission_control",
+                "swipe_down": "app_expose",
+            },
+        )
+
+    def test_gesture_bindings_for_unbound_owner_is_all_none(self):
+        cfg = _cfg_with_mappings({"gesture_forward_up": "mission_control"})
+        self.assertEqual(
+            config.gesture_bindings_for(cfg, "back"),
+            {"swipe_left": "none", "swipe_right": "none", "swipe_up": "none", "swipe_down": "none"},
+        )
+
+
+class GestureHoldFloorTests(unittest.TestCase):
+    def test_default_hold_floor_is_80ms(self):
+        migrated = config._migrate({"version": 1, "profiles": {}, "settings": {}})
+        self.assertEqual(migrated["settings"]["gesture_hold_floor_ms"], 80)
+
+    def test_hold_floor_preserves_a_valid_custom_value(self):
+        migrated = config._migrate(
+            {"version": 9, "profiles": {}, "settings": {"gesture_hold_floor_ms": 120}}
+        )
+        self.assertEqual(migrated["settings"]["gesture_hold_floor_ms"], 120)
+
+    def test_hold_floor_clamped_to_zero_minimum(self):
+        migrated = config._migrate(
+            {"version": 9, "profiles": {}, "settings": {"gesture_hold_floor_ms": -50}}
+        )
+        self.assertEqual(migrated["settings"]["gesture_hold_floor_ms"], 0)
+
+
+class GestureBackCompatTests(unittest.TestCase):
+    def test_preexisting_config_with_no_owner_keys_loads_with_zero_owners(self):
+        # Simulates a config saved by pre-#001 Mouser: no per-button gesture
+        # keys anywhere in the mappings dict.
+        legacy = {
+            "version": 9,
+            "active_profile": "default",
+            "profiles": {
+                "default": {
+                    "label": "Default",
+                    "apps": [],
+                    "mappings": {
+                        "middle": "none",
+                        "xbutton1": "alt_tab",
+                        "xbutton2": "alt_tab",
+                    },
+                }
+            },
+            "settings": {},
+        }
+
+        migrated = config._migrate(legacy)
+
+        self.assertEqual(config.gesture_owners(migrated), set())
+        for key in config.PER_BUTTON_GESTURE_KEYS:
+            self.assertEqual(migrated["profiles"]["default"]["mappings"][key], "none")
+
+    def test_legacy_global_gesture_keys_still_resolve_and_are_not_owners(self):
+        # A config with the OLD global gesture_left/right/up/down keys bound
+        # (the MX Master HID-thumb-button path) must keep working exactly as
+        # before, and must NOT be mistaken for a per-button owner.
+        legacy = {
+            "version": 3,
+            "active_profile": "default",
+            "profiles": {
+                "default": {
+                    "label": "Default",
+                    "apps": [],
+                    "mappings": {
+                        "gesture": "gesture_click_action",
+                        "gesture_left": "mission_control",
+                        "gesture_right": "app_expose",
+                        "gesture_up": "desktop_left",
+                        "gesture_down": "desktop_right",
+                    },
+                }
+            },
+            "settings": {},
+        }
+
+        migrated = config._migrate(legacy)
+
+        mappings = migrated["profiles"]["default"]["mappings"]
+        self.assertEqual(mappings["gesture"], "gesture_click_action")
+        self.assertEqual(mappings["gesture_left"], "mission_control")
+        self.assertEqual(mappings["gesture_right"], "app_expose")
+        self.assertEqual(mappings["gesture_up"], "desktop_left")
+        self.assertEqual(mappings["gesture_down"], "desktop_right")
+        self.assertEqual(config.gesture_owners(migrated), set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_device_layouts.py
+++ b/tests/test_device_layouts.py
@@ -148,6 +148,47 @@ class DeviceLayoutTests(unittest.TestCase):
     def test_mx_anywhere_2s_has_no_self_fallback(self):
         self.assertEqual(_FAMILY_FALLBACKS.get("mx_anywhere_2s"), "mx_anywhere")
 
+    def test_mx_anywhere_2s_exposes_per_button_gesture_keys_in_capability_model(self):
+        # Issue #005: back/forward/middle must be reachable as gesture owners
+        # once the event-tap flag (issue #002) is wired in.
+        device = next(d for d in KNOWN_LOGI_DEVICES if d.key == "mx_anywhere_2s")
+
+        self.assertTrue(device.supports_event_tap_gestures)
+        for owner in ("back", "forward", "middle"):
+            for direction in ("left", "right", "up", "down"):
+                self.assertIn(f"gesture_{owner}_{direction}", device.supported_buttons)
+
+        # No dedicated "gesture" hotspot on the 2S -- per-button gesture mode
+        # is reached via each button's own hotspot (middle/xbutton1/xbutton2),
+        # not a separate affordance (issue #005 technical decision).
+        layout = get_device_layout("mx_anywhere_2s")
+        hotspot_keys = {hotspot["buttonKey"] for hotspot in layout["hotspots"]}
+        self.assertNotIn("gesture", hotspot_keys)
+
+    def test_mx_master_layouts_untouched_by_2s_gesture_affordance_work(self):
+        # Regression guard for issue #005: MX Master family layouts and specs
+        # must be byte-identical -- this feature is 2S-only.
+        expected_hotspot_keys = {
+            "mx_master_4": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+            "mx_master_3s": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+            "mx_master_3": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+            "mx_master_2s": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+            "mx_master_classic": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+        }
+        for layout_key, expected_keys in expected_hotspot_keys.items():
+            with self.subTest(layout=layout_key):
+                layout = LOGI_DEVICE_LAYOUTS[layout_key]
+                self.assertEqual(
+                    [hotspot["buttonKey"] for hotspot in layout["hotspots"]],
+                    expected_keys,
+                )
+
+        for device in KNOWN_LOGI_DEVICES:
+            if device.key.startswith("mx_master"):
+                with self.subTest(device=device.key):
+                    self.assertFalse(device.supports_event_tap_gestures)
+                    self.assertNotIn("gesture_back_left", device.supported_buttons)
+
     def test_mx_vertical_layout_is_interactive(self):
         layout = get_device_layout("mx_vertical")
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,11 +1,58 @@
 import copy
+import sys
+import types
 import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from core.config import DEFAULT_CONFIG
-from core.mouse_hook import MouseEvent
-from core.mouse_hook_types import HidRuntimeState
+def _ensure_core_engine_importable():
+    """Make `core.engine` importable in this sandbox (no PyObjC/objc).
+
+    core.engine does `from core.mouse_hook import ...` (platform dispatch)
+    and `from core.app_detector import AppDetector`, both of which pull in
+    the native macOS hook at module load. Every test in this file patches
+    both classes out anyway (_FakeMouseHook / _FakeAppDetector), so stub
+    the two modules just long enough to import core.engine once — it's
+    then cached for the rest of the session — and remove the stubs again
+    immediately after, so any *other* test file that imports
+    core.mouse_hook / core.app_detector directly still sees the real
+    (missing-PyObjC) failure, unaffected by this workaround.
+    """
+    try:
+        import core.engine  # noqa: F401
+        return
+    except ImportError:
+        pass
+
+    from core.mouse_hook_types import MouseEvent as _MouseEvent
+
+    stubbed = []
+    for name, attr, extra in (
+        ("core.mouse_hook", "MouseHook", {"MouseEvent": _MouseEvent}),
+        ("core.app_detector", "AppDetector", {}),
+    ):
+        if name in sys.modules:
+            continue
+        stub = types.ModuleType(name)
+        setattr(stub, attr, object)
+        for key, value in extra.items():
+            setattr(stub, key, value)
+        sys.modules[name] = stub
+        stubbed.append(name)
+
+    try:
+        import core.engine  # noqa: F401
+    finally:
+        for name in stubbed:
+            del sys.modules[name]
+
+
+_ensure_core_engine_importable()
+
+from core.config import DEFAULT_CONFIG, GESTURE_HOLD_FLOOR_MS_DEFAULT
+# core.mouse_hook_types (not core.mouse_hook — see _ensure_core_engine_importable
+# above) so this import is objc-free regardless of whether the sandbox stub ran.
+from core.mouse_hook_types import HidRuntimeState, MouseEvent
 
 
 class _FakeMouseHook:
@@ -18,6 +65,7 @@ class _FakeMouseHook:
         self._hid_gesture = None
         self.start_called = False
         self.stop_called = False
+        self.registered = {}
 
     def set_debug_callback(self, cb):
         self._debug_callback = cb
@@ -38,10 +86,10 @@ class _FakeMouseHook:
         pass
 
     def register(self, event_type, callback):
-        pass
+        self.registered.setdefault(event_type, []).append(callback)
 
     def reset_bindings(self):
-        pass
+        self.registered = {}
 
     def start(self):
         self.start_called = True
@@ -511,6 +559,359 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
 
         engine.hook._hid_gesture.read_battery.assert_called_once_with()
         engine.hook._hid_gesture.read_smart_shift.assert_not_called()
+
+
+_ALL_GESTURE_OWNERS = ("back", "forward", "middle")
+_ALL_GESTURE_DIRECTIONS = ("left", "right", "up", "down")
+
+
+def _fully_eligible_device():
+    """A device whose supported_buttons cover every owner's 4 directions --
+    used as the default device for tests that exercise ROUTING, not the
+    finding #1 enable/eligibility gate itself (covered separately below)."""
+    return SimpleNamespace(
+        supported_buttons=tuple(
+            f"gesture_{owner}_{direction}"
+            for owner in _ALL_GESTURE_OWNERS
+            for direction in _ALL_GESTURE_DIRECTIONS
+        )
+    )
+
+
+def _connected_mouse_hook_cls(device):
+    """A _FakeMouseHook subclass pre-wired with a connected device, so
+    Engine.__init__'s synchronous _setup_hooks() call sees it (there is no
+    window to inject the device after construction)."""
+    class _ConnectedFakeMouseHook(_FakeMouseHook):
+        def __init__(self):
+            super().__init__()
+            self.connected_device = device
+            self.device_connected = device is not None
+    return _ConnectedFakeMouseHook
+
+
+class EngineGestureDispatchTests(unittest.TestCase):
+    """Issue 004: configure_gestures wiring + per-owner direction dispatch.
+
+    These tests are about ROUTING, not the arming gate (finding #1, covered
+    by EngineGestureArmingGateTests below) -- so every owner is enabled and
+    the fake device is eligible for all of them by default.
+    """
+
+    _DEFAULT_DEVICE = object()  # sentinel: distinguish "use the default eligible device" from device=None
+
+    def _make_engine(self, cfg, device=_DEFAULT_DEVICE):
+        from core.engine import Engine
+
+        if device is self._DEFAULT_DEVICE:
+            device = _fully_eligible_device()
+        hook_cls = _connected_mouse_hook_cls(device) if device is not None else _FakeMouseHook
+        with (
+            patch("core.engine.MouseHook", hook_cls),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=cfg),
+        ):
+            return Engine()
+
+    def _cfg(self, **mapping_overrides):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["profiles"]["default"]["mappings"].update(mapping_overrides)
+        cfg["settings"]["gesture_owner_enabled"] = {owner: True for owner in _ALL_GESTURE_OWNERS}
+        return cfg
+
+    def _owner_event(self, owner, dx=0, dy=-80):
+        return SimpleNamespace(
+            event_type=MouseEvent.GESTURE_SWIPE_UP,
+            raw_data={"delta_x": dx, "delta_y": dy, "source": "event_tap", "gesture_owner": owner},
+        )
+
+    def test_configure_gestures_receives_owner_set_and_default_hold_floor(self):
+        cfg = self._cfg(gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg)
+
+        gesture_cfg = engine.hook._gesture_config
+        self.assertEqual(gesture_cfg["owners"], {"forward"})
+        self.assertEqual(gesture_cfg["hold_floor_ms"], GESTURE_HOLD_FLOOR_MS_DEFAULT)
+        self.assertIs(gesture_cfg["enabled"], True)
+
+    def test_configure_gestures_threads_custom_hold_floor(self):
+        cfg = self._cfg(gesture_forward_up="mission_control")
+        cfg["settings"]["gesture_hold_floor_ms"] = 150
+        engine = self._make_engine(cfg)
+
+        self.assertEqual(engine.hook._gesture_config["hold_floor_ms"], 150)
+
+    def test_zero_owners_disables_gestures_with_empty_owner_set(self):
+        engine = self._make_engine(self._cfg())
+
+        gesture_cfg = engine.hook._gesture_config
+        self.assertEqual(gesture_cfg["owners"], set())
+        self.assertIs(gesture_cfg["enabled"], False)
+
+    def test_hid_direction_only_still_enables_gestures_with_empty_owners(self):
+        engine = self._make_engine(self._cfg(gesture_up="mission_control"))
+
+        gesture_cfg = engine.hook._gesture_config
+        self.assertEqual(gesture_cfg["owners"], set())
+        self.assertIs(gesture_cfg["enabled"], True)
+
+    def test_owner_gesture_dispatches_to_namespaced_action(self):
+        engine = self._make_engine(self._cfg(gesture_forward_up="mission_control"))
+        handlers = engine.hook.registered["gesture_swipe_up"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(self._owner_event("forward"))
+
+        execute_action_mock.assert_called_once_with("mission_control")
+
+    def test_two_owners_same_direction_fire_their_own_actions(self):
+        engine = self._make_engine(self._cfg(
+            gesture_forward_up="mission_control",
+            gesture_back_up="app_expose",
+        ))
+        handlers = engine.hook.registered["gesture_swipe_up"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(self._owner_event("forward"))
+            for handler in handlers:
+                handler(self._owner_event("back"))
+
+        execute_action_mock.assert_has_calls(
+            [unittest.mock.call("mission_control"), unittest.mock.call("app_expose")]
+        )
+        self.assertEqual(execute_action_mock.call_count, 2)
+
+    def test_owner_direction_without_binding_does_not_fire(self):
+        # forward only binds "up" — a "down" swipe from forward has no action.
+        engine = self._make_engine(self._cfg(gesture_forward_up="mission_control"))
+        handlers = engine.hook.registered["gesture_swipe_down"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(SimpleNamespace(
+                    event_type=MouseEvent.GESTURE_SWIPE_DOWN,
+                    raw_data={"delta_x": 0, "delta_y": 80, "source": "event_tap", "gesture_owner": "forward"},
+                ))
+
+        execute_action_mock.assert_not_called()
+
+    def test_hid_gesture_button_still_routes_when_owners_configured(self):
+        """Regression guard: MX Master HID gesture path still fires from its
+        own (non-owner-tagged) events once per-owner routing is also wired."""
+        engine = self._make_engine(self._cfg(
+            gesture_up="app_expose",
+            gesture_forward_up="mission_control",
+        ))
+        handlers = engine.hook.registered["gesture_swipe_up"]
+        self.assertEqual(len(handlers), 2)
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(SimpleNamespace(
+                    event_type=MouseEvent.GESTURE_SWIPE_UP,
+                    raw_data={"delta_x": 0, "delta_y": -80, "source": "hid_rawxy"},
+                ))
+
+        execute_action_mock.assert_called_once_with("app_expose")
+
+    def test_owner_tagged_event_does_not_also_fire_hid_direction_action(self):
+        """The generic gesture_up binding must not double-fire on an
+        owner-tagged (event-tap) swipe — only the owner routing should."""
+        engine = self._make_engine(self._cfg(
+            gesture_up="app_expose",
+            gesture_forward_up="mission_control",
+        ))
+        handlers = engine.hook.registered["gesture_swipe_up"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(self._owner_event("forward"))
+
+        execute_action_mock.assert_called_once_with("mission_control")
+
+    def test_no_owner_routing_registered_when_owners_empty(self):
+        engine = self._make_engine(self._cfg(gesture_up="app_expose"))
+
+        self.assertNotIn("gesture_swipe_down", engine.hook.registered)
+        self.assertNotIn("gesture_swipe_left", engine.hook.registered)
+        self.assertNotIn("gesture_swipe_right", engine.hook.registered)
+        # gesture_swipe_up IS registered here, but only by the HID-direction path.
+        self.assertEqual(len(engine.hook.registered["gesture_swipe_up"]), 1)
+
+
+class EngineGestureArmingGateTests(unittest.TestCase):
+    """Finding #1 (adversarial review, 2026-07-03): arming a per-button
+    event-tap gesture must be gated by settings.gesture_owner_enabled AND
+    device eligibility, not just by config bindings -- else the OFF switch
+    has no runtime effect and a per-button gesture leaks onto a device that
+    can't host it (e.g. config carried over to an MX Master)."""
+
+    _MX_ANYWHERE_2S = SimpleNamespace(
+        supported_buttons=(
+            "middle", "xbutton1", "xbutton2",
+            "gesture_forward_left", "gesture_forward_right",
+            "gesture_forward_up", "gesture_forward_down",
+        )
+    )
+    _MX_MASTER_3S = SimpleNamespace(supported_buttons=("middle", "xbutton1", "xbutton2"))
+
+    def _cfg(self, enabled=None, **mapping_overrides):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["profiles"]["default"]["mappings"].update(mapping_overrides)
+        if enabled is not None:
+            cfg["settings"]["gesture_owner_enabled"] = dict(enabled)
+        return cfg
+
+    def _make_engine(self, cfg, device=None):
+        from core.engine import Engine
+
+        hook_cls = _connected_mouse_hook_cls(device) if device is not None else _FakeMouseHook
+        with (
+            patch("core.engine.MouseHook", hook_cls),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=cfg),
+        ):
+            return Engine()
+
+    def test_bound_owner_stays_off_when_enable_toggle_is_off(self):
+        cfg = self._cfg(enabled={"forward": False}, gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=self._MX_ANYWHERE_2S)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+        self.assertNotIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_bound_owner_stays_off_when_enable_flag_absent(self):
+        # No settings.gesture_owner_enabled key at all -- default is off
+        # (matches ui.backend "gesture mode off by default").
+        cfg = self._cfg(gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=self._MX_ANYWHERE_2S)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+
+    def test_bound_and_enabled_owner_stays_off_with_no_device_connected(self):
+        cfg = self._cfg(enabled={"forward": True}, gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=None)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+
+    def test_bound_and_enabled_owner_does_not_leak_onto_ineligible_device(self):
+        # Regression: MX Master 3S has no per-button event-tap gesture support --
+        # config carried over from another device must not arm it here.
+        cfg = self._cfg(enabled={"forward": True}, gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=self._MX_MASTER_3S)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+        self.assertNotIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_bound_enabled_and_eligible_owner_arms(self):
+        cfg = self._cfg(enabled={"forward": True}, gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=self._MX_ANYWHERE_2S)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], {"forward"})
+        self.assertIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_second_owner_off_does_not_block_first_owner_that_is_on(self):
+        cfg = self._cfg(
+            enabled={"forward": True, "back": False},
+            gesture_forward_up="mission_control",
+            gesture_back_up="app_expose",
+        )
+        engine = self._make_engine(cfg, device=_fully_eligible_device())
+
+        self.assertEqual(engine.hook._gesture_config["owners"], {"forward"})
+
+
+class EngineGestureRearmOnConnectTests(unittest.TestCase):
+    """Hardware bugs A/B (fixed live, 2026-07): __init__'s _setup_hooks() runs
+    before the device is connected, so _active_gesture_owners computes empty
+    and nothing ever arms. _on_connection_change recomputes on the
+    hid-features-ready rising edge -- and must reset_bindings() first so a
+    second connect cycle doesn't stack a duplicate handler (the owner action
+    firing 2-3x)."""
+
+    _DEVICE = SimpleNamespace(
+        supported_buttons=(
+            "middle", "xbutton1", "xbutton2",
+            "gesture_forward_left", "gesture_forward_right",
+            "gesture_forward_up", "gesture_forward_down",
+        )
+    )
+
+    def _cfg(self):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["profiles"]["default"]["mappings"]["gesture_forward_up"] = "mission_control"
+        cfg["settings"]["gesture_owner_enabled"] = {"forward": True}
+        return cfg
+
+    def _make_engine(self):
+        from core.engine import Engine
+
+        with (
+            patch("core.engine.MouseHook", _FakeMouseHook),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=self._cfg()),
+        ):
+            return Engine()
+
+    def _connect_device(self, engine):
+        engine.hook.connected_device = self._DEVICE
+        engine.hook.device_connected = True
+        engine.hook._hid_gesture = SimpleNamespace(connected_device=self._DEVICE)
+
+    def _disconnect_device(self, engine):
+        engine.hook.connected_device = None
+        engine.hook.device_connected = False
+        engine.hook._hid_gesture = SimpleNamespace(connected_device=None)
+
+    @staticmethod
+    def _thread_factory(instances):
+        def factory(*args, **kwargs):
+            thread = _RecordedThread(*args, **kwargs)
+            instances.append(thread)
+            return thread
+        return factory
+
+    def test_owner_arms_once_device_becomes_ready_after_construction(self):
+        """Bug A: constructed with no device connected, the owner stays
+        unarmed until a hid-features-ready connection-change recomputes it."""
+        engine = self._make_engine()
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+        self.assertNotIn("gesture_swipe_up", engine.hook.registered)
+
+        with patch("core.engine.threading.Thread", side_effect=self._thread_factory([])):
+            self._connect_device(engine)
+            engine._on_connection_change(True)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], {"forward"})
+        self.assertIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_reconnect_cycle_does_not_stack_duplicate_handlers(self):
+        """Bug B: a disconnect/reconnect cycle must reset_bindings() before
+        re-registering, so the owner action fires exactly once, not 2-3x."""
+        engine = self._make_engine()
+        threads = []
+
+        with patch("core.engine.threading.Thread", side_effect=self._thread_factory(threads)):
+            self._connect_device(engine)
+            engine._on_connection_change(True)
+            self._disconnect_device(engine)
+            engine._on_connection_change(False)
+            self._connect_device(engine)
+            engine._on_connection_change(True)
+
+        handlers = engine.hook.registered["gesture_swipe_up"]
+        self.assertEqual(len(handlers), 1)
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(SimpleNamespace(
+                    event_type=MouseEvent.GESTURE_SWIPE_UP,
+                    raw_data={"delta_x": 0, "delta_y": -80, "source": "event_tap", "gesture_owner": "forward"},
+                ))
+
+        execute_action_mock.assert_called_once_with("mission_control")
 
 
 if __name__ == "__main__":

--- a/tests/test_event_tap_gesture.py
+++ b/tests/test_event_tap_gesture.py
@@ -1,0 +1,359 @@
+"""Issue 003 — event-tap gesture activation kernel.
+
+Exercises the pure, objc-free decision helpers that the macOS CGEventTap handler
+calls: the click-vs-gesture release decision (`decide_gesture`) and the
+first-wins arming gate (`should_arm_gesture`). The native tap wiring is verified
+on real hardware (issue 007); these tests pin the logic that decides it.
+
+Also covers the stateful hook transitions (arming / release / abort, finding #4
+of the 2026-07-03 adversarial review) via a tiny fake-Quartz harness: real
+core.mouse_hook_macos is imported against a minimal fake objc/Quartz so the
+actual callback code runs, objc-free, in this sandbox.
+"""
+
+import importlib
+import sys
+import time
+import types
+import unittest
+
+from core.mouse_hook_base import CLICK, GESTURE, decide_gesture, should_arm_gesture
+from core.mouse_hook_types import MouseEvent
+
+# The engine's default gesture tuning (core/config.py DEFAULT_CONFIG settings).
+_THRESHOLD = 50.0
+_DEADZONE = 40.0
+_FLOOR_MS = 80
+
+
+class DecideGestureTests(unittest.TestCase):
+    def test_quick_tap_no_movement_is_a_click(self):
+        decision, direction = decide_gesture(
+            held_ms=200, dx=0, dy=0,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, CLICK)
+        self.assertIsNone(direction)
+
+    def test_sub_deadzone_micro_drift_is_a_click(self):
+        # Held well past the floor, but the slide never clears the threshold.
+        decision, direction = decide_gesture(
+            held_ms=250, dx=12, dy=7,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, CLICK)
+        self.assertIsNone(direction)
+
+    def test_fast_flick_below_hold_floor_is_a_click(self):
+        # A big slide, but released before the hold floor — must NOT misfire (D4).
+        decision, direction = decide_gesture(
+            held_ms=40, dx=0, dy=-200,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, CLICK)
+        self.assertIsNone(direction)
+
+    def test_clean_four_way_gestures_detect_the_direction(self):
+        cases = {
+            (0, -120): MouseEvent.GESTURE_SWIPE_UP,
+            (0, 120): MouseEvent.GESTURE_SWIPE_DOWN,
+            (-120, 0): MouseEvent.GESTURE_SWIPE_LEFT,
+            (120, 0): MouseEvent.GESTURE_SWIPE_RIGHT,
+        }
+        for (dx, dy), expected in cases.items():
+            with self.subTest(dx=dx, dy=dy):
+                decision, direction = decide_gesture(
+                    held_ms=150, dx=dx, dy=dy,
+                    hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+                )
+                self.assertEqual(decision, GESTURE)
+                self.assertEqual(direction, expected)
+
+    def test_boundary_held_exactly_at_floor_is_eligible(self):
+        decision, direction = decide_gesture(
+            held_ms=_FLOOR_MS, dx=120, dy=0,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, GESTURE)
+        self.assertEqual(direction, MouseEvent.GESTURE_SWIPE_RIGHT)
+
+    def test_ambiguous_diagonal_is_a_click_not_a_random_gesture(self):
+        # Equal cross-axis motion → existing cross-axis reject → no direction.
+        decision, direction = decide_gesture(
+            held_ms=150, dx=120, dy=120,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, CLICK)
+        self.assertIsNone(direction)
+
+
+class ShouldArmGestureTests(unittest.TestCase):
+    def test_owner_button_arms_when_idle(self):
+        self.assertTrue(
+            should_arm_gesture(gesture_active=False, btn_owner="forward",
+                               owners={"forward", "back"})
+        )
+
+    def test_non_owner_button_never_arms(self):
+        self.assertFalse(
+            should_arm_gesture(gesture_active=False, btn_owner="middle",
+                               owners={"forward", "back"})
+        )
+
+    def test_second_owner_passes_through_while_one_is_active(self):
+        # Two-owner overlap: first-held wins, the second must not arm (PRD rule).
+        self.assertFalse(
+            should_arm_gesture(gesture_active=True, btn_owner="back",
+                               owners={"forward", "back"})
+        )
+
+    def test_no_owners_configured_means_feature_off(self):
+        self.assertFalse(
+            should_arm_gesture(gesture_active=False, btn_owner="forward", owners=set())
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fake-Quartz harness: exercises the real core.mouse_hook_macos callback code
+# (arming, release, abort) against a minimal fake objc/Quartz so it runs
+# objc-free in this sandbox. Loaded fresh per test and popped from
+# sys.modules afterwards, so any OTHER test file that imports
+# core.mouse_hook_macos directly still sees the real (missing-PyObjC)
+# ImportError, unaffected by this workaround (mirrors tests/test_engine.py's
+# _ensure_core_engine_importable hygiene).
+# ---------------------------------------------------------------------------
+
+class _FakeCGEvent:
+    """Minimal CGEventRef stand-in: an integer-field store + location."""
+
+    def __init__(self, location=(0.0, 0.0)):
+        self.fields = {}
+        self.location = location
+        self.flags = 0
+
+
+class _NullContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def _build_fake_quartz():
+    """A fake Quartz module exposing just the surface core.mouse_hook_macos
+    touches, backed by _FakeCGEvent so the real callback code runs unmodified."""
+    mod = types.ModuleType("Quartz")
+
+    const_names = [
+        "kCGEventMouseMoved", "kCGEventOtherMouseDragged",
+        "kCGEventOtherMouseDown", "kCGEventOtherMouseUp", "kCGEventScrollWheel",
+        "kCGMouseEventDeltaX", "kCGMouseEventDeltaY", "kCGMouseEventButtonNumber",
+        "kCGEventSourceUserData",
+        "kCGScrollWheelEventFixedPtDeltaAxis1", "kCGScrollWheelEventFixedPtDeltaAxis2",
+        "kCGScrollWheelEventPointDeltaAxis1", "kCGScrollWheelEventPointDeltaAxis2",
+        "kCGScrollWheelEventDeltaAxis1", "kCGScrollWheelEventDeltaAxis2",
+        "kCGScrollWheelEventScrollPhase", "kCGScrollWheelEventMomentumPhase",
+        "kCGScrollEventUnitPixel", "kCGHIDEventTap",
+        "kCGEventSourceStateHIDSystemState",
+        "kCGSessionEventTap", "kCGHeadInsertEventTap", "kCGEventTapOptionDefault",
+        "kCFRunLoopCommonModes",
+    ]
+    for i, cname in enumerate(const_names):
+        setattr(mod, cname, i + 1)
+
+    mod.posted_events = []
+    mod.modifier_flags = 0
+
+    mod.CGEventGetIntegerValueField = lambda event, field: event.fields.get(field, 0)
+    mod.CGEventSetIntegerValueField = lambda event, field, value: event.fields.__setitem__(field, value)
+    mod.CGEventGetFlags = lambda event: event.flags
+    mod.CGEventSetFlags = lambda event, flags: setattr(event, "flags", flags)
+    mod.CGEventGetLocation = lambda event: event.location
+    mod.CGEventCreate = lambda source: _FakeCGEvent()
+    mod.CGEventSourceFlagsState = lambda state_id: mod.modifier_flags
+    mod.CGEventPost = lambda tap, event: mod.posted_events.append(event)
+    mod.CGEventTapEnable = lambda tap, enable: None
+    mod.CGEventMaskBit = lambda bit: 1 << int(bit)
+
+    def _create_mouse_event(source, mouse_type, point, button):
+        ev = _FakeCGEvent(location=point)
+        ev.fields[mod.kCGMouseEventButtonNumber] = button
+        return ev
+
+    mod.CGEventCreateMouseEvent = _create_mouse_event
+    return mod
+
+
+def _load_mouse_hook_macos():
+    """Import a FRESH core.mouse_hook_macos backed by a fake objc/Quartz and
+    return (MouseHook, fake_quartz_module). Saves and restores any real objc /
+    Quartz / core.mouse_hook_macos already in sys.modules, so this works whether
+    or not PyObjC is installed and never corrupts other test files: on Linux/CI
+    the real modules are absent; on a real Mac they ARE loaded (e.g. by
+    tests/test_engine.py) and MUST be forced aside, else this imports the real
+    objc-backed module and the fake-CGEvent assertions run against a live tap."""
+    name = "core.mouse_hook_macos"
+    quartz = _build_fake_quartz()
+    fake_objc = types.ModuleType("objc")
+    fake_objc.autorelease_pool = lambda: _NullContext()
+
+    sentinel = object()
+    saved = {k: sys.modules.get(k, sentinel) for k in ("objc", "Quartz", name)}
+    sys.modules["objc"] = fake_objc
+    sys.modules["Quartz"] = quartz
+    sys.modules.pop(name, None)  # force a fresh, fake-backed import
+    try:
+        module = importlib.import_module(name)
+        MouseHook = module.MouseHook  # capture before restoring real modules
+    finally:
+        for key, value in saved.items():
+            if value is sentinel:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+    return MouseHook, quartz
+
+
+_MIDDLE_BTN = 2
+_BACK_BTN = 3
+_FORWARD_BTN = 4
+
+
+class EventTapGestureStateTransitionTests(unittest.TestCase):
+    """Finding #4: the callback's owner-state transitions (arm / release /
+    abort) driven through the real macOS callback code via the fake-Quartz
+    harness above."""
+
+    def setUp(self):
+        MouseHook, quartz = _load_mouse_hook_macos()
+        self.quartz = quartz
+        self.hook = MouseHook()
+        self.hook.configure_gestures(
+            enabled=True, threshold=50, deadzone=40,
+            timeout_ms=3000, cooldown_ms=500, owners={"forward", "back"},
+            hold_floor_ms=80,
+        )
+
+    def _down(self, btn):
+        ev = _FakeCGEvent()
+        ev.fields[self.quartz.kCGMouseEventButtonNumber] = btn
+        return self.hook._event_tap_callback(None, self.quartz.kCGEventOtherMouseDown, ev, None)
+
+    def _up(self, btn):
+        ev = _FakeCGEvent()
+        ev.fields[self.quartz.kCGMouseEventButtonNumber] = btn
+        return self.hook._event_tap_callback(None, self.quartz.kCGEventOtherMouseUp, ev, None)
+
+    def _move(self, dx, dy):
+        ev = _FakeCGEvent()
+        ev.fields[self.quartz.kCGMouseEventDeltaX] = dx
+        ev.fields[self.quartz.kCGMouseEventDeltaY] = dy
+        return self.hook._event_tap_callback(None, self.quartz.kCGEventMouseMoved, ev, None)
+
+    def test_down_then_quick_up_resets_owner_and_dispatches_owner_click(self):
+        result = self._down(_FORWARD_BTN)
+        self.assertIsNone(result)  # down is swallowed/deferred
+        self.assertEqual(self.hook._gesture_owner, "forward")
+        self.assertTrue(self.hook._gesture_active)
+
+        result = self._up(_FORWARD_BTN)  # released well under the 80ms floor
+
+        self.assertIsNone(result)
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+        self.assertEqual(self.quartz.posted_events, [])  # no native replay (Bug C)
+        fired = [self.hook._dispatch_queue.get_nowait(), self.hook._dispatch_queue.get_nowait()]
+        self.assertEqual(
+            [ev.event_type for ev in fired],
+            [MouseEvent.XBUTTON2_DOWN, MouseEvent.XBUTTON2_UP],
+        )
+
+    def test_down_slide_up_fires_tagged_event_and_resets(self):
+        self._down(_FORWARD_BTN)
+        self.hook._gesture_press_at = time.monotonic() - 0.2  # outlive the hold floor
+        self._move(120, 0)  # swallowed, accumulated
+
+        result = self._up(_FORWARD_BTN)
+
+        self.assertIsNone(result)
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+        fired = self.hook._dispatch_queue.get_nowait()
+        self.assertEqual(fired.event_type, MouseEvent.GESTURE_SWIPE_RIGHT)
+        self.assertEqual(fired.raw_data["gesture_owner"], "forward")
+        self.assertEqual(len(self.quartz.posted_events), 0)  # no click replay
+
+    def test_missed_up_then_move_does_not_stay_frozen_past_timeout(self):
+        self.hook.configure_gestures(
+            enabled=True, threshold=50, deadzone=40,
+            timeout_ms=250, cooldown_ms=500, owners={"forward", "back"},
+            hold_floor_ms=80,
+        )
+        self._down(_FORWARD_BTN)
+        self.hook._gesture_press_at = time.monotonic() - 1.0  # older than the timeout
+
+        result = self._move(50, 0)
+
+        # Cursor is no longer frozen: the move is NOT swallowed.
+        self.assertIsNotNone(result)
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+
+        # The shared should_arm_gesture gate is unstuck: a different owner
+        # can arm right away.
+        result = self._down(_BACK_BTN)
+        self.assertIsNone(result)
+        self.assertEqual(self.hook._gesture_owner, "back")
+
+    def test_tap_disabled_event_aborts_a_pending_gesture(self):
+        self._down(_FORWARD_BTN)
+
+        self.hook._event_tap_callback(
+            None, 0xFFFFFFFE, _FakeCGEvent(), None  # _kCGEventTapDisabledByTimeout
+        )
+
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+
+    def test_stop_aborts_a_pending_gesture(self):
+        self._down(_FORWARD_BTN)
+
+        self.hook.stop()
+
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+
+    def test_tap_dispatches_owner_click_pair_not_native_replay(self):
+        """Bug C: a tap of ANY armed owner button fires that button's own
+        (DOWN, UP) MouseEvent pair via the dispatch queue (dual-mode) --
+        never a Quartz.CGEventPost native replay (macOS ignores raw button
+        4/3, so a native replay would be a dead click)."""
+        self.hook.configure_gestures(
+            enabled=True, threshold=50, deadzone=40,
+            timeout_ms=3000, cooldown_ms=500, owners={"forward", "back", "middle"},
+            hold_floor_ms=80,
+        )
+        cases = {
+            _MIDDLE_BTN: (MouseEvent.MIDDLE_DOWN, MouseEvent.MIDDLE_UP),
+            _BACK_BTN: (MouseEvent.XBUTTON1_DOWN, MouseEvent.XBUTTON1_UP),
+            _FORWARD_BTN: (MouseEvent.XBUTTON2_DOWN, MouseEvent.XBUTTON2_UP),
+        }
+        for btn, (expected_down, expected_up) in cases.items():
+            with self.subTest(btn=btn):
+                self._down(btn)
+                self._up(btn)  # quick tap, well under the hold floor
+
+                fired = [
+                    self.hook._dispatch_queue.get_nowait(),
+                    self.hook._dispatch_queue.get_nowait(),
+                ]
+                self.assertEqual(
+                    [ev.event_type for ev in fired], [expected_down, expected_up]
+                )
+                self.assertEqual(self.quartz.posted_events, [])  # no native replay
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -358,6 +358,25 @@ class LogiDeviceRegistryTests(unittest.TestCase):
         self.assertIsNotNone(device)
         self.assertIs(get_buttons_for_layout("mx_anywhere_2s"), device.supported_buttons)
 
+    def test_mx_anywhere_2s_spec_supports_event_tap_gestures(self):
+        device = resolve_device(product_id=0xB01A)
+
+        self.assertIsNotNone(device)
+        self.assertTrue(device.supports_event_tap_gestures)
+        for owner in ("back", "forward", "middle"):
+            for direction in ("left", "right", "up", "down"):
+                key = f"gesture_{owner}_{direction}"
+                with self.subTest(key=key):
+                    self.assertIn(key, device.supported_buttons)
+
+    def test_other_known_devices_do_not_support_event_tap_gestures(self):
+        # supports_event_tap_gestures is opt-in; only the 2S has it in issue #005.
+        for device in KNOWN_LOGI_DEVICES:
+            if device.key == "mx_anywhere_2s":
+                continue
+            with self.subTest(device=device.key):
+                self.assertFalse(device.supports_event_tap_gestures)
+
 
 class RuntimeSupportedButtonTests(unittest.TestCase):
     @staticmethod
@@ -674,6 +693,92 @@ class RuntimeSupportedButtonTests(unittest.TestCase):
         self.assertIn("gesture_up", info.supported_buttons)
         self.assertIn("hscroll_left", info.supported_buttons)
         self.assertIn("hscroll_right", info.supported_buttons)
+
+    # -- Per-button event-tap gestures (issue #002) --------------------------
+
+    _EVENT_TAP_STATIC_BUTTONS = (
+        "middle",
+        "xbutton1",
+        "xbutton2",
+        "gesture",
+        "gesture_left",
+        "gesture_right",
+        "gesture_up",
+        "gesture_down",
+        "gesture_back_left",
+        "gesture_back_right",
+        "gesture_forward_up",
+        "gesture_forward_down",
+        "gesture_middle_left",
+        "gesture_middle_right",
+    )
+
+    def test_event_tap_only_device_keeps_per_button_gesture_keys_without_rawxy(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            self._EVENT_TAP_STATIC_BUTTONS,
+            [self._control(0x0052, flags=0x0130), self._control(0x0053, flags=0x0130)],
+            supports_event_tap_gestures=True,
+        )
+
+        self.assertIn("gesture_back_left", buttons)
+        self.assertIn("gesture_forward_up", buttons)
+        self.assertIn("gesture_middle_right", buttons)
+        # No divertable HID gesture control present, so the legacy HID path
+        # stays stripped -- the event-tap flag doesn't resurrect it.
+        self.assertNotIn("gesture", buttons)
+        self.assertNotIn("gesture_left", buttons)
+
+    def test_device_with_neither_flag_still_strips_all_gesture_keys(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            self._EVENT_TAP_STATIC_BUTTONS,
+            [self._control(0x0052, flags=0x0130), self._control(0x0053, flags=0x0130)],
+        )
+
+        self.assertNotIn("gesture_back_left", buttons)
+        self.assertNotIn("gesture_forward_up", buttons)
+        self.assertNotIn("gesture_middle_right", buttons)
+        self.assertNotIn("gesture", buttons)
+        self.assertNotIn("gesture_left", buttons)
+
+    def test_real_hid_gesture_control_unaffected_by_event_tap_flag(self):
+        # MX Master regression guard: a device with a real divertable RawXY
+        # gesture control keeps working exactly as before, and the (absent)
+        # event-tap flag does not add per-button keys it never declared.
+        buttons = derive_supported_buttons_from_reprog_controls(
+            self._EVENT_TAP_STATIC_BUTTONS,
+            [self._control(0x00D7, flags=0x03A0)],
+            gesture_cids=(0x00D7,),
+            active_gesture_cid=0x00D7,
+            gesture_rawxy_enabled=True,
+            supports_event_tap_gestures=False,
+        )
+
+        self.assertIn("gesture", buttons)
+        self.assertIn("gesture_left", buttons)
+        self.assertIn("gesture_right", buttons)
+        self.assertNotIn("gesture_back_left", buttons)
+        self.assertNotIn("gesture_forward_up", buttons)
+
+    def test_mx_anywhere_2s_exposes_per_button_gesture_keys_via_capability_model(self):
+        info = build_connected_device_info(
+            product_id=0xB01A,
+            reprog_controls=[
+                self._control(0x0052, flags=0x0130),
+                self._control(0x0053, flags=0x0130),
+                self._control(0x0056, flags=0x0130),
+            ],
+        )
+
+        self.assertTrue(info.capability_inventory.supports_event_tap_gestures)
+        for owner in ("back", "forward", "middle"):
+            for direction in ("left", "right", "up", "down"):
+                key = f"gesture_{owner}_{direction}"
+                with self.subTest(key=key):
+                    self.assertIn(key, info.supported_buttons)
+        # No real HID gesture control on the 2S -- the legacy global path
+        # stays inert (stripped), same as before this feature existed.
+        self.assertNotIn("gesture", info.supported_buttons)
+        self.assertNotIn("gesture_left", info.supported_buttons)
 
     def test_mx_master_4_haptic_control_does_not_create_supported_button(self):
         info = build_connected_device_info(

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -20,7 +20,8 @@ from core.accessibility import is_process_trusted
 from core.config import (
     BUTTON_NAMES, load_config, save_config, get_active_mappings,
     PROFILE_BUTTON_NAMES, set_mapping, create_profile, delete_profile,
-    get_icon_for_exe,
+    get_icon_for_exe, GESTURE_OWNERS, GESTURE_DIRECTIONS,
+    GESTURE_HOLD_FLOOR_MS_DEFAULT,
 )
 from core import app_catalog
 from core.device_layouts import get_device_layout, get_manual_layout_choices
@@ -78,6 +79,12 @@ def _action_label(action_id):
     if action_id.startswith("custom:"):
         return custom_action_label(action_id)
     return ACTIONS.get(action_id, {}).get("label", "Do Nothing")
+
+
+# Physical hotspot button -> the per-button gesture owner name it can host
+# (issue #001 namespaced config keys). "gesture" (the HID thumb button) isn't
+# an owner here -- it keeps its own always-on 4-direction panel.
+_GESTURE_OWNER_FOR_BUTTON = {"xbutton1": "back", "xbutton2": "forward", "middle": "middle"}
 
 
 def _qt_shortcut_modifier_name(name):
@@ -529,6 +536,30 @@ class Backend(QObject):
     @Property(int, notify=settingsChanged)
     def gestureThreshold(self):
         return int(self._cfg.get("settings", {}).get("gesture_threshold", 50))
+
+    @Property(int, notify=settingsChanged)
+    def gestureHoldFloorMs(self):
+        """Min hold time (ms) before a slide arms a per-button gesture (issue #001)."""
+        return int(self._cfg.get("settings", {}).get(
+            "gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT
+        ))
+
+    @Property(list, notify=deviceLayoutChanged)
+    def gestureEligibleOwners(self):
+        """Owners (back/forward/middle) the connected device can host a per-button
+        gesture on -- mirrors the capability narrowing in core/logi_devices.py."""
+        btns = self._effective_supported_buttons
+        return [
+            owner for owner in GESTURE_OWNERS
+            if btns is None or f"gesture_{owner}_left" in btns
+        ]
+
+    @Property(list, notify=settingsChanged)
+    def gestureEnabledOwners(self):
+        """Owners with gesture mode toggled on. Persisted independently of the 4
+        direction bindings, so turning gesture mode off never drops them."""
+        flags = self._cfg.get("settings", {}).get("gesture_owner_enabled", {})
+        return [owner for owner in GESTURE_OWNERS if flags.get(owner, False)]
 
     @Property(str, notify=settingsChanged)
     def appearanceMode(self):
@@ -1386,6 +1417,64 @@ class Backend(QObject):
         if self._engine:
             self._engine.reload_mappings()
         self.settingsChanged.emit()
+
+    @Slot(int)
+    def setGestureHoldFloorMs(self, value):
+        clamped = max(0, int(value))
+        if clamped == self.gestureHoldFloorMs:
+            return
+        self._cfg.setdefault("settings", {})["gesture_hold_floor_ms"] = clamped
+        save_config(self._cfg)
+        if self._engine:
+            self._engine.reload_mappings()
+        self.settingsChanged.emit()
+
+    @Slot(str, result=str)
+    def gestureOwnerForButton(self, buttonKey):
+        """Resolve a hotspot button key (xbutton1/xbutton2/middle) to its gesture
+        owner name, or "" if that button can't own a per-button gesture."""
+        return _GESTURE_OWNER_FOR_BUTTON.get(buttonKey, "")
+
+    @Slot(str, bool)
+    def setGestureOwnerEnabled(self, owner, enabled):
+        """Toggle gesture mode for a button. Independent of the 4 direction
+        bindings -- turning it off leaves them in config untouched, and leaves
+        the button's normal single-action mapping untouched too."""
+        if owner not in GESTURE_OWNERS:
+            return
+        flags = self._cfg.setdefault("settings", {}).setdefault("gesture_owner_enabled", {})
+        enabled = bool(enabled)
+        if flags.get(owner, False) == enabled:
+            return
+        flags[owner] = enabled
+        save_config(self._cfg)
+        if self._engine:
+            self._engine.reload_mappings()
+        self.settingsChanged.emit()
+
+    @Slot(str, str, result=list)
+    def gestureOwnerBindings(self, profileName, owner):
+        """Return the 4 direction bindings (gesture_<owner>_<dir>) for a profile."""
+        if owner not in GESTURE_OWNERS:
+            return []
+        profiles = self._cfg.get("profiles", {})
+        mappings = profiles.get(profileName, {}).get("mappings", {})
+        result = []
+        for direction in GESTURE_DIRECTIONS:
+            aid = mappings.get(f"gesture_{owner}_{direction}", "none")
+            result.append({
+                "direction": direction,
+                "actionId": aid,
+                "actionLabel": _action_label(aid),
+            })
+        return result
+
+    @Slot(str, str, str, str)
+    def setGestureOwnerBinding(self, profileName, owner, direction, actionId):
+        """Set one direction's action for a per-button gesture owner."""
+        if owner not in GESTURE_OWNERS or direction not in GESTURE_DIRECTIONS:
+            return
+        self.setProfileMapping(profileName, f"gesture_{owner}_{direction}", actionId)
 
     @Slot(str)
     def setAppearanceMode(self, mode):

--- a/ui/qml/MousePage.qml
+++ b/ui/qml/MousePage.qml
@@ -109,6 +109,7 @@ Item {
         selectedButton = ""
         selectedButtonName = ""
         selectedActionId = ""
+        refreshSelectedGestureBindings()
     }
 
     function appMatchesSearch(app, query) {
@@ -367,11 +368,38 @@ Item {
                                              || gestureUpActionId !== "none"
                                              || gestureDownActionId !== "none"
 
+    // ── Per-button slide gesture state (issue #006, config keys from #001) ──
+    // selectedButton is a hotspot key ("xbutton1"/"xbutton2"/"middle"/...);
+    // selectedGestureOwner is "" unless that hotspot can own a per-button gesture.
+    readonly property string selectedGestureOwner: backend.gestureOwnerForButton(selectedButton)
+    readonly property bool selectedGestureOwnerEligible: selectedGestureOwner !== ""
+                                             && backend.gestureEligibleOwners.indexOf(selectedGestureOwner) !== -1
+    readonly property bool selectedGestureOwnerEnabled: selectedGestureOwner !== ""
+                                             && backend.gestureEnabledOwners.indexOf(selectedGestureOwner) !== -1
+    property var selectedGestureBindingsState: ({})
+
+    function refreshSelectedGestureBindings() {
+        if (selectedGestureOwner === "") {
+            selectedGestureBindingsState = {}
+            return
+        }
+        var bindings = backend.gestureOwnerBindings(selectedProfile, selectedGestureOwner)
+        var state = ({})
+        for (var i = 0; i < bindings.length; i++)
+            state[bindings[i].direction] = bindings[i].actionId
+        selectedGestureBindingsState = state
+    }
+
+    function gestureBindingActionId(direction) {
+        return selectedGestureBindingsState[direction] || "none"
+    }
+
     function selectButton(key) {
         if (selectedButton === key) {
             selectedButton = ""
             selectedButtonName = ""
             selectedActionId = ""
+            refreshSelectedGestureBindings()
             return
         }
         var mapping = mappingFor(key)
@@ -379,6 +407,7 @@ Item {
             selectedButton = key
             selectedButtonName = lm.trButton(mapping.name)
             selectedActionId = mapping.actionId
+            refreshSelectedGestureBindings()
         }
     }
 
@@ -400,6 +429,7 @@ Item {
         target: backend
         function onMappingsChanged() {
             refreshSelectedProfileMappings()
+            refreshSelectedGestureBindings()
             if (selectedButton === "") return
             var mapping = mappingFor(selectedButton)
             if (mapping) {
@@ -491,6 +521,7 @@ Item {
                 selectedButton = ""
                 selectedButtonName = ""
                 selectedActionId = ""
+                refreshSelectedGestureBindings()
             }
         }
     }
@@ -1577,6 +1608,117 @@ Item {
                                 }
                             }
 
+                            // Per-button slide gesture: toggle + 4-direction panel
+                            // (issue #006). Reuses the swipe-panel layout above, but
+                            // attached to whichever eligible button (back/forward/
+                            // middle) is selected, via the namespaced gesture_<owner>_
+                            // <dir> keys (issue #001) instead of the HID gesture keys.
+                            Column {
+                                width: parent.width
+                                spacing: 14
+                                visible: selectedGestureOwnerEligible
+
+                                RowLayout {
+                                    width: parent.width
+                                    spacing: 12
+
+                                    Column {
+                                        Layout.fillWidth: true
+                                        spacing: 3
+
+                                        Text {
+                                            text: "Gesture mode"
+                                            font { family: uiState.fontFamily; pixelSize: 13; bold: true }
+                                            color: theme.textPrimary
+                                        }
+                                        Text {
+                                            width: parent.width
+                                            wrapMode: Text.WordWrap
+                                            text: "Hold and slide for a directional action. A quick tap still runs the normal action above."
+                                            font { family: uiState.fontFamily; pixelSize: 11 }
+                                            color: theme.textSecondary
+                                        }
+                                    }
+
+                                    Switch {
+                                        checked: selectedGestureOwnerEnabled
+                                        text: checked ? s["mouse.on"] : s["mouse.off"]
+                                        Material.accent: theme.accent
+                                        onToggled: backend.setGestureOwnerEnabled(selectedGestureOwner, checked)
+                                    }
+                                }
+
+                                Text {
+                                    visible: selectedGestureOwner === "middle" && selectedGestureOwnerEnabled
+                                    width: parent.width
+                                    wrapMode: Text.WordWrap
+                                    text: "Middle-click gets a brief hold delay while gesture mode is on, so Mouser can tell a click from a slide. If you use middle-click for paste or open-in-new-tab, expect a short delay before it fires. Middle-button drag/autoscroll is swallowed while gesture mode is on."
+                                    font { family: uiState.fontFamily; pixelSize: 11 }
+                                    color: theme.textDim
+                                }
+
+                                Column {
+                                    width: parent.width
+                                    spacing: 14
+                                    visible: selectedGestureOwnerEnabled
+
+                                    Rectangle {
+                                        width: parent.width
+                                        height: 1
+                                        color: theme.border
+                                    }
+
+                                    Text {
+                                        text: s["mouse.swipe_actions"]
+                                        font { family: uiState.fontFamily; pixelSize: 11;
+                                               capitalization: Font.AllUppercase; letterSpacing: 1 }
+                                        color: theme.textDim
+                                    }
+
+                                    Repeater {
+                                        model: ["left", "right", "up", "down"]
+                                        delegate: RowLayout {
+                                            width: parent.width
+                                            spacing: 12
+
+                                            Text {
+                                                text: modelData === "left" ? s["mouse.swipe_left"]
+                                                      : modelData === "right" ? s["mouse.swipe_right"]
+                                                      : modelData === "up" ? s["mouse.swipe_up"]
+                                                      : s["mouse.swipe_down"]
+                                                Layout.preferredWidth: 100
+                                                font { family: uiState.fontFamily; pixelSize: 12 }
+                                                color: theme.textPrimary
+                                            }
+
+                                            ComboBox {
+                                                Layout.fillWidth: true
+                                                model: backend.allActions
+                                                textRole: "label"
+                                                delegate: actionComboDelegate
+                                                Material.accent: theme.accent
+                                                font { family: uiState.fontFamily; pixelSize: 11 }
+                                                currentIndex: actionIndexForId(gestureBindingActionId(modelData))
+                                                displayText: isCustomAction(gestureBindingActionId(modelData))
+                                                             ? customLabel(gestureBindingActionId(modelData))
+                                                             : (lm.strings, lm.trAction(currentText))
+                                                onActivated: function(index) {
+                                                    var aid = backend.allActions[index].id
+                                                    if (aid === "__custom__") {
+                                                        keyCaptureDialog.open(
+                                                            selectedProfile,
+                                                            "gesture_" + selectedGestureOwner + "_" + modelData)
+                                                        return
+                                                    }
+                                                    backend.setGestureOwnerBinding(
+                                                        selectedProfile, selectedGestureOwner, modelData, aid)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
                             // Single button: categorized chips
                             Column {
                                 width: parent.width
@@ -1585,6 +1727,7 @@ Item {
                                          && selectedButton !== "hscroll_left"
                                          && !(selectedButton === "gesture"
                                               && backend.supportsGestureDirections)
+                                         && !(selectedGestureOwnerEligible && selectedGestureOwnerEnabled)
 
                                 Repeater {
                                     model: backend.actionCategories


### PR DESCRIPTION
# Per-button event-tap slide gestures (back/forward/middle)

Adds a working gesture path for mice that have no dedicated hardware gesture button.

## Problem

Mouser's gesture feature — hold a button, slide up/down/left/right, fire a per-direction
action — only *activates* when the device reports a diverted "gesture button held" event
over HID++. Only mice with a dedicated hardware gesture button (the MX Master thumb
button) ever emit that. Many Logitech mice — the MX Anywhere 2S among them — have no such
button, so they get zero working gestures today even though the direction-detection engine
underneath is already there and their side/middle buttons are ordinary mouse events on the
macOS event tap.

## Solution

An event-tap-driven arming path, per button: any of back/forward/middle can independently
own a 4-direction gesture. Holding an armed button and sliding past a deadzone runs the
existing direction engine and fires the bound action; a quick tap with no slide still fires
the button's normal mapping (dual-mode). No HID++ remap involved.

## Scope and caveats (read before merging)

1. **macOS only.** The event-tap arming path was added to `core/mouse_hook_macos.py` only.
   Windows/Linux have the identical gap (no dedicated gesture button on many mice) but
   share none of this wiring yet — a clean, separately-scoped follow-up.
2. **Per-device opt-in, not on by default for all mice.** A single catalog flag,
   `supports_event_tap_gestures`, gates which devices offer this. It is currently set on
   **one** device: the MX Anywhere 2S (`core/logi_device_catalog.py`) — the only mouse this
   was tested against. Any other mouse whose back/forward/middle buttons reach the event
   tap as standard `OtherMouseDown`/`Up` should work the same way, but each one is enabled
   by flipping this flag on its catalog entry only after someone verifies it on real
   hardware. No mouse is opted in implicitly.
3. **Off by default, no behavior change for existing users.** A button only arms a gesture
   if (a) the device's flag is set, (b) the user has bound at least one direction on it, and
   (c) the user has explicitly turned on gesture mode for that button in the UI. The
   existing MX Master HID++ gesture path is untouched — `core/hid_gesture.py` has a byte-for-byte
   empty diff in this branch.

## Reused vs. new

**Reused (~80%):** the direction-detection math (`decide_gesture`, deadzone/threshold/hold-floor,
`core/mouse_hook_base.py`), the delta-accumulation and cooldown machinery
(`_accumulate_gesture_delta`), the gesture-direction UI panel pattern in
`ui/qml/MousePage.qml` (now attached per-button instead of only to the HID gesture button),
and the existing action catalog (40+ actions, unchanged).

**New:** the event-tap arming mechanism itself — `OtherMouseDown`/`Up` handling in
`core/mouse_hook_macos.py` arms/releases a per-button gesture, decides click-vs-gesture on
release, and (on a tap) dispatches the button's own mapped click instead of a native replay
(macOS ignores synthetic clicks on button 3/4, so a native replay would be dead); plus the
12 namespaced `gesture_<owner>_<direction>` config binding keys, the `gesture_owners()` /
`gesture_bindings_for()` config helpers, the `supports_event_tap_gestures` capability flag,
and the per-owner routing in `core/engine.py` (`_make_owner_gesture_handler`, keyed on the
`gesture_owner` tag the kernel attaches rather than a namespaced event string).

## Testing

**Unit-tested (objc-free, runs in CI):**
- Direction decision logic (`decide_gesture`) — tap-vs-gesture, hold-floor boundary, deadzone,
  cross-axis ambiguity (`tests/test_event_tap_gesture.py`).
- Arming gate (`should_arm_gesture`) — first-held-wins, no-owners-configured off-switch.
- Config schema/migration for the 12 namespaced keys, `gesture_owners()`, `gesture_bindings_for()`
  (`tests/test_config_gestures.py`).
- Engine wiring: owner-gate (config-bound AND UI-enabled AND device-eligible), per-owner
  direction routing, no double-fire against the HID direction path (`tests/test_engine.py`).
- Two hardware-found regressions, now pinned: (1) the initial hook setup runs before the
  device connects, so arming must recompute on the HID-features-ready transition; (2) that
  recompute must reset bindings before re-registering, or a reconnect stacks a duplicate
  handler and the gesture action fires 2-3x.
- A fake-Quartz harness exercises the real macOS callback's arm/release/abort state machine,
  including that a tap dispatches the button's own (DOWN, UP) pair rather than any native
  CGEventPost replay.

**Hardware-verified (real MX Anywhere 2S, not automatable):**
- All 4 directions on back, forward, and middle fire their bound actions.
- A normal quick click of an armed button still performs its normal action — no misfire.
- Cursor does not drift during an active slide.
- No regression to MX Master HID++ gestures or normal remapping.

## Out of scope (this PR)

- Windows / Linux event-tap arming.
- Diagonal / 8-way gestures.
- Options+ config import / cloud sync.
