### PR TITLE
macOS: keep the menu-bar icon from vanishing when the window opens

### DIFF
--- a/main_qml.py
+++ b/main_qml.py
@@ -385,6 +385,9 @@ _MACOS_DOCK_ICON_NSIMAGE = None
 _MACOS_ACTIVATION_POLICY_REGULAR: "bool | None" = None
 _MACOS_NATIVE_STATUS_ITEM = None
 _MACOS_NATIVE_STATUS_TARGET = None
+# (qmenu, on_left_click) captured at first install, so the status item can be
+# re-created after an activation-policy flip detaches it (see below).
+_MACOS_STATUS_ITEM_PARAMS = None
 _MACOS_QUIT_FILTER = None
 _MACOS_SYSTEM_QUIT_REASONS = {
     "quia",  # kAEQuitAll
@@ -645,6 +648,27 @@ def _schedule_macos_dock_icon_refresh() -> None:
         _install_macos_dock_icon()
 
 
+def _schedule_macos_status_item_reinstall() -> None:
+    """An .accessory -> .regular activation-policy flip detaches our custom
+    NSStatusItem from the menu bar (the object survives, its menu-bar slot does
+    not), so the icon vanishes when the window opens. Re-create it after the
+    flip. Mirrors _schedule_macos_dock_icon_refresh's 0ms + 250ms double-fire
+    so it works whether AppKit detaches synchronously or a tick later. No-op
+    until the item has first been installed."""
+    if sys.platform != "darwin" or _MACOS_STATUS_ITEM_PARAMS is None:
+        return
+
+    def _reinstall():
+        if _MACOS_STATUS_ITEM_PARAMS is not None:
+            _install_native_macos_status_item(*_MACOS_STATUS_ITEM_PARAMS)
+
+    try:
+        QTimer.singleShot(0, _reinstall)
+        QTimer.singleShot(250, _reinstall)
+    except Exception:
+        _reinstall()
+
+
 def _set_macos_activation_policy(regular: bool) -> None:
     """Toggle between the Regular (foreground, Dock + Cmd+Tab) and
     Accessory (menu-bar only) policies. On a Regular promotion AppKit
@@ -677,6 +701,7 @@ def _set_macos_activation_policy(regular: bool) -> None:
     if regular:
         _install_macos_dock_icon()
         _schedule_macos_dock_icon_refresh()
+        _schedule_macos_status_item_reinstall()
 
 
 def _activate_macos_window():
@@ -706,11 +731,24 @@ def _install_native_macos_status_item(qmenu, on_left_click):
     any failure -- callers should fall back to ``QSystemTrayIcon``.
     """
     global _MACOS_NATIVE_STATUS_ITEM, _MACOS_NATIVE_STATUS_TARGET
+    global _MACOS_STATUS_ITEM_PARAMS
     if sys.platform != "darwin":
         return None
+    _MACOS_STATUS_ITEM_PARAMS = (qmenu, on_left_click)
     appkit = _macos_appkit()
     if appkit is None:
         return None
+    # A prior item may still exist (re-install after an activation-policy flip
+    # detached the old one); drop it first so we never leave a duplicate.
+    if _MACOS_NATIVE_STATUS_ITEM is not None:
+        try:
+            appkit.NSStatusBar.systemStatusBar().removeStatusItem_(
+                _MACOS_NATIVE_STATUS_ITEM
+            )
+        except Exception:
+            pass
+        _MACOS_NATIVE_STATUS_ITEM = None
+        _MACOS_NATIVE_STATUS_TARGET = None
     if _MacOSStatusItemTarget is None:
         print("[Mouser] Foundation.NSObject unavailable; using Qt tray icon")
         return None

--- a/main_qml.py
+++ b/main_qml.py
@@ -385,9 +385,14 @@ _MACOS_DOCK_ICON_NSIMAGE = None
 _MACOS_ACTIVATION_POLICY_REGULAR: "bool | None" = None
 _MACOS_NATIVE_STATUS_ITEM = None
 _MACOS_NATIVE_STATUS_TARGET = None
-# (qmenu, on_left_click) captured at first install, so the status item can be
-# re-created after an activation-policy flip detaches it (see below).
+# (qmenu, on_left_click) captured only after a successful native install, so
+# the status item can be re-created after an activation-policy flip detaches
+# it (see below) without later replacing the Qt fallback after a failed setup.
 _MACOS_STATUS_ITEM_PARAMS = None
+# Every successful activation-policy change invalidates callbacks scheduled
+# before it. A rapid show/hide transition must not let an old delayed callback
+# tear down a newer, working status item.
+_MACOS_STATUS_ITEM_REINSTALL_GENERATION = 0
 _MACOS_QUIT_FILTER = None
 _MACOS_SYSTEM_QUIT_REASONS = {
     "quia",  # kAEQuitAll
@@ -648,25 +653,62 @@ def _schedule_macos_dock_icon_refresh() -> None:
         _install_macos_dock_icon()
 
 
+def _macos_native_status_item_is_attached() -> bool:
+    """Whether the retained native item still belongs to an AppKit window.
+
+    AppKit keeps an ``NSStatusItem`` object alive after an activation-policy
+    flip can remove its menu-bar slot. Its button no longer has a window in
+    that state, which lets the delayed retry avoid replacing an item that the
+    immediate retry already restored.
+    """
+    if _MACOS_NATIVE_STATUS_ITEM is None:
+        return False
+    try:
+        button = _MACOS_NATIVE_STATUS_ITEM.button()
+        return button is not None and button.window() is not None
+    except Exception:
+        return False
+
+
 def _schedule_macos_status_item_reinstall() -> None:
     """An .accessory -> .regular activation-policy flip detaches our custom
     NSStatusItem from the menu bar (the object survives, its menu-bar slot does
     not), so the icon vanishes when the window opens. Re-create it after the
-    flip. Mirrors _schedule_macos_dock_icon_refresh's 0ms + 250ms double-fire
-    so it works whether AppKit detaches synchronously or a tick later. No-op
-    until the item has first been installed."""
+    flip. The delayed retry runs only when the immediate attempt failed or
+    AppKit subsequently detached the replacement. No-op until a native item
+    has first been installed successfully."""
     if sys.platform != "darwin" or _MACOS_STATUS_ITEM_PARAMS is None:
         return
+    generation = _MACOS_STATUS_ITEM_REINSTALL_GENERATION
+    first_attempt_succeeded = False
 
-    def _reinstall():
-        if _MACOS_STATUS_ITEM_PARAMS is not None:
-            _install_native_macos_status_item(*_MACOS_STATUS_ITEM_PARAMS)
+    def _is_current() -> bool:
+        return generation == _MACOS_STATUS_ITEM_REINSTALL_GENERATION
+
+    def _reinstall() -> bool:
+        if not _is_current() or _MACOS_STATUS_ITEM_PARAMS is None:
+            return False
+        return _install_native_macos_status_item(*_MACOS_STATUS_ITEM_PARAMS) is not None
+
+    def _immediate_reinstall() -> None:
+        nonlocal first_attempt_succeeded
+        first_attempt_succeeded = _reinstall()
+
+    def _delayed_reinstall() -> None:
+        if not _is_current():
+            return
+        if first_attempt_succeeded and _macos_native_status_item_is_attached():
+            return
+        _reinstall()
 
     try:
-        QTimer.singleShot(0, _reinstall)
-        QTimer.singleShot(250, _reinstall)
+        QTimer.singleShot(0, _immediate_reinstall)
     except Exception:
-        _reinstall()
+        _immediate_reinstall()
+    try:
+        QTimer.singleShot(250, _delayed_reinstall)
+    except Exception:
+        pass
 
 
 def _set_macos_activation_policy(regular: bool) -> None:
@@ -679,6 +721,7 @@ def _set_macos_activation_policy(regular: bool) -> None:
     ``visibilityChanged`` storms cheap.
     """
     global _MACOS_ACTIVATION_POLICY_REGULAR
+    global _MACOS_STATUS_ITEM_REINSTALL_GENERATION
     if sys.platform != "darwin":
         return
     if _MACOS_ACTIVATION_POLICY_REGULAR == regular:
@@ -698,6 +741,7 @@ def _set_macos_activation_policy(regular: bool) -> None:
         print(f"[Mouser] Failed to set macOS activation policy: {exc}")
         return
     _MACOS_ACTIVATION_POLICY_REGULAR = regular
+    _MACOS_STATUS_ITEM_REINSTALL_GENERATION += 1
     if regular:
         _install_macos_dock_icon()
         _schedule_macos_dock_icon_refresh()
@@ -734,7 +778,6 @@ def _install_native_macos_status_item(qmenu, on_left_click):
     global _MACOS_STATUS_ITEM_PARAMS
     if sys.platform != "darwin":
         return None
-    _MACOS_STATUS_ITEM_PARAMS = (qmenu, on_left_click)
     appkit = _macos_appkit()
     if appkit is None:
         return None
@@ -745,8 +788,12 @@ def _install_native_macos_status_item(qmenu, on_left_click):
             appkit.NSStatusBar.systemStatusBar().removeStatusItem_(
                 _MACOS_NATIVE_STATUS_ITEM
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            # Do not clear the retained references or create another item: an
+            # AppKit removal failure can leave the old item mounted, and a
+            # replacement would give the user duplicate menu-bar icons.
+            print(f"[Mouser] Failed to remove native status item: {exc}")
+            return None
         _MACOS_NATIVE_STATUS_ITEM = None
         _MACOS_NATIVE_STATUS_TARGET = None
     if _MacOSStatusItemTarget is None:
@@ -830,6 +877,10 @@ def _install_native_macos_status_item(qmenu, on_left_click):
     # while the app keeps running.
     _MACOS_NATIVE_STATUS_ITEM = status_item
     _MACOS_NATIVE_STATUS_TARGET = target
+    # Publish retry parameters only once this native item is fully installed.
+    # If initial setup falls back to QSystemTrayIcon, leaving this unset keeps
+    # a later activation-policy change from creating a second icon beside it.
+    _MACOS_STATUS_ITEM_PARAMS = (qmenu, on_left_click)
     return status_item
 
 

--- a/tests/test_macos_app_shell.py
+++ b/tests/test_macos_app_shell.py
@@ -3,7 +3,7 @@ import sys
 import unittest
 import ctypes
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 try:
     import main_qml
@@ -156,6 +156,185 @@ class AppIdentityTests(unittest.TestCase):
                 (250, main_qml._install_macos_dock_icon),
             ],
         )
+
+
+@unittest.skipIf(main_qml is None, "main_qml / PySide6 not available")
+class MacOSStatusItemReinstallTests(unittest.TestCase):
+    _global_names = (
+        "_MACOS_ACTIVATION_POLICY_REGULAR",
+        "_MACOS_NATIVE_STATUS_ITEM",
+        "_MACOS_NATIVE_STATUS_TARGET",
+        "_MACOS_STATUS_ITEM_PARAMS",
+        "_MACOS_STATUS_ITEM_REINSTALL_GENERATION",
+    )
+
+    def setUp(self):
+        self._original_globals = {
+            name: getattr(main_qml, name) for name in self._global_names
+        }
+        for name in self._global_names:
+            self.addCleanup(setattr, main_qml, name, self._original_globals[name])
+
+    @staticmethod
+    def _attached_status_item():
+        return SimpleNamespace(
+            button=lambda: SimpleNamespace(window=lambda: object())
+        )
+
+    def _queue_reinstall_callbacks(self):
+        callbacks = []
+        with (
+            patch.object(main_qml.sys, "platform", "darwin"),
+            patch.object(
+                main_qml.QTimer,
+                "singleShot",
+                side_effect=lambda delay, callback: callbacks.append((delay, callback)),
+            ),
+        ):
+            main_qml._schedule_macos_status_item_reinstall()
+        self.assertEqual([delay for delay, _ in callbacks], [0, 250])
+        return [callback for _, callback in callbacks]
+
+    def test_successful_immediate_reinstall_skips_delayed_replacement(self):
+        main_qml._MACOS_STATUS_ITEM_PARAMS = ("menu", lambda: None)
+        status_item = self._attached_status_item()
+
+        def install(*_args):
+            main_qml._MACOS_NATIVE_STATUS_ITEM = status_item
+            return status_item
+
+        with patch.object(
+            main_qml,
+            "_install_native_macos_status_item",
+            side_effect=install,
+        ) as installer:
+            immediate, delayed = self._queue_reinstall_callbacks()
+            immediate()
+            delayed()
+
+        installer.assert_called_once_with("menu", ANY)
+
+    def test_delayed_reinstall_runs_only_when_immediate_attempt_failed(self):
+        main_qml._MACOS_STATUS_ITEM_PARAMS = ("menu", lambda: None)
+        status_item = self._attached_status_item()
+
+        def install(*_args):
+            if installer.call_count == 1:
+                return None
+            main_qml._MACOS_NATIVE_STATUS_ITEM = status_item
+            return status_item
+
+        with patch.object(
+            main_qml,
+            "_install_native_macos_status_item",
+            side_effect=install,
+        ) as installer:
+            immediate, delayed = self._queue_reinstall_callbacks()
+            immediate()
+            delayed()
+
+        self.assertEqual(installer.call_count, 2)
+
+    def test_delayed_reinstall_runs_when_appkit_detaches_the_new_item(self):
+        main_qml._MACOS_STATUS_ITEM_PARAMS = ("menu", lambda: None)
+        status_item = self._attached_status_item()
+
+        def install(*_args):
+            main_qml._MACOS_NATIVE_STATUS_ITEM = status_item
+            return status_item
+
+        with patch.object(
+            main_qml,
+            "_install_native_macos_status_item",
+            side_effect=install,
+        ) as installer:
+            immediate, delayed = self._queue_reinstall_callbacks()
+            immediate()
+            main_qml._MACOS_NATIVE_STATUS_ITEM = None
+            delayed()
+
+        self.assertEqual(installer.call_count, 2)
+
+    def test_policy_change_invalidates_stale_reinstall_callbacks(self):
+        main_qml._MACOS_STATUS_ITEM_PARAMS = ("menu", lambda: None)
+        main_qml._MACOS_ACTIVATION_POLICY_REGULAR = False
+        main_qml._MACOS_STATUS_ITEM_REINSTALL_GENERATION = 10
+        appkit = SimpleNamespace(
+            NSApplicationActivationPolicyRegular="regular",
+            NSApplicationActivationPolicyAccessory="accessory",
+            NSApp=SimpleNamespace(setActivationPolicy_=MagicMock()),
+        )
+        callbacks = []
+
+        with (
+            patch.object(main_qml.sys, "platform", "darwin"),
+            patch.object(main_qml, "_macos_appkit", return_value=appkit),
+            patch.object(main_qml, "_install_macos_dock_icon"),
+            patch.object(main_qml, "_schedule_macos_dock_icon_refresh"),
+            patch.object(
+                main_qml.QTimer,
+                "singleShot",
+                side_effect=lambda delay, callback: callbacks.append((delay, callback)),
+            ),
+            patch.object(main_qml, "_install_native_macos_status_item") as installer,
+        ):
+            main_qml._set_macos_activation_policy(regular=True)
+            main_qml._set_macos_activation_policy(regular=False)
+            self.assertEqual([delay for delay, _ in callbacks], [0, 250])
+            immediate, delayed = [callback for _, callback in callbacks]
+            immediate()
+            delayed()
+
+        installer.assert_not_called()
+        self.assertEqual(main_qml._MACOS_STATUS_ITEM_REINSTALL_GENERATION, 12)
+
+    def test_failed_initial_native_install_leaves_qt_fallback_unarmed(self):
+        main_qml._MACOS_STATUS_ITEM_PARAMS = None
+
+        with (
+            patch.object(main_qml.sys, "platform", "darwin"),
+            patch.object(main_qml, "_macos_appkit", return_value=None),
+        ):
+            self.assertIsNone(
+                main_qml._install_native_macos_status_item("menu", lambda: None)
+            )
+
+        self.assertIsNone(main_qml._MACOS_STATUS_ITEM_PARAMS)
+        with (
+            patch.object(main_qml.sys, "platform", "darwin"),
+            patch.object(main_qml.QTimer, "singleShot") as single_shot,
+        ):
+            main_qml._schedule_macos_status_item_reinstall()
+        single_shot.assert_not_called()
+
+    def test_remove_failure_keeps_existing_item_and_does_not_replace_it(self):
+        original_item = object()
+        original_target = object()
+        original_params = ("old-menu", lambda: None)
+        status_bar = SimpleNamespace(
+            removeStatusItem_=MagicMock(side_effect=RuntimeError("remove failed"))
+        )
+        appkit = SimpleNamespace(
+            NSStatusBar=SimpleNamespace(systemStatusBar=lambda: status_bar)
+        )
+        main_qml._MACOS_NATIVE_STATUS_ITEM = original_item
+        main_qml._MACOS_NATIVE_STATUS_TARGET = original_target
+        main_qml._MACOS_STATUS_ITEM_PARAMS = original_params
+
+        with (
+            patch.object(main_qml.sys, "platform", "darwin"),
+            patch.object(main_qml, "_macos_appkit", return_value=appkit),
+            patch("builtins.print") as printed,
+        ):
+            self.assertIsNone(
+                main_qml._install_native_macos_status_item("new-menu", lambda: None)
+            )
+
+        status_bar.removeStatusItem_.assert_called_once_with(original_item)
+        self.assertIs(main_qml._MACOS_NATIVE_STATUS_ITEM, original_item)
+        self.assertIs(main_qml._MACOS_NATIVE_STATUS_TARGET, original_target)
+        self.assertIs(main_qml._MACOS_STATUS_ITEM_PARAMS, original_params)
+        printed.assert_called_once()
 
 
 @unittest.skipIf(main_qml is None, "main_qml / PySide6 not available")


### PR DESCRIPTION
## Problem

On macOS, opening the window (e.g. clicking the menu-bar icon) makes the menu-bar
icon **disappear** until the app is relaunched. Opening the window promotes the app
`.accessory` -> `.regular` to give the window a Dock tile + Cmd-Tab entry, and that
activation-policy flip detaches our custom `NSStatusItem` from the menu bar: the object
survives (it's strongly referenced), but its menu-bar slot is dropped. On a
multi-monitor setup it's especially confusing — the window opens on one display while
the icon vanishes on another, so it reads as the app having quit.

## Fix

Re-create the status item right after the `.regular` flip, mirroring the existing
`_schedule_macos_dock_icon_refresh` 0ms + 250ms double-fire so it works whether AppKit
detaches the item synchronously or a tick later. A re-install drops any prior item
first, so it never leaves a duplicate. The intended Dock-tile-on-window-open behavior
is preserved.

## Known limitation (being upfront)

This turns "icon vanishes until relaunch" into "icon blinks briefly and returns" — but
a one-frame blink remains, because the activation-policy toggle inherently tears the
status item off the menu bar before we can re-add it. I tried a synchronous re-install
to close the gap; it still blinks, so the detach isn't cleanly synchronous. Fully
eliminating the blink would mean **not** toggling activation policy (i.e. dropping the
Dock tile / Cmd-Tab entry for the window) — a deliberate design call I've left to you
rather than change unilaterally. Happy to follow up either way.

## Testing

Verified on a real MX Anywhere 2S / macOS, including the multi-monitor case that
surfaced it: before, the icon vanished permanently; after, it returns immediately.
Menu (right/control/option-click) and Dock-tile behavior are unchanged.
