### PR TITLE
Tilt (horizontal-scroll) slide gestures [stacked on #228]

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -46,21 +46,43 @@ GESTURE_DIRECTION_BUTTONS = (
 # independently own a 4-direction gesture, driven by the macOS event tap
 # rather than the HID++ thumb gesture button above. Namespaced keys keep this
 # additive to GESTURE_DIRECTION_BUTTONS, which stays wired to the HID path.
-GESTURE_OWNERS = ("back", "forward", "middle")
+BUTTON_GESTURE_OWNERS = ("back", "forward", "middle")
+# Tilt (horizontal-scroll) slide gestures: the hscroll pulse stream is armed as
+# two gesture owners. Same gesture_<owner>_<dir> shape as the button owners, but
+# the engine feeds these to configure_gestures(tilt_owners=) not owners=.
+TILT_GESTURE_OWNERS = ("tilt_left", "tilt_right")
+# Combined owner list the gesture_owners()/gesture_bindings_for() helpers iterate.
+GESTURE_OWNERS = BUTTON_GESTURE_OWNERS + TILT_GESTURE_OWNERS
 GESTURE_DIRECTIONS = ("left", "right", "up", "down")
 
-_GESTURE_OWNER_LABELS = {"back": "Back", "forward": "Forward", "middle": "Middle"}
+_GESTURE_OWNER_LABELS = {
+    "back": "Back",
+    "forward": "Forward",
+    "middle": "Middle",
+    "tilt_left": "Tilt left",
+    "tilt_right": "Tilt right",
+}
 
 _PER_BUTTON_GESTURE_LABELS = {
     f"gesture_{owner}_{direction}": f"{_GESTURE_OWNER_LABELS[owner]} gesture swipe {direction}"
-    for owner in GESTURE_OWNERS
+    for owner in BUTTON_GESTURE_OWNERS
     for direction in GESTURE_DIRECTIONS
 }
 
-# The 12 namespaced keys, e.g. "gesture_back_left" .. "gesture_middle_down".
+# The 12 namespaced button keys, e.g. "gesture_back_left" .. "gesture_middle_down".
 PER_BUTTON_GESTURE_KEYS = tuple(_PER_BUTTON_GESTURE_LABELS)
 
+_TILT_GESTURE_LABELS = {
+    f"gesture_{owner}_{direction}": f"{_GESTURE_OWNER_LABELS[owner]} gesture swipe {direction}"
+    for owner in TILT_GESTURE_OWNERS
+    for direction in GESTURE_DIRECTIONS
+}
+
+# The 8 namespaced tilt keys, e.g. "gesture_tilt_left_left" .. "gesture_tilt_right_down".
+TILT_GESTURE_KEYS = tuple(_TILT_GESTURE_LABELS)
+
 GESTURE_HOLD_FLOOR_MS_DEFAULT = 80
+TILT_GESTURE_RELEASE_MS_DEFAULT = 150
 
 PROFILE_BUTTON_NAMES = {
     **BUTTON_NAMES,
@@ -69,14 +91,17 @@ PROFILE_BUTTON_NAMES = {
     "gesture_up":    "Gesture swipe up",
     "gesture_down":  "Gesture swipe down",
     **_PER_BUTTON_GESTURE_LABELS,
+    **_TILT_GESTURE_LABELS,
 }
 
 # Maps config button keys to the MouseEvent types they correspond to.
-# NOTE: the 12 namespaced gesture_<owner>_<direction> binding keys deliberately
-# have NO entry here. The event-tap kernel emits the generic gesture_swipe_<dir>
-# event tagged with raw_data["gesture_owner"], and engine._make_owner_gesture_handler
-# routes on that tag -- a namespaced "gesture_<owner>_swipe_<dir>" string is never
-# dispatched. Resolve these bindings via gesture_bindings_for(), not this map.
+# NOTE: the 12 namespaced button gesture_<owner>_<direction> keys AND the 8 tilt
+# gesture_tilt_{left,right}_<direction> keys deliberately have NO entry here. The
+# kernel emits the generic gesture_swipe_<dir> event tagged with
+# raw_data["gesture_owner"], and engine._make_owner_gesture_handler routes on that
+# tag -- a namespaced string is never dispatched. (A tilt TAP instead reuses the
+# existing hscroll_left/hscroll_right mapping below.) Resolve these bindings via
+# gesture_bindings_for(), not this map.
 BUTTON_TO_EVENTS = {
     "middle":        ("middle_down", "middle_up"),
     "gesture":       ("gesture_click",),
@@ -107,6 +132,7 @@ DEFAULT_CONFIG = {
                 "gesture_up": "none",
                 "gesture_down": "none",
                 **{key: "none" for key in PER_BUTTON_GESTURE_KEYS},
+                **{key: "none" for key in TILT_GESTURE_KEYS},
                 "xbutton1": "alt_tab",
                 "xbutton2": "alt_tab",
                 "hscroll_left": "browser_back",
@@ -130,6 +156,7 @@ DEFAULT_CONFIG = {
         "gesture_timeout_ms": 3000,
         "gesture_cooldown_ms": 500,
         "gesture_hold_floor_ms": GESTURE_HOLD_FLOOR_MS_DEFAULT,
+        "tilt_gesture_release_ms": TILT_GESTURE_RELEASE_MS_DEFAULT,
         "appearance_mode": "system",
         "debug_mode": False,
         "device_layout_overrides": {},
@@ -393,6 +420,10 @@ def _migrate(cfg):
     cfg["settings"]["gesture_hold_floor_ms"] = max(
         0, int(cfg["settings"].get("gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT))
     )
+    cfg["settings"].setdefault("tilt_gesture_release_ms", TILT_GESTURE_RELEASE_MS_DEFAULT)
+    cfg["settings"]["tilt_gesture_release_ms"] = max(
+        50, int(cfg["settings"].get("tilt_gesture_release_ms", TILT_GESTURE_RELEASE_MS_DEFAULT))
+    )
 
     # Always migrate old wmplayer.exe → Microsoft.Media.Player.exe in profile apps
     for pdata in cfg.get("profiles", {}).values():
@@ -401,11 +432,13 @@ def _migrate(cfg):
             if a.lower() == "wmplayer.exe":
                 apps[i] = "Microsoft.Media.Player.exe"
 
-    # Always ensure the 12 namespaced per-button gesture keys exist ("none" =
-    # off) so pre-existing configs surface no owners without erroring.
+    # Always ensure the 12 per-button + 8 tilt namespaced gesture keys exist
+    # ("none" = off) so pre-existing configs surface no owners without erroring.
     for pdata in cfg.get("profiles", {}).values():
         mappings = pdata.setdefault("mappings", {})
         for key in PER_BUTTON_GESTURE_KEYS:
+            mappings.setdefault(key, "none")
+        for key in TILT_GESTURE_KEYS:
             mappings.setdefault(key, "none")
 
     return cfg

--- a/core/config.py
+++ b/core/config.py
@@ -42,15 +42,41 @@ GESTURE_DIRECTION_BUTTONS = (
     "gesture_down",
 )
 
+# Per-button slide gestures: each non-primary button (back/forward/middle) can
+# independently own a 4-direction gesture, driven by the macOS event tap
+# rather than the HID++ thumb gesture button above. Namespaced keys keep this
+# additive to GESTURE_DIRECTION_BUTTONS, which stays wired to the HID path.
+GESTURE_OWNERS = ("back", "forward", "middle")
+GESTURE_DIRECTIONS = ("left", "right", "up", "down")
+
+_GESTURE_OWNER_LABELS = {"back": "Back", "forward": "Forward", "middle": "Middle"}
+
+_PER_BUTTON_GESTURE_LABELS = {
+    f"gesture_{owner}_{direction}": f"{_GESTURE_OWNER_LABELS[owner]} gesture swipe {direction}"
+    for owner in GESTURE_OWNERS
+    for direction in GESTURE_DIRECTIONS
+}
+
+# The 12 namespaced keys, e.g. "gesture_back_left" .. "gesture_middle_down".
+PER_BUTTON_GESTURE_KEYS = tuple(_PER_BUTTON_GESTURE_LABELS)
+
+GESTURE_HOLD_FLOOR_MS_DEFAULT = 80
+
 PROFILE_BUTTON_NAMES = {
     **BUTTON_NAMES,
     "gesture_left":  "Gesture swipe left",
     "gesture_right": "Gesture swipe right",
     "gesture_up":    "Gesture swipe up",
     "gesture_down":  "Gesture swipe down",
+    **_PER_BUTTON_GESTURE_LABELS,
 }
 
-# Maps config button keys to the MouseEvent types they correspond to
+# Maps config button keys to the MouseEvent types they correspond to.
+# NOTE: the 12 namespaced gesture_<owner>_<direction> binding keys deliberately
+# have NO entry here. The event-tap kernel emits the generic gesture_swipe_<dir>
+# event tagged with raw_data["gesture_owner"], and engine._make_owner_gesture_handler
+# routes on that tag -- a namespaced "gesture_<owner>_swipe_<dir>" string is never
+# dispatched. Resolve these bindings via gesture_bindings_for(), not this map.
 BUTTON_TO_EVENTS = {
     "middle":        ("middle_down", "middle_up"),
     "gesture":       ("gesture_click",),
@@ -80,6 +106,7 @@ DEFAULT_CONFIG = {
                 "gesture_right": "none",
                 "gesture_up": "none",
                 "gesture_down": "none",
+                **{key: "none" for key in PER_BUTTON_GESTURE_KEYS},
                 "xbutton1": "alt_tab",
                 "xbutton2": "alt_tab",
                 "hscroll_left": "browser_back",
@@ -102,6 +129,7 @@ DEFAULT_CONFIG = {
         "gesture_deadzone": 40,
         "gesture_timeout_ms": 3000,
         "gesture_cooldown_ms": 500,
+        "gesture_hold_floor_ms": GESTURE_HOLD_FLOOR_MS_DEFAULT,
         "appearance_mode": "system",
         "debug_mode": False,
         "device_layout_overrides": {},
@@ -200,6 +228,28 @@ def get_active_mappings(cfg):
     profiles = cfg.get("profiles", {})
     profile = profiles.get(profile_name, profiles.get("default", {}))
     return profile.get("mappings", DEFAULT_CONFIG["profiles"]["default"]["mappings"])
+
+
+def gesture_owners(cfg):
+    """Buttons (back/forward/middle) with >=1 per-button gesture direction bound."""
+    mappings = get_active_mappings(cfg)
+    return {
+        owner
+        for owner in GESTURE_OWNERS
+        if any(
+            mappings.get(f"gesture_{owner}_{direction}", "none") != "none"
+            for direction in GESTURE_DIRECTIONS
+        )
+    }
+
+
+def gesture_bindings_for(cfg, owner):
+    """Return {swipe_left: action_id, swipe_right: ..., swipe_up: ..., swipe_down: ...}."""
+    mappings = get_active_mappings(cfg)
+    return {
+        f"swipe_{direction}": mappings.get(f"gesture_{owner}_{direction}", "none")
+        for direction in GESTURE_DIRECTIONS
+    }
 
 
 def set_mapping(cfg, button, action_id, profile=None):
@@ -339,6 +389,10 @@ def _migrate(cfg):
     cfg["settings"].setdefault("screenshot_directory", "")
     cfg["settings"].setdefault("check_for_updates", True)
     cfg["settings"].setdefault("update_check_state", {})
+    cfg["settings"].setdefault("gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT)
+    cfg["settings"]["gesture_hold_floor_ms"] = max(
+        0, int(cfg["settings"].get("gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT))
+    )
 
     # Always migrate old wmplayer.exe → Microsoft.Media.Player.exe in profile apps
     for pdata in cfg.get("profiles", {}).values():
@@ -346,6 +400,13 @@ def _migrate(cfg):
         for i, a in enumerate(apps):
             if a.lower() == "wmplayer.exe":
                 apps[i] = "Microsoft.Media.Player.exe"
+
+    # Always ensure the 12 namespaced per-button gesture keys exist ("none" =
+    # off) so pre-existing configs surface no owners without erroring.
+    for pdata in cfg.get("profiles", {}).values():
+        mappings = pdata.setdefault("mappings", {})
+        for key in PER_BUTTON_GESTURE_KEYS:
+            mappings.setdefault(key, "none")
 
     return cfg
 

--- a/core/engine.py
+++ b/core/engine.py
@@ -14,7 +14,8 @@ from core.key_simulator import (
 from core.config import (
     load_config, get_active_mappings, get_profile_for_app,
     BUTTON_TO_EVENTS, GESTURE_DIRECTION_BUTTONS, GESTURE_DIRECTIONS,
-    GESTURE_HOLD_FLOOR_MS_DEFAULT, gesture_owners, gesture_bindings_for,
+    GESTURE_HOLD_FLOOR_MS_DEFAULT, BUTTON_GESTURE_OWNERS, TILT_GESTURE_OWNERS,
+    TILT_GESTURE_RELEASE_MS_DEFAULT, gesture_owners, gesture_bindings_for,
     save_config,
 )
 from core.app_detector import AppDetector
@@ -98,14 +99,32 @@ class Engine:
     # Hook wiring
     # ------------------------------------------------------------------
     def _active_gesture_owners(self, cfg, settings):
-        """Owners actually armed at the hook (finding #1): config-bound AND
-        the UI enable toggle (settings.gesture_owner_enabled) is on AND the
-        connected device can host a per-button gesture on that owner --
-        mirrors the capability check in ui.backend.gestureEligibleOwners.
-        Direction bindings themselves are left untouched in config; this only
-        narrows what gets passed to the hook as armed. No device connected
-        means arming is moot, so nothing is eligible."""
-        bound = gesture_owners(cfg)
+        """Button owners (back/forward/middle) actually armed at the hook
+        (finding #1): config-bound AND the UI enable toggle
+        (settings.gesture_owner_enabled) is on AND the connected device can
+        host a per-button gesture on that owner -- mirrors the capability
+        check in ui.backend.gestureEligibleOwners. Direction bindings
+        themselves are left untouched in config; this only narrows what gets
+        passed to the hook as armed. No device connected means arming is
+        moot, so nothing is eligible. Restricted to BUTTON_GESTURE_OWNERS so
+        a bound+enabled+eligible tilt owner (gesture_owners() is the
+        button+tilt union) isn't also fed to the hook's button-owner path --
+        see _active_tilt_owners for the tilt counterpart."""
+        bound = gesture_owners(cfg) & set(BUTTON_GESTURE_OWNERS)
+        return self._gate_owner_eligibility(bound, settings)
+
+    def _active_tilt_owners(self, cfg, settings):
+        """Tilt owners (tilt_left/tilt_right) actually armed on the hscroll
+        pulse stream: config-bound AND the UI enable toggle is on AND the
+        connected device is tilt-eligible (supports_tilt_gestures, exposed as
+        gesture_<owner>_left in supported_buttons). Same gate as
+        _active_gesture_owners, restricted to TILT_GESTURE_OWNERS."""
+        bound = gesture_owners(cfg) & set(TILT_GESTURE_OWNERS)
+        return self._gate_owner_eligibility(bound, settings)
+
+    def _gate_owner_eligibility(self, bound, settings):
+        """Shared enable+device-eligibility filter for an already owner-kind-
+        scoped `bound` set. See _active_gesture_owners / _active_tilt_owners."""
         if not bound:
             return set()
         device = getattr(self, "connected_device", None)
@@ -130,15 +149,19 @@ class Engine:
             self.hook.ignore_trackpad = settings.get("ignore_trackpad", True)
         self.hook.debug_mode = self._debug_events_enabled
         owners = self._active_gesture_owners(self.cfg, settings)
+        tilt_owners = self._active_tilt_owners(self.cfg, settings)
         self.hook.configure_gestures(
-            enabled=bool(owners) or any(mappings.get(key, "none") != "none"
-                                        for key in GESTURE_DIRECTION_BUTTONS),
+            enabled=bool(owners) or bool(tilt_owners) or any(
+                mappings.get(key, "none") != "none" for key in GESTURE_DIRECTION_BUTTONS
+            ),
             threshold=settings.get("gesture_threshold", 50),
             deadzone=settings.get("gesture_deadzone", 40),
             timeout_ms=settings.get("gesture_timeout_ms", 3000),
             cooldown_ms=settings.get("gesture_cooldown_ms", 500),
             owners=owners,
             hold_floor_ms=settings.get("gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT),
+            tilt_owners=tilt_owners,
+            tilt_release_ms=settings.get("tilt_gesture_release_ms", TILT_GESTURE_RELEASE_MS_DEFAULT),
         )
         # Divert mode shift CID only when the device has the button and
         # at least one profile maps it to an action.  When no device is
@@ -197,11 +220,18 @@ class Engine:
                     else:
                         self.hook.register(evt_type, self._make_handler(action_id))
 
-        # Per-owner event-tap gestures (issue 004): the kernel tags the fired
-        # gesture with the active owner in raw_data rather than a namespaced
-        # event, so route (owner, direction) -> gesture_<owner>_<dir> here.
-        if owners:
-            owner_bindings = {owner: gesture_bindings_for(self.cfg, owner) for owner in owners}
+        # Per-owner event-tap + tilt gestures (issue 004 + tilt): the kernel
+        # tags the fired gesture with the active owner in raw_data rather than
+        # a namespaced event, so route (owner, direction) -> gesture_<owner>_<dir>
+        # here for BOTH button owners (armed via owners=) and tilt owners
+        # (armed via tilt_owners=) -- the routing itself doesn't care which
+        # arming path fired the swipe. A tilt TAP instead reuses the existing
+        # hscroll_left/hscroll_right mapping above, no routing needed here.
+        active_owners = owners | tilt_owners
+        if active_owners:
+            owner_bindings = {
+                owner: gesture_bindings_for(self.cfg, owner) for owner in active_owners
+            }
             for direction in GESTURE_DIRECTIONS:
                 self.hook.register(
                     f"gesture_swipe_{direction}",

--- a/core/engine.py
+++ b/core/engine.py
@@ -13,7 +13,9 @@ from core.key_simulator import (
 )
 from core.config import (
     load_config, get_active_mappings, get_profile_for_app,
-    BUTTON_TO_EVENTS, GESTURE_DIRECTION_BUTTONS, save_config,
+    BUTTON_TO_EVENTS, GESTURE_DIRECTION_BUTTONS, GESTURE_DIRECTIONS,
+    GESTURE_HOLD_FLOOR_MS_DEFAULT, gesture_owners, gesture_bindings_for,
+    save_config,
 )
 from core.app_detector import AppDetector
 from core.mouse_hook_types import HidRuntimeState
@@ -95,6 +97,27 @@ class Engine:
     # ------------------------------------------------------------------
     # Hook wiring
     # ------------------------------------------------------------------
+    def _active_gesture_owners(self, cfg, settings):
+        """Owners actually armed at the hook (finding #1): config-bound AND
+        the UI enable toggle (settings.gesture_owner_enabled) is on AND the
+        connected device can host a per-button gesture on that owner --
+        mirrors the capability check in ui.backend.gestureEligibleOwners.
+        Direction bindings themselves are left untouched in config; this only
+        narrows what gets passed to the hook as armed. No device connected
+        means arming is moot, so nothing is eligible."""
+        bound = gesture_owners(cfg)
+        if not bound:
+            return set()
+        device = getattr(self, "connected_device", None)
+        device_buttons = getattr(device, "supported_buttons", None) if device else None
+        if device_buttons is None:
+            return set()
+        enabled_flags = settings.get("gesture_owner_enabled", {})
+        return {
+            owner for owner in bound
+            if enabled_flags.get(owner, False) and f"gesture_{owner}_left" in device_buttons
+        }
+
     def _setup_hooks(self):
         """Register callbacks and block events for all mapped buttons."""
         mappings = get_active_mappings(self.cfg)
@@ -106,13 +129,16 @@ class Engine:
         if hasattr(self.hook, "ignore_trackpad"):
             self.hook.ignore_trackpad = settings.get("ignore_trackpad", True)
         self.hook.debug_mode = self._debug_events_enabled
+        owners = self._active_gesture_owners(self.cfg, settings)
         self.hook.configure_gestures(
-            enabled=any(mappings.get(key, "none") != "none"
-                        for key in GESTURE_DIRECTION_BUTTONS),
+            enabled=bool(owners) or any(mappings.get(key, "none") != "none"
+                                        for key in GESTURE_DIRECTION_BUTTONS),
             threshold=settings.get("gesture_threshold", 50),
             deadzone=settings.get("gesture_deadzone", 40),
             timeout_ms=settings.get("gesture_timeout_ms", 3000),
             cooldown_ms=settings.get("gesture_cooldown_ms", 500),
+            owners=owners,
+            hold_floor_ms=settings.get("gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT),
         )
         # Divert mode shift CID only when the device has the button and
         # at least one profile maps it to an action.  When no device is
@@ -166,36 +192,76 @@ class Engine:
                         else:
                             # Single-fire event (gesture, swipe) → full click
                             self.hook.register(evt_type, self._make_handler(action_id))
+                    elif btn_key in GESTURE_DIRECTION_BUTTONS:
+                        self.hook.register(evt_type, self._make_hid_gesture_handler(action_id))
                     else:
                         self.hook.register(evt_type, self._make_handler(action_id))
 
+        # Per-owner event-tap gestures (issue 004): the kernel tags the fired
+        # gesture with the active owner in raw_data rather than a namespaced
+        # event, so route (owner, direction) -> gesture_<owner>_<dir> here.
+        if owners:
+            owner_bindings = {owner: gesture_bindings_for(self.cfg, owner) for owner in owners}
+            for direction in GESTURE_DIRECTIONS:
+                self.hook.register(
+                    f"gesture_swipe_{direction}",
+                    self._make_owner_gesture_handler(owner_bindings, direction),
+                )
+
     def _make_handler(self, action_id):
         def handler(event):
-            try:
-                if self._enabled:
-                    self._emit_debug(
-                        f"Mapped {event.event_type} -> {action_id} "
-                        f"({self._action_label(action_id)})"
-                    )
-                    if event.event_type.startswith("gesture_"):
-                        self._emit_gesture_event({
-                            "type": "mapped",
-                            "event_name": event.event_type,
-                            "action_id": action_id,
-                            "action_label": self._action_label(action_id),
-                        })
-                    if action_id == "toggle_smart_shift":
-                        self._toggle_smart_shift()
-                    elif action_id == "switch_scroll_mode":
-                        self._switch_scroll_mode()
-                    elif action_id == "cycle_dpi":
-                        self._cycle_dpi()
-                    else:
-                        execute_action(action_id)
-            except Exception as exc:
-                print(f"[Engine] _make_handler EXCEPTION for {action_id}: {exc}")
-                import traceback; traceback.print_exc()
+            self._run_action(action_id, event)
         return handler
+
+    def _make_hid_gesture_handler(self, action_id):
+        """Like _make_handler, but yields to per-owner routing: a gesture_swipe_*
+        event tagged with a gesture_owner came from an event-tap owner gesture,
+        not the HID dedicated gesture button this handler is bound to."""
+        def handler(event):
+            raw = event.raw_data
+            if isinstance(raw, dict) and raw.get("gesture_owner") is not None:
+                return
+            self._run_action(action_id, event)
+        return handler
+
+    def _make_owner_gesture_handler(self, owner_bindings, direction):
+        field = f"swipe_{direction}"
+        def handler(event):
+            raw = event.raw_data
+            owner = raw.get("gesture_owner") if isinstance(raw, dict) else None
+            if owner is None:
+                return
+            action_id = owner_bindings.get(owner, {}).get(field, "none")
+            if action_id == "none":
+                return
+            self._run_action(action_id, event)
+        return handler
+
+    def _run_action(self, action_id, event):
+        try:
+            if self._enabled:
+                self._emit_debug(
+                    f"Mapped {event.event_type} -> {action_id} "
+                    f"({self._action_label(action_id)})"
+                )
+                if event.event_type.startswith("gesture_"):
+                    self._emit_gesture_event({
+                        "type": "mapped",
+                        "event_name": event.event_type,
+                        "action_id": action_id,
+                        "action_label": self._action_label(action_id),
+                    })
+                if action_id == "toggle_smart_shift":
+                    self._toggle_smart_shift()
+                elif action_id == "switch_scroll_mode":
+                    self._switch_scroll_mode()
+                elif action_id == "cycle_dpi":
+                    self._cycle_dpi()
+                else:
+                    execute_action(action_id)
+        except Exception as exc:
+            print(f"[Engine] _run_action EXCEPTION for {action_id}: {exc}")
+            import traceback; traceback.print_exc()
 
     def _make_mouse_down_handler(self, action_id):
         def _safety_release():
@@ -634,6 +700,15 @@ class Engine:
             self._battery_poll_thread.start()
         if hid_features_ready and hid_features_changed:
             self._request_saved_settings_replay()
+            # Device capabilities (supported_buttons) are only known once HID
+            # features are ready; the initial _setup_hooks ran with no device
+            # connected, so device-gated features (per-button gesture arming)
+            # computed empty. Re-wire now that the button set is known -- reset
+            # first (mirrors _switch_profile/reload_mappings) so handlers don't
+            # stack on reconnect.
+            with self._lock:
+                self.hook.reset_bindings()
+                self._setup_hooks()
 
     def _battery_poll_loop(self, stop_event):
         """Read battery and smart shift mode periodically until disconnected."""

--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -46,6 +46,16 @@ MX_ANYWHERE_2S_BUTTONS = (
     "gesture_middle_right",
     "gesture_middle_up",
     "gesture_middle_down",
+    # Tilt (horizontal-scroll) slide gestures — armed off the hscroll pulse
+    # stream, gated on supports_tilt_gestures (mirror of the event-tap flag).
+    "gesture_tilt_left_left",
+    "gesture_tilt_left_right",
+    "gesture_tilt_left_up",
+    "gesture_tilt_left_down",
+    "gesture_tilt_right_left",
+    "gesture_tilt_right_right",
+    "gesture_tilt_right_up",
+    "gesture_tilt_right_down",
 )
 
 # G502 family (G-series gaming mice). These run onboard profiles and do not
@@ -224,6 +234,8 @@ LOGI_DEVICE_SPECS = (
         # No hardware gesture button — gestures are event-tap-driven per
         # button (back/forward/middle), not the HID++ RawXY path.
         "supports_event_tap_gestures": True,
+        # Horizontal-scroll tilt slide gestures (tilt_left/tilt_right owners).
+        "supports_tilt_gestures": True,
     },
     # -- M650 Signature family ------------------------------------------------
     # Compact wireless mouse (middle, back, forward buttons). Connects via Logi

--- a/core/logi_device_catalog.py
+++ b/core/logi_device_catalog.py
@@ -27,6 +27,27 @@ MX_ANYWHERE_SMARTSHIFT_BUTTONS = (
     "mode_shift",
 )
 
+# MX Anywhere 2S has no dedicated HID++ gesture button, so its slide gestures
+# are event-tap-driven and per-button (issue #002) rather than the shared
+# gesture/gesture_left/etc keys above. Extends (not replaces) the family
+# tuple: the legacy global gesture_* keys stay listed but remain inert at
+# runtime (narrowed away — no divertable HID gesture control on this mouse).
+MX_ANYWHERE_2S_BUTTONS = (
+    *MX_ANYWHERE_BUTTONS,
+    "gesture_back_left",
+    "gesture_back_right",
+    "gesture_back_up",
+    "gesture_back_down",
+    "gesture_forward_left",
+    "gesture_forward_right",
+    "gesture_forward_up",
+    "gesture_forward_down",
+    "gesture_middle_left",
+    "gesture_middle_right",
+    "gesture_middle_up",
+    "gesture_middle_down",
+)
+
 # G502 family (G-series gaming mice). These run onboard profiles and do not
 # expose REPROG_CONTROLS_V4 (0x1B04), so HID++ button diversion -- gesture,
 # mode_shift, dpi_switch -- is unavailable. The buttons below are the ones the
@@ -198,8 +219,11 @@ LOGI_DEVICE_SPECS = (
         ),
         "ui_layout": "mx_anywhere_2s",
         "image_asset": "logitech-mice/mx_anywhere_2s/mouse.png",
-        "supported_buttons": MX_ANYWHERE_BUTTONS,
+        "supported_buttons": MX_ANYWHERE_2S_BUTTONS,
         "dpi_max": 4000,
+        # No hardware gesture button — gestures are event-tap-driven per
+        # button (back/forward/middle), not the HID++ RawXY path.
+        "supports_event_tap_gestures": True,
     },
     # -- M650 Signature family ------------------------------------------------
     # Compact wireless mouse (middle, back, forward buttons). Connects via Logi

--- a/core/logi_devices.py
+++ b/core/logi_devices.py
@@ -84,6 +84,13 @@ _PER_BUTTON_GESTURE_DIRECTION_KEYS = tuple(
     for owner in ("back", "forward", "middle")
     for direction in ("left", "right", "up", "down")
 )
+# Tilt slide-gesture keys (hscroll pulse stream, tilt_left/tilt_right owners).
+# Gated on supports_tilt_gestures, a sibling of supports_event_tap_gestures.
+_TILT_GESTURE_DIRECTION_KEYS = tuple(
+    f"gesture_{owner}_{direction}"
+    for owner in ("tilt_left", "tilt_right")
+    for direction in ("left", "right", "up", "down")
+)
 _CID_GATED_BUTTONS = {
     "mode_shift": 0x00C4,
     "dpi_switch": 0x00FD,
@@ -129,6 +136,7 @@ class LogiDeviceSpec:
     dpi_min: int = DEFAULT_DPI_MIN
     dpi_max: int = DEFAULT_DPI_MAX
     supports_event_tap_gestures: bool = False
+    supports_tilt_gestures: bool = False
 
     def matches(self, product_id=None, product_name=None) -> bool:
         if product_id is not None and int(product_id) in self.product_ids:
@@ -297,6 +305,7 @@ class DeviceCapabilityInventory:
     gesture_click: bool = False
     gesture_directions: bool = False
     supports_event_tap_gestures: bool = False
+    supports_tilt_gestures: bool = False
     mode_shift: bool = False
     dpi_switch: bool = False
     hscroll_cids: tuple[int, ...] = ()
@@ -319,6 +328,9 @@ class DeviceCapabilityInventory:
 
         if not self.supports_event_tap_gestures:
             allowed.difference_update(_PER_BUTTON_GESTURE_DIRECTION_KEYS)
+
+        if not self.supports_tilt_gestures:
+            allowed.difference_update(_TILT_GESTURE_DIRECTION_KEYS)
 
         if not self.mode_shift:
             allowed.discard("mode_shift")
@@ -353,6 +365,7 @@ class DeviceCapabilityInventory:
             "gesture_click": self.gesture_click,
             "gesture_directions": self.gesture_directions,
             "supports_event_tap_gestures": self.supports_event_tap_gestures,
+            "supports_tilt_gestures": self.supports_tilt_gestures,
             "mode_shift": self.mode_shift,
             "dpi_switch": self.dpi_switch,
             "hscroll": bool(self.hscroll_cids),
@@ -687,6 +700,7 @@ def build_device_capability_inventory(
     discovered_features=None,
     diagnostics=None,
     supports_event_tap_gestures=False,
+    supports_tilt_gestures=False,
 ) -> DeviceCapabilityInventory:
     controls_by_cid = _control_by_cid(controls or ())
     feature_entries = _feature_entries(discovered_features)
@@ -735,6 +749,7 @@ def build_device_capability_inventory(
         gesture_click=gesture_click,
         gesture_directions=gesture_directions,
         supports_event_tap_gestures=bool(supports_event_tap_gestures),
+        supports_tilt_gestures=bool(supports_tilt_gestures),
         mode_shift=bool(
             mode_shift_control and _control_is_divertable(mode_shift_control)
         ),
@@ -762,6 +777,7 @@ def derive_supported_buttons_from_reprog_controls(
     active_gesture_cid=None,
     gesture_rawxy_enabled=None,
     supports_event_tap_gestures=False,
+    supports_tilt_gestures=False,
 ) -> tuple[str, ...]:
     """Narrow HID++-gated buttons using discovered REPROG_V4 controls.
 
@@ -774,6 +790,7 @@ def derive_supported_buttons_from_reprog_controls(
         active_gesture_cid=active_gesture_cid,
         gesture_rawxy_enabled=gesture_rawxy_enabled,
         supports_event_tap_gestures=supports_event_tap_gestures,
+        supports_tilt_gestures=supports_tilt_gestures,
     )
     return inventory.supported_buttons(static_buttons)
 
@@ -830,6 +847,7 @@ def build_connected_device_info(
         discovered_features=discovered_features,
         diagnostics=diagnostics,
         supports_event_tap_gestures=getattr(spec, "supports_event_tap_gestures", False),
+        supports_tilt_gestures=getattr(spec, "supports_tilt_gestures", False),
     )
     if spec:
         resolved_gesture_cids = tuple(gesture_cids or spec.gesture_cids)

--- a/core/logi_devices.py
+++ b/core/logi_devices.py
@@ -75,6 +75,15 @@ _GESTURE_BUTTON_KEYS = (
     "gesture_up",
     "gesture_down",
 )
+# Per-button slide-gesture keys (event-tap path, issue #001/#002). Distinct
+# from the HID++ thumb-gesture keys above: gated on supports_event_tap_gestures
+# rather than a divertable RawXY control, so a mouse with no gesture button
+# (e.g. the MX Anywhere 2S) can still advertise them.
+_PER_BUTTON_GESTURE_DIRECTION_KEYS = tuple(
+    f"gesture_{owner}_{direction}"
+    for owner in ("back", "forward", "middle")
+    for direction in ("left", "right", "up", "down")
+)
 _CID_GATED_BUTTONS = {
     "mode_shift": 0x00C4,
     "dpi_switch": 0x00FD,
@@ -119,6 +128,7 @@ class LogiDeviceSpec:
     supported_buttons: tuple[str, ...] = DEFAULT_BUTTON_LAYOUT
     dpi_min: int = DEFAULT_DPI_MIN
     dpi_max: int = DEFAULT_DPI_MAX
+    supports_event_tap_gestures: bool = False
 
     def matches(self, product_id=None, product_name=None) -> bool:
         if product_id is not None and int(product_id) in self.product_ids:
@@ -286,6 +296,7 @@ class DeviceCapabilityInventory:
     divertable_gesture_cids: tuple[int, ...] = ()
     gesture_click: bool = False
     gesture_directions: bool = False
+    supports_event_tap_gestures: bool = False
     mode_shift: bool = False
     dpi_switch: bool = False
     hscroll_cids: tuple[int, ...] = ()
@@ -305,6 +316,9 @@ class DeviceCapabilityInventory:
             allowed.difference_update(
                 ("gesture_left", "gesture_right", "gesture_up", "gesture_down")
             )
+
+        if not self.supports_event_tap_gestures:
+            allowed.difference_update(_PER_BUTTON_GESTURE_DIRECTION_KEYS)
 
         if not self.mode_shift:
             allowed.discard("mode_shift")
@@ -338,6 +352,7 @@ class DeviceCapabilityInventory:
             ],
             "gesture_click": self.gesture_click,
             "gesture_directions": self.gesture_directions,
+            "supports_event_tap_gestures": self.supports_event_tap_gestures,
             "mode_shift": self.mode_shift,
             "dpi_switch": self.dpi_switch,
             "hscroll": bool(self.hscroll_cids),
@@ -671,6 +686,7 @@ def build_device_capability_inventory(
     gesture_rawxy_enabled=None,
     discovered_features=None,
     diagnostics=None,
+    supports_event_tap_gestures=False,
 ) -> DeviceCapabilityInventory:
     controls_by_cid = _control_by_cid(controls or ())
     feature_entries = _feature_entries(discovered_features)
@@ -718,6 +734,7 @@ def build_device_capability_inventory(
         divertable_gesture_cids=divertable_gesture_cids,
         gesture_click=gesture_click,
         gesture_directions=gesture_directions,
+        supports_event_tap_gestures=bool(supports_event_tap_gestures),
         mode_shift=bool(
             mode_shift_control and _control_is_divertable(mode_shift_control)
         ),
@@ -744,6 +761,7 @@ def derive_supported_buttons_from_reprog_controls(
     gesture_cids=None,
     active_gesture_cid=None,
     gesture_rawxy_enabled=None,
+    supports_event_tap_gestures=False,
 ) -> tuple[str, ...]:
     """Narrow HID++-gated buttons using discovered REPROG_V4 controls.
 
@@ -755,6 +773,7 @@ def derive_supported_buttons_from_reprog_controls(
         gesture_cids=gesture_cids,
         active_gesture_cid=active_gesture_cid,
         gesture_rawxy_enabled=gesture_rawxy_enabled,
+        supports_event_tap_gestures=supports_event_tap_gestures,
     )
     return inventory.supported_buttons(static_buttons)
 
@@ -810,6 +829,7 @@ def build_connected_device_info(
         gesture_rawxy_enabled=gesture_rawxy_enabled,
         discovered_features=discovered_features,
         diagnostics=diagnostics,
+        supports_event_tap_gestures=getattr(spec, "supports_event_tap_gestures", False),
     )
     if spec:
         resolved_gesture_cids = tuple(gesture_cids or spec.gesture_cids)

--- a/core/mouse_hook_base.py
+++ b/core/mouse_hook_base.py
@@ -97,6 +97,8 @@ class BaseMouseHook:
         self._gesture_input_source = None
         self._gesture_owners = set()
         self._gesture_hold_floor_ms = _GESTURE_HOLD_FLOOR_MS_DEFAULT
+        self._tilt_gesture_owners = set()
+        self._tilt_release_ms = 150
         self._connected_device = None
         self._dispatch_queue = None
 
@@ -148,6 +150,8 @@ class BaseMouseHook:
         cooldown_ms=500,
         owners=None,
         hold_floor_ms=None,
+        tilt_owners=None,
+        tilt_release_ms=None,
     ):
         self._gesture_direction_enabled = bool(enabled)
         self._gesture_threshold = float(max(5, threshold))
@@ -157,6 +161,11 @@ class BaseMouseHook:
         # Per-button event-tap gesture owners are independent of the HID
         # direction feature above; issue 004 supplies both from config.
         self._gesture_owners = set(owners) if owners else set()
+        # Tilt (horizontal-scroll) gesture owners ("tilt_left"/"tilt_right"),
+        # armed off the hscroll pulse stream (macOS hook) rather than a button.
+        self._tilt_gesture_owners = set(tilt_owners) if tilt_owners else set()
+        if tilt_release_ms is not None:
+            self._tilt_release_ms = max(50, int(tilt_release_ms))
         if hold_floor_ms is not None:
             self._gesture_hold_floor_ms = max(0, int(hold_floor_ms))
         if not self._gesture_direction_enabled:

--- a/core/mouse_hook_base.py
+++ b/core/mouse_hook_base.py
@@ -12,6 +12,59 @@ except Exception:
 
 from core.mouse_hook_types import HidRuntimeState, MouseEvent, format_debug_details
 
+# Default hold floor (ms) below which an owner-button press is a click, not a
+# gesture (D4). Mirrors core.config GESTURE_HOLD_FLOOR_MS_DEFAULT.
+_GESTURE_HOLD_FLOOR_MS_DEFAULT = 80
+
+# Release-decision outcomes for an event-tap gesture-owner button.
+CLICK = "click"
+GESTURE = "gesture"
+
+
+def _gesture_direction(dx, dy, threshold, deadzone):
+    """Cardinal swipe direction for accumulated deltas, or None if none.
+
+    Pure mirror of BaseMouseHook._detect_gesture_event so the event-tap
+    on-release decision matches the live HID detector exactly.
+    """
+    abs_x = abs(dx)
+    abs_y = abs(dy)
+    dominant = max(abs_x, abs_y)
+    if dominant < threshold:
+        return None
+    cross_limit = max(deadzone, dominant * 0.35)
+    if abs_x > abs_y:
+        if abs_y > cross_limit:
+            return None
+        return MouseEvent.GESTURE_SWIPE_RIGHT if dx > 0 else MouseEvent.GESTURE_SWIPE_LEFT
+    if abs_x > cross_limit:
+        return None
+    return MouseEvent.GESTURE_SWIPE_DOWN if dy > 0 else MouseEvent.GESTURE_SWIPE_UP
+
+
+def decide_gesture(held_ms, dx, dy, hold_floor_ms, threshold, deadzone):
+    """Classify a gesture-owner button release as a click or a directional gesture.
+
+    Returns (CLICK, None) or (GESTURE, MouseEvent.GESTURE_SWIPE_*). Objc-free so
+    the CGEventTap handler and unit tests share one decision. A release is a
+    gesture only when held >= the floor AND the slide resolves to a direction;
+    everything else replays the button's normal click (dual-mode, D2/D4).
+    """
+    if held_ms < hold_floor_ms:
+        return CLICK, None
+    direction = _gesture_direction(dx, dy, threshold, deadzone)
+    if direction is None:
+        return CLICK, None
+    return GESTURE, direction
+
+
+def should_arm_gesture(gesture_active, btn_owner, owners):
+    """First-wins arming gate: arm an event-tap gesture only for an owner button
+    while no gesture (event-tap or HID) is already active; else pass it through."""
+    if btn_owner not in owners:
+        return False
+    return not gesture_active
+
 
 class BaseMouseHook:
     def __init__(self):
@@ -42,6 +95,8 @@ class BaseMouseHook:
         self._gesture_delta_y = 0.0
         self._gesture_cooldown_until = 0.0
         self._gesture_input_source = None
+        self._gesture_owners = set()
+        self._gesture_hold_floor_ms = _GESTURE_HOLD_FLOOR_MS_DEFAULT
         self._connected_device = None
         self._dispatch_queue = None
 
@@ -91,12 +146,19 @@ class BaseMouseHook:
         deadzone=40,
         timeout_ms=3000,
         cooldown_ms=500,
+        owners=None,
+        hold_floor_ms=None,
     ):
         self._gesture_direction_enabled = bool(enabled)
         self._gesture_threshold = float(max(5, threshold))
         self._gesture_deadzone = float(max(0, deadzone))
         self._gesture_timeout_ms = max(250, int(timeout_ms))
         self._gesture_cooldown_ms = max(0, int(cooldown_ms))
+        # Per-button event-tap gesture owners are independent of the HID
+        # direction feature above; issue 004 supplies both from config.
+        self._gesture_owners = set(owners) if owners else set()
+        if hold_floor_ms is not None:
+            self._gesture_hold_floor_ms = max(0, int(hold_floor_ms))
         if not self._gesture_direction_enabled:
             self._gesture_tracking = False
             self._gesture_triggered = False

--- a/core/mouse_hook_contract.py
+++ b/core/mouse_hook_contract.py
@@ -2,7 +2,7 @@
 Structural contract exposed by platform mouse hook implementations.
 """
 
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Any, Callable, Optional, Protocol, runtime_checkable
 
 from core.mouse_hook_types import HidRuntimeState
 
@@ -27,6 +27,8 @@ class MouseHookLike(Protocol):
         deadzone: int = 40,
         timeout_ms: int = 3000,
         cooldown_ms: int = 500,
+        owners: Optional[set] = None,
+        hold_floor_ms: Optional[int] = None,
     ) -> None: ...
     def set_connection_change_callback(self, cb: Callable[[bool], None]) -> None: ...
     def set_debug_callback(self, callback: Callable[[str], None]) -> None: ...

--- a/core/mouse_hook_macos.py
+++ b/core/mouse_hook_macos.py
@@ -80,6 +80,17 @@ class MouseHook(BaseMouseHook):
         self._gesture_owner = None
         self._gesture_owner_btn = None
         self._gesture_press_at = 0.0
+        # Tilt (horizontal-scroll) gesture: the tilt has no button down/up, so
+        # arm on the first hscroll pulse, stay armed while pulses stream, and
+        # release ~release_ms after the last pulse. Reuses the button-gesture
+        # fields above (one gesture active at a time). Owners come from config
+        # via configure_gestures (empty = feature off). The release timer fires
+        # on its own thread, so _tilt_lock guards arm-vs-finalize.
+        self._tilt_gesture_owners = set()
+        self._tilt_last_pulse_at = 0.0
+        self._tilt_release_timer = None
+        self._tilt_release_ms = 150
+        self._tilt_lock = threading.Lock()
 
     def _negate_scroll_axis(self, cg_event, axis):
         for field_name in (
@@ -262,12 +273,18 @@ class MouseHook(BaseMouseHook):
 
     def _reset_event_tap_gesture_state(self):
         """Clear all armed-owner-gesture state (scopes the D8 cursor freeze
-        and the should_arm_gesture gate shared with the HID path)."""
+        and the should_arm_gesture gate shared with the HID path). Also cancels
+        any pending tilt release timer so an abort/reconfigure can't leave it to
+        fire a stray event later (finding #4). Timer.cancel() is thread-safe."""
         self._gesture_active = False
         self._gesture_owner = None
         self._gesture_owner_btn = None
         self._gesture_press_at = 0.0
         self._gesture_triggered = False
+        timer = self._tilt_release_timer
+        if timer is not None:
+            timer.cancel()
+            self._tilt_release_timer = None
         self._finish_gesture_tracking()
 
     def _abort_event_tap_gesture(self, reason):
@@ -356,6 +373,69 @@ class MouseHook(BaseMouseHook):
         self._enqueue_dispatch_event(MouseEvent(down))
         self._enqueue_dispatch_event(MouseEvent(up))
 
+    # ---- Tilt (horizontal-scroll) gesture -----------------------------------
+    def _maybe_arm_tilt_gesture(self, h_delta):
+        """A tilt pulse arrived. Arm a gesture on the first pulse of an opt-in
+        tilt direction, keep it alive while pulses stream, and (re)schedule the
+        release. Returns True if the scroll should be swallowed (gesture owns the
+        tilt now). Reuses the button-gesture fields + move accumulation."""
+        owner = "tilt_right" if h_delta > 0 else "tilt_left"
+        if owner not in self._tilt_gesture_owners:
+            return False
+        with self._tilt_lock:
+            now = time.monotonic()
+            if not self._gesture_active:
+                self._gesture_active = True
+                self._gesture_owner = owner
+                self._gesture_owner_btn = None
+                self._gesture_triggered = False
+                self._gesture_press_at = now
+                self._start_gesture_tracking()
+            elif self._gesture_owner != owner:
+                return False  # another gesture already active -- don't hijack it
+            self._tilt_last_pulse_at = now
+            self._schedule_tilt_release()
+        return True
+
+    def _schedule_tilt_release(self):
+        if self._tilt_release_timer is not None:
+            self._tilt_release_timer.cancel()
+        self._tilt_release_timer = threading.Timer(
+            self._tilt_release_ms / 1000.0, self._on_tilt_release_timeout
+        )
+        self._tilt_release_timer.daemon = True
+        self._tilt_release_timer.start()
+
+    def _on_tilt_release_timeout(self):
+        # Fired ~release_ms after a pulse; bail if a newer pulse arrived (a newer
+        # timer is pending) or the gesture was already finalized/aborted.
+        with self._tilt_lock:
+            # Guard on the tilt-owner NAMES, not the (possibly-since-cleared)
+            # enabled set: a reconfigure that drops the owner mid-tilt must still
+            # finalize+reset here, else _gesture_active stays stuck and the cursor
+            # freezes until the move-timeout abort (finding #4).
+            if not self._gesture_active or self._gesture_owner not in ("tilt_left", "tilt_right"):
+                return
+            if (time.monotonic() - self._tilt_last_pulse_at) < (self._tilt_release_ms / 1000.0 - 0.01):
+                return
+            self._finish_tilt_gesture()
+
+    def _finish_tilt_gesture(self):
+        """Resolve a released tilt gesture (called holding _tilt_lock): fire the
+        bound direction on a slide, or the tilt's normal hscroll action on a tap
+        (dual-mode; the tap fires once = the debounce)."""
+        owner = self._gesture_owner
+        # A slide already fired the gesture mid-hold (fire-on-slide-cross); the
+        # release only resolves the remaining case: no slide crossed -> a TAP,
+        # which fires the tilt's normal horizontal-scroll action once (debounce).
+        if not self._gesture_triggered:
+            hs = MouseEvent.HSCROLL_LEFT if owner == "tilt_left" else MouseEvent.HSCROLL_RIGHT
+            self._enqueue_dispatch_event(MouseEvent(hs, 1.0))
+        if self._tilt_release_timer is not None:
+            self._tilt_release_timer.cancel()
+            self._tilt_release_timer = None
+        self._reset_event_tap_gesture_state()
+
     def _dispatch_worker(self):
         while self._running:
             try:
@@ -425,6 +505,31 @@ class MouseHook(BaseMouseHook):
                     self._gesture_delta_y += Quartz.CGEventGetIntegerValueField(
                         cg_event, Quartz.kCGMouseEventDeltaY
                     )
+                    # Tilt gestures fire the INSTANT the slide crosses threshold
+                    # (mid-hold), not on release: the tilt's pulse stream can
+                    # fragment (gentle holds pulse slowly), so decide-on-release
+                    # would drop them. The release timer then only fires taps.
+                    # Under _tilt_lock: the release timer (other thread) also
+                    # reads/writes _gesture_triggered in _finish_tilt_gesture, so
+                    # the check-and-set here must not race it (else tap+gesture
+                    # both fire for one engagement).
+                    if self._gesture_owner in ("tilt_left", "tilt_right"):
+                        with self._tilt_lock:
+                            if not self._gesture_triggered:
+                                decision, direction = decide_gesture(
+                                    (time.monotonic() - self._gesture_press_at) * 1000.0,
+                                    self._gesture_delta_x, self._gesture_delta_y,
+                                    self._gesture_hold_floor_ms, self._gesture_threshold,
+                                    self._gesture_deadzone,
+                                )
+                                if decision == GESTURE:
+                                    self._gesture_triggered = True
+                                    self._enqueue_dispatch_event(MouseEvent(direction, {
+                                        "delta_x": self._gesture_delta_x,
+                                        "delta_y": self._gesture_delta_y,
+                                        "source": "tilt",
+                                        "gesture_owner": self._gesture_owner,
+                                    }))
                     return None
 
             if (
@@ -537,6 +642,8 @@ class MouseHook(BaseMouseHook):
                     cg_event, Quartz.kCGScrollWheelEventFixedPtDeltaAxis2
                 )
                 h_delta = h_delta / 65536.0
+                if h_delta != 0 and self._maybe_arm_tilt_gesture(h_delta):
+                    return None  # tilt gesture armed/held -- swallow the scroll
                 if self.debug_mode and self._debug_callback:
                     try:
                         v_delta = (

--- a/core/mouse_hook_macos.py
+++ b/core/mouse_hook_macos.py
@@ -8,7 +8,14 @@ import sys
 import threading
 import time
 
-from core.mouse_hook_base import BaseMouseHook, HidGestureListener
+from core.mouse_hook_base import (
+    CLICK,
+    GESTURE,
+    BaseMouseHook,
+    HidGestureListener,
+    decide_gesture,
+    should_arm_gesture,
+)
 from core.mouse_hook_types import MouseEvent
 
 try:
@@ -42,6 +49,8 @@ def _autoreleased(fn):
 _BTN_MIDDLE = 2
 _BTN_BACK = 3
 _BTN_FORWARD = 4
+# CGEvent button number -> per-button gesture owner name (core.config GESTURE_OWNERS).
+_BTN_TO_OWNER = {_BTN_BACK: "back", _BTN_FORWARD: "forward", _BTN_MIDDLE: "middle"}
 _SCROLL_INVERT_MARKER = 0x4D4F5553
 _INJECTED_EVENT_MARKER = 0x4D4F5554
 _kCGEventTapDisabledByTimeout = 0xFFFFFFFE
@@ -66,6 +75,11 @@ class MouseHook(BaseMouseHook):
         self._init_dispatch_queue(maxsize=512)
         self._dispatch_thread = None
         self._first_event_logged = False
+        # Active event-tap gesture (None = none). Set on an owner-button down,
+        # cleared on its up; scopes the deferred click + cursor freeze.
+        self._gesture_owner = None
+        self._gesture_owner_btn = None
+        self._gesture_press_at = 0.0
 
     def _negate_scroll_axis(self, cg_event, axis):
         for field_name in (
@@ -246,6 +260,102 @@ class MouseHook(BaseMouseHook):
             self._finish_gesture_tracking()
             return
 
+    def _reset_event_tap_gesture_state(self):
+        """Clear all armed-owner-gesture state (scopes the D8 cursor freeze
+        and the should_arm_gesture gate shared with the HID path)."""
+        self._gesture_active = False
+        self._gesture_owner = None
+        self._gesture_owner_btn = None
+        self._gesture_press_at = 0.0
+        self._gesture_triggered = False
+        self._finish_gesture_tracking()
+
+    def _abort_event_tap_gesture(self, reason):
+        """Give up an armed owner-button gesture without firing an event or
+        replaying a click. Used when the release is missed -- the move-swallow
+        timeout, a tap re-enable after CGEventTap was disabled by the system,
+        or stop() -- so the cursor freeze and should_arm_gesture never stick
+        forever (finding #2)."""
+        if self._gesture_owner is None:
+            return
+        owner = self._gesture_owner
+        self._emit_debug(f"Event-tap gesture aborted owner={owner} reason={reason}")
+        self._emit_gesture_event(
+            {"type": "aborted", "source": "event_tap", "owner": owner, "reason": reason}
+        )
+        self._reset_event_tap_gesture_state()
+
+    def _finish_event_tap_gesture(self, btn):
+        """Resolve an armed owner-button release: fire the tagged gesture event,
+        or replay the deferred normal click (dual-mode, D2/D4)."""
+        owner = self._gesture_owner
+        held_ms = (time.monotonic() - self._gesture_press_at) * 1000.0
+        decision, direction = decide_gesture(
+            held_ms,
+            self._gesture_delta_x,
+            self._gesture_delta_y,
+            self._gesture_hold_floor_ms,
+            self._gesture_threshold,
+            self._gesture_deadzone,
+        )
+        if decision == GESTURE:
+            self._gesture_triggered = True
+            # Tag the generic direction event with the active owner; issue 004
+            # routes (owner + direction) -> the namespaced gesture_<owner>_swipe_<dir>.
+            self._enqueue_dispatch_event(
+                MouseEvent(
+                    direction,
+                    {
+                        "delta_x": self._gesture_delta_x,
+                        "delta_y": self._gesture_delta_y,
+                        "source": "event_tap",
+                        "gesture_owner": owner,
+                    },
+                )
+            )
+            self._emit_debug(
+                f"Event-tap gesture fired owner={owner} dir={direction} "
+                f"held_ms={held_ms:.0f}"
+            )
+            self._emit_gesture_event(
+                {
+                    "type": "detected",
+                    "event_name": direction,
+                    "source": "event_tap",
+                    "owner": owner,
+                }
+            )
+        else:
+            self._emit_debug(f"Event-tap tap->click owner={owner} held_ms={held_ms:.0f}")
+            self._emit_gesture_event(
+                {"type": "button_up", "source": "event_tap", "owner": owner,
+                 "click_candidate": True}
+            )
+            # A tap fires the button's normal Mouser mapping (dispatch its
+            # DOWN+UP so the engine runs the mapped action), NOT a native
+            # replay -- macOS ignores raw button 4/3, so a native replay is a
+            # dead click. Falls through to nothing if the button is unmapped.
+            self._dispatch_owner_button_click(btn)
+
+        self._reset_event_tap_gesture_state()
+
+    # gesture-owner button number -> its normal (down, up) MouseEvent pair.
+    _OWNER_CLICK_EVENTS = {
+        _BTN_MIDDLE: (MouseEvent.MIDDLE_DOWN, MouseEvent.MIDDLE_UP),
+        _BTN_BACK: (MouseEvent.XBUTTON1_DOWN, MouseEvent.XBUTTON1_UP),
+        _BTN_FORWARD: (MouseEvent.XBUTTON2_DOWN, MouseEvent.XBUTTON2_UP),
+    }
+
+    def _dispatch_owner_button_click(self, btn):
+        """Tap of a gesture-owner button: dispatch its normal DOWN+UP events so
+        the engine fires the button's mapped action (dual-mode, option 1)."""
+        pair = self._OWNER_CLICK_EVENTS.get(btn)
+        if pair is None:
+            return
+        down, up = pair
+        self._enqueue_dispatch_event(MouseEvent(down))
+        self._enqueue_dispatch_event(MouseEvent(up))
+
     def _dispatch_worker(self):
         while self._running:
             try:
@@ -266,6 +376,10 @@ class MouseHook(BaseMouseHook):
                     f"(type=0x{event_type:X}), re-enabling",
                     flush=True,
                 )
+                # A pending owner-gesture release may have been dropped while
+                # the tap was disabled -- abort it rather than leave the
+                # cursor frozen (finding #2).
+                self._abort_event_tap_gesture("tap_disabled")
                 Quartz.CGEventTapEnable(self._tap, True)
                 return cg_event
 
@@ -286,12 +400,35 @@ class MouseHook(BaseMouseHook):
             mouse_event = None
             should_block = False
 
+            is_move = event_type in (
+                Quartz.kCGEventMouseMoved,
+                Quartz.kCGEventOtherMouseDragged,
+            )
+            if is_move and self._gesture_active and self._gesture_owner is not None:
+                # A missed button-up (tap disabled under load, device drops
+                # mid-hold) must not freeze the cursor forever (finding #2):
+                # abort and let this move through once the hold outlives the
+                # configured gesture timeout.
+                if (
+                    time.monotonic() - self._gesture_press_at
+                    > self._gesture_timeout_ms / 1000.0
+                ):
+                    self._abort_event_tap_gesture("timeout")
+                    # fall through -- do not swallow this move
+                else:
+                    # Event-tap owner gesture: accumulate for the on-release
+                    # decision and freeze the cursor (D8) by swallowing the
+                    # motion so no net pointer delta reaches the OS.
+                    self._gesture_delta_x += Quartz.CGEventGetIntegerValueField(
+                        cg_event, Quartz.kCGMouseEventDeltaX
+                    )
+                    self._gesture_delta_y += Quartz.CGEventGetIntegerValueField(
+                        cg_event, Quartz.kCGMouseEventDeltaY
+                    )
+                    return None
+
             if (
-                event_type
-                in (
-                    Quartz.kCGEventMouseMoved,
-                    Quartz.kCGEventOtherMouseDragged,
-                )
+                is_move
                 and self._gesture_direction_enabled
                 and self._gesture_active
             ):
@@ -335,6 +472,23 @@ class MouseHook(BaseMouseHook):
                         self._debug_callback(f"OtherMouseDown btn={btn}")
                     except Exception:
                         pass
+                owner = _BTN_TO_OWNER.get(btn)
+                if owner and should_arm_gesture(
+                    self._gesture_active, owner, self._gesture_owners
+                ):
+                    # Arm the gesture and DEFER this button's normal down; the
+                    # click is replayed on release iff it turns out to be a tap.
+                    self._gesture_active = True
+                    self._gesture_owner = owner
+                    self._gesture_owner_btn = btn
+                    self._gesture_triggered = False
+                    self._gesture_press_at = time.monotonic()
+                    self._start_gesture_tracking()
+                    self._emit_debug(f"Event-tap gesture armed owner={owner} btn={btn}")
+                    self._emit_gesture_event(
+                        {"type": "button_down", "source": "event_tap", "owner": owner}
+                    )
+                    return None
                 if btn == _BTN_MIDDLE:
                     mouse_event = MouseEvent(MouseEvent.MIDDLE_DOWN)
                     should_block = MouseEvent.MIDDLE_DOWN in self._blocked_events
@@ -354,6 +508,9 @@ class MouseHook(BaseMouseHook):
                         self._debug_callback(f"OtherMouseUp btn={btn}")
                     except Exception:
                         pass
+                if self._gesture_owner is not None and btn == self._gesture_owner_btn:
+                    self._finish_event_tap_gesture(btn)
+                    return None
                 if btn == _BTN_MIDDLE:
                     mouse_event = MouseEvent(MouseEvent.MIDDLE_UP)
                     should_block = MouseEvent.MIDDLE_UP in self._blocked_events
@@ -604,6 +761,7 @@ class MouseHook(BaseMouseHook):
     def stop(self):
         self._unregister_wake_observer()
         self._running = False
+        self._abort_event_tap_gesture("stop")
         self._stop_hid_listener()
         self._connected_device = None
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1413,6 +1413,195 @@ class BackendPerButtonGestureTests(unittest.TestCase):
 
 
 @unittest.skipIf(Backend is None, "PySide6 not installed in test environment")
+class BackendTiltGestureTests(unittest.TestCase):
+    """Tilt (horizontal-scroll) slide gesture toggle + namespaced binding get/set
+    -- mirrors BackendPerButtonGestureTests, but for the tilt_left/tilt_right
+    owners hosted on the hscroll pulse stream instead of a per-button event tap."""
+
+    def _make_backend(self, engine=None, cfg=None):
+        loaded_config = copy.deepcopy(cfg or DEFAULT_CONFIG)
+        with (
+            patch("ui.backend.load_config", return_value=loaded_config),
+            patch("ui.backend.save_config"),
+            patch("ui.backend.supports_login_startup", return_value=False),
+        ):
+            return Backend(engine=engine)
+
+    def _mx_anywhere_2s_tilt(self):
+        return SimpleNamespace(
+            key="mx_anywhere_2s",
+            display_name="MX Anywhere 2S",
+            dpi_min=200,
+            dpi_max=4000,
+            ui_layout="mx_anywhere_2s",
+            supported_buttons=(
+                "middle", "xbutton1", "xbutton2", "hscroll_left", "hscroll_right",
+                "gesture_tilt_left_left", "gesture_tilt_left_right",
+                "gesture_tilt_left_up", "gesture_tilt_left_down",
+            ),
+        )
+
+    def test_tilt_gesture_mode_off_by_default(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.tiltGestureEnabledOwners, [])
+        bindings = backend.tiltGestureOwnerBindings("default", "tilt_left")
+        self.assertTrue(all(entry["actionId"] == "none" for entry in bindings))
+
+    def test_set_tilt_gesture_owner_enabled_persists_and_notifies(self):
+        backend = self._make_backend()
+        settings_changed = []
+        backend.settingsChanged.connect(lambda: settings_changed.append(True))
+
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setTiltGestureOwnerEnabled("tilt_left", True)
+
+        save_mock.assert_called_once()
+        self.assertEqual(backend.tiltGestureEnabledOwners, ["tilt_left"])
+        self.assertEqual(len(settings_changed), 1)
+
+    def test_set_tilt_gesture_owner_enabled_noop_when_unchanged(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setTiltGestureOwnerEnabled("tilt_left", True)
+
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setTiltGestureOwnerEnabled("tilt_left", True)
+
+        save_mock.assert_not_called()
+
+    def test_set_tilt_gesture_owner_enabled_rejects_unknown_owner(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config") as save_mock:
+            # "back" is a per-button owner, not a tilt owner.
+            backend.setTiltGestureOwnerEnabled("back", True)
+        save_mock.assert_not_called()
+        self.assertEqual(backend.tiltGestureEnabledOwners, [])
+
+    def test_set_tilt_gesture_owner_enabled_reruns_engine_mapping_reload(self):
+        engine = _FakeEngine()
+        backend = self._make_backend(engine=engine)
+        with patch("ui.backend.save_config"):
+            backend.setTiltGestureOwnerEnabled("tilt_right", True)
+        self.assertEqual(engine.reload_mappings_count, 1)
+
+    def test_tilt_and_button_owner_enabled_flags_are_independent(self):
+        """tilt_left/tilt_right share the gesture_owner_enabled dict with
+        back/forward/middle (disjoint keys) -- toggling one must not leak
+        into the other's enabled-owner list."""
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setTiltGestureOwnerEnabled("tilt_left", True)
+            backend.setGestureOwnerEnabled("forward", True)
+
+        self.assertEqual(backend.tiltGestureEnabledOwners, ["tilt_left"])
+        self.assertEqual(backend.gestureEnabledOwners, ["forward"])
+
+    def test_toggle_off_does_not_clear_tilt_direction_bindings(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setTiltGestureOwnerEnabled("tilt_left", True)
+        with patch("core.config.save_config"):
+            backend.setTiltGestureOwnerBinding("default", "tilt_left", "up", "mission_control")
+        with patch("ui.backend.save_config"):
+            backend.setTiltGestureOwnerEnabled("tilt_left", False)
+
+        self.assertEqual(backend.tiltGestureEnabledOwners, [])
+        bindings = {
+            entry["direction"]: entry["actionId"]
+            for entry in backend.tiltGestureOwnerBindings("default", "tilt_left")
+        }
+        self.assertEqual(bindings["up"], "mission_control")
+
+    def test_toggle_off_does_not_touch_hscroll_tap_mapping(self):
+        backend = self._make_backend()
+
+        def hscroll_left_action():
+            mappings = backend.getProfileMappings("default")
+            return next(m["actionId"] for m in mappings if m["key"] == "hscroll_left")
+
+        original = hscroll_left_action()
+        self.assertEqual(original, "browser_back")  # DEFAULT_CONFIG value, sanity check
+
+        with patch("ui.backend.save_config"):
+            backend.setTiltGestureOwnerEnabled("tilt_left", True)
+        with patch("core.config.save_config"):
+            backend.setTiltGestureOwnerBinding("default", "tilt_left", "left", "mission_control")
+        with patch("ui.backend.save_config"):
+            backend.setTiltGestureOwnerEnabled("tilt_left", False)
+
+        self.assertEqual(hscroll_left_action(), original)
+
+    def test_set_and_get_tilt_gesture_owner_binding_round_trip(self):
+        backend = self._make_backend()
+        with patch("core.config.save_config"):
+            backend.setTiltGestureOwnerBinding("default", "tilt_right", "up", "mission_control")
+
+        bindings = {
+            entry["direction"]: entry["actionId"]
+            for entry in backend.tiltGestureOwnerBindings("default", "tilt_right")
+        }
+        self.assertEqual(bindings["up"], "mission_control")
+        self.assertEqual(bindings["left"], "none")
+        self.assertEqual(bindings["right"], "none")
+        self.assertEqual(bindings["down"], "none")
+
+    def test_set_tilt_gesture_owner_binding_rejects_unknown_owner_or_direction(self):
+        backend = self._make_backend()
+        with patch("core.config.save_config") as save_mock:
+            backend.setTiltGestureOwnerBinding("default", "trigger", "up", "mission_control")
+            backend.setTiltGestureOwnerBinding("default", "tilt_left", "diagonal", "mission_control")
+        save_mock.assert_not_called()
+
+    def test_tilt_gesture_owner_bindings_unknown_owner_returns_empty(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.tiltGestureOwnerBindings("default", "trigger"), [])
+
+    def test_tilt_gesture_release_ms_default(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.tiltGestureReleaseMs, 150)
+
+    def test_set_tilt_gesture_release_ms_clamps_and_persists(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setTiltGestureReleaseMs(10)
+        save_mock.assert_called_once()
+        self.assertEqual(backend.tiltGestureReleaseMs, 50)
+
+    def test_set_tilt_gesture_release_ms_noop_when_unchanged(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setTiltGestureReleaseMs(200)
+
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setTiltGestureReleaseMs(200)
+        save_mock.assert_not_called()
+
+    def test_tilt_gesture_eligible_owners_defaults_permissive_without_device(self):
+        backend = self._make_backend()
+        self.assertEqual(set(backend.tiltGestureEligibleOwners), {"tilt_left", "tilt_right"})
+
+    def test_tilt_gesture_eligible_owners_narrowed_by_device_capability(self):
+        backend = self._make_backend(
+            engine=_FakeEngine(device_connected=True, connected_device=self._mx_anywhere_2s_tilt())
+        )
+        self.assertEqual(backend.tiltGestureEligibleOwners, ["tilt_left"])
+
+    def test_tilt_gesture_eligible_owners_empty_when_device_lacks_capability(self):
+        device = SimpleNamespace(
+            key="mx_master_3s",
+            display_name="MX Master 3S",
+            dpi_min=200,
+            dpi_max=8000,
+            ui_layout="mx_master_3s",
+            supported_buttons=("middle", "xbutton1", "xbutton2", "hscroll_left", "hscroll_right"),
+        )
+        backend = self._make_backend(
+            engine=_FakeEngine(device_connected=True, connected_device=device)
+        )
+        self.assertEqual(backend.tiltGestureEligibleOwners, [])
+
+
+@unittest.skipIf(Backend is None, "PySide6 not installed in test environment")
 class BackendLoginStartupTests(unittest.TestCase):
     def test_init_calls_sync_from_config_when_supported(self):
         cfg = copy.deepcopy(DEFAULT_CONFIG)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -50,6 +50,7 @@ class _FakeEngine:
         self.start_count = 0
         self.stop_count = 0
         self.start_error = None
+        self.reload_mappings_count = 0
 
     def set_profile_change_callback(self, cb):
         self.profile_callback = cb
@@ -82,6 +83,9 @@ class _FakeEngine:
 
     def stop(self):
         self.stop_count += 1
+
+    def reload_mappings(self):
+        self.reload_mappings_count += 1
 
 
 @unittest.skipIf(Backend is None, "PySide6 not installed in test environment")
@@ -1224,6 +1228,188 @@ class BackendDeviceLayoutTests(unittest.TestCase):
 
         create_profile.assert_not_called()
         self.assertIn("Profile already exists", status_messages)
+
+
+@unittest.skipIf(Backend is None, "PySide6 not installed in test environment")
+class BackendPerButtonGestureTests(unittest.TestCase):
+    """issue #006 -- per-button gesture toggle + namespaced binding get/set."""
+
+    def _make_backend(self, engine=None, cfg=None):
+        loaded_config = copy.deepcopy(cfg or DEFAULT_CONFIG)
+        with (
+            patch("ui.backend.load_config", return_value=loaded_config),
+            patch("ui.backend.save_config"),
+            patch("ui.backend.supports_login_startup", return_value=False),
+        ):
+            return Backend(engine=engine)
+
+    def _mx_anywhere_2s(self):
+        return SimpleNamespace(
+            key="mx_anywhere_2s",
+            display_name="MX Anywhere 2S",
+            dpi_min=200,
+            dpi_max=4000,
+            ui_layout="mx_anywhere_2s",
+            supported_buttons=(
+                "middle", "xbutton1", "xbutton2",
+                "gesture_forward_left", "gesture_forward_right",
+                "gesture_forward_up", "gesture_forward_down",
+            ),
+        )
+
+    def test_gesture_owner_for_button_maps_hotspot_keys_to_owners(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.gestureOwnerForButton("xbutton1"), "back")
+        self.assertEqual(backend.gestureOwnerForButton("xbutton2"), "forward")
+        self.assertEqual(backend.gestureOwnerForButton("middle"), "middle")
+        self.assertEqual(backend.gestureOwnerForButton("hscroll_left"), "")
+
+    def test_gesture_mode_off_by_default(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.gestureEnabledOwners, [])
+        bindings = backend.gestureOwnerBindings("default", "forward")
+        self.assertTrue(all(entry["actionId"] == "none" for entry in bindings))
+
+    def test_set_gesture_owner_enabled_persists_and_notifies(self):
+        backend = self._make_backend()
+        settings_changed = []
+        backend.settingsChanged.connect(lambda: settings_changed.append(True))
+
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setGestureOwnerEnabled("forward", True)
+
+        save_mock.assert_called_once()
+        self.assertEqual(backend.gestureEnabledOwners, ["forward"])
+        self.assertEqual(len(settings_changed), 1)
+
+    def test_set_gesture_owner_enabled_noop_when_unchanged(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("forward", True)
+
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setGestureOwnerEnabled("forward", True)
+
+        save_mock.assert_not_called()
+
+    def test_set_gesture_owner_enabled_rejects_unknown_owner(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config") as save_mock:
+            # "gesture" is the HID thumb button, not a per-button owner.
+            backend.setGestureOwnerEnabled("gesture", True)
+        save_mock.assert_not_called()
+        self.assertEqual(backend.gestureEnabledOwners, [])
+
+    def test_set_gesture_owner_enabled_reruns_engine_mapping_reload(self):
+        engine = _FakeEngine()
+        backend = self._make_backend(engine=engine)
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("middle", True)
+        self.assertEqual(engine.reload_mappings_count, 1)
+
+    def test_toggle_off_does_not_clear_direction_bindings(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("back", True)
+        with patch("core.config.save_config"):
+            backend.setGestureOwnerBinding("default", "back", "up", "mission_control")
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("back", False)
+
+        self.assertEqual(backend.gestureEnabledOwners, [])
+        bindings = {
+            entry["direction"]: entry["actionId"]
+            for entry in backend.gestureOwnerBindings("default", "back")
+        }
+        self.assertEqual(bindings["up"], "mission_control")
+
+    def test_toggle_off_does_not_touch_single_action_mapping(self):
+        backend = self._make_backend()
+
+        def xbutton1_action():
+            mappings = backend.getProfileMappings("default")
+            return next(m["actionId"] for m in mappings if m["key"] == "xbutton1")
+
+        original = xbutton1_action()
+        self.assertEqual(original, "alt_tab")  # DEFAULT_CONFIG value, sanity check
+
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("back", True)
+        with patch("core.config.save_config"):
+            backend.setGestureOwnerBinding("default", "back", "left", "browser_back")
+        with patch("ui.backend.save_config"):
+            backend.setGestureOwnerEnabled("back", False)
+
+        self.assertEqual(xbutton1_action(), original)
+
+    def test_set_and_get_gesture_owner_binding_round_trip(self):
+        backend = self._make_backend()
+        with patch("core.config.save_config"):
+            backend.setGestureOwnerBinding("default", "forward", "up", "mission_control")
+
+        bindings = {
+            entry["direction"]: entry["actionId"]
+            for entry in backend.gestureOwnerBindings("default", "forward")
+        }
+        self.assertEqual(bindings["up"], "mission_control")
+        self.assertEqual(bindings["left"], "none")
+        self.assertEqual(bindings["right"], "none")
+        self.assertEqual(bindings["down"], "none")
+
+    def test_set_gesture_owner_binding_rejects_unknown_owner_or_direction(self):
+        backend = self._make_backend()
+        with patch("core.config.save_config") as save_mock:
+            backend.setGestureOwnerBinding("default", "trigger", "up", "mission_control")
+            backend.setGestureOwnerBinding("default", "back", "diagonal", "mission_control")
+        save_mock.assert_not_called()
+
+    def test_gesture_owner_bindings_unknown_owner_returns_empty(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.gestureOwnerBindings("default", "trigger"), [])
+
+    def test_gesture_hold_floor_ms_default(self):
+        backend = self._make_backend()
+        self.assertEqual(backend.gestureHoldFloorMs, 80)
+
+    def test_set_gesture_hold_floor_ms_clamps_and_persists(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setGestureHoldFloorMs(-25)
+        save_mock.assert_called_once()
+        self.assertEqual(backend.gestureHoldFloorMs, 0)
+
+    def test_set_gesture_hold_floor_ms_noop_when_unchanged(self):
+        backend = self._make_backend()
+        with patch("ui.backend.save_config"):
+            backend.setGestureHoldFloorMs(120)
+
+        with patch("ui.backend.save_config") as save_mock:
+            backend.setGestureHoldFloorMs(120)
+        save_mock.assert_not_called()
+
+    def test_gesture_eligible_owners_defaults_permissive_without_device(self):
+        backend = self._make_backend()
+        self.assertEqual(set(backend.gestureEligibleOwners), {"back", "forward", "middle"})
+
+    def test_gesture_eligible_owners_narrowed_by_device_capability(self):
+        backend = self._make_backend(
+            engine=_FakeEngine(device_connected=True, connected_device=self._mx_anywhere_2s())
+        )
+        self.assertEqual(backend.gestureEligibleOwners, ["forward"])
+
+    def test_gesture_eligible_owners_empty_when_device_lacks_capability(self):
+        device = SimpleNamespace(
+            key="mx_master_3s",
+            display_name="MX Master 3S",
+            dpi_min=200,
+            dpi_max=8000,
+            ui_layout="mx_master_3s",
+            supported_buttons=("middle", "xbutton1", "xbutton2"),
+        )
+        backend = self._make_backend(
+            engine=_FakeEngine(device_connected=True, connected_device=device)
+        )
+        self.assertEqual(backend.gestureEligibleOwners, [])
 
 
 @unittest.skipIf(Backend is None, "PySide6 not installed in test environment")

--- a/tests/test_config_gestures.py
+++ b/tests/test_config_gestures.py
@@ -70,6 +70,100 @@ class GestureOwnersTests(unittest.TestCase):
         )
 
 
+class TiltGestureSchemaTests(unittest.TestCase):
+    def test_owner_split_button_vs_tilt(self):
+        self.assertEqual(config.BUTTON_GESTURE_OWNERS, ("back", "forward", "middle"))
+        self.assertEqual(config.TILT_GESTURE_OWNERS, ("tilt_left", "tilt_right"))
+        # GESTURE_OWNERS is the union the helpers iterate; the two subsets are disjoint.
+        self.assertEqual(
+            set(config.GESTURE_OWNERS),
+            set(config.BUTTON_GESTURE_OWNERS) | set(config.TILT_GESTURE_OWNERS),
+        )
+        self.assertEqual(
+            set(config.BUTTON_GESTURE_OWNERS) & set(config.TILT_GESTURE_OWNERS), set()
+        )
+
+    def test_eight_tilt_keys_exist_and_validate(self):
+        self.assertEqual(len(config.TILT_GESTURE_KEYS), 8)
+        for owner in ("tilt_left", "tilt_right"):
+            for direction in ("left", "right", "up", "down"):
+                key = f"gesture_{owner}_{direction}"
+                with self.subTest(key=key):
+                    self.assertIn(key, config.TILT_GESTURE_KEYS)
+                    self.assertIn(key, config.PROFILE_BUTTON_NAMES)
+                    # Same as the button gesture keys: a tilt TAP reuses the
+                    # existing hscroll mapping and a tilt SLIDE routes via the
+                    # gesture_owner tag, so no namespaced event is dispatched.
+                    self.assertNotIn(key, config.BUTTON_TO_EVENTS)
+                    self.assertEqual(
+                        config.DEFAULT_CONFIG["profiles"]["default"]["mappings"][key],
+                        "none",
+                    )
+
+    def test_tilt_keys_do_not_leak_into_per_button_keys(self):
+        self.assertEqual(len(config.PER_BUTTON_GESTURE_KEYS), 12)
+        self.assertEqual(
+            set(config.PER_BUTTON_GESTURE_KEYS) & set(config.TILT_GESTURE_KEYS), set()
+        )
+
+    def test_default_config_has_zero_tilt_owners(self):
+        cfg = _cfg_with_mappings({})
+        self.assertEqual(
+            config.gesture_owners(cfg) & set(config.TILT_GESTURE_OWNERS), set()
+        )
+
+    def test_bound_tilt_direction_marks_its_owner(self):
+        cfg = _cfg_with_mappings({"gesture_tilt_left_up": "mission_control"})
+        self.assertIn("tilt_left", config.gesture_owners(cfg))
+
+    def test_gesture_bindings_for_tilt_owner(self):
+        cfg = _cfg_with_mappings({
+            "gesture_tilt_right_left": "browser_back",
+            "gesture_tilt_right_right": "browser_forward",
+        })
+        self.assertEqual(
+            config.gesture_bindings_for(cfg, "tilt_right"),
+            {
+                "swipe_left": "browser_back",
+                "swipe_right": "browser_forward",
+                "swipe_up": "none",
+                "swipe_down": "none",
+            },
+        )
+
+
+class TiltReleaseMsTests(unittest.TestCase):
+    def test_default_release_ms_is_150(self):
+        # 150ms sits safely above the ~110ms tilt inter-pulse gap so a held
+        # tilt's pulse stream keeps the gesture armed instead of fragmenting
+        # into spurious taps / dropped slow slides.
+        migrated = config._migrate({"version": 1, "profiles": {}, "settings": {}})
+        self.assertEqual(migrated["settings"]["tilt_gesture_release_ms"], 150)
+
+    def test_release_ms_preserves_valid_custom_value(self):
+        migrated = config._migrate(
+            {"version": 9, "profiles": {}, "settings": {"tilt_gesture_release_ms": 220}}
+        )
+        self.assertEqual(migrated["settings"]["tilt_gesture_release_ms"], 220)
+
+    def test_release_ms_clamped_to_50_minimum(self):
+        migrated = config._migrate(
+            {"version": 9, "profiles": {}, "settings": {"tilt_gesture_release_ms": 10}}
+        )
+        self.assertEqual(migrated["settings"]["tilt_gesture_release_ms"], 50)
+
+    def test_legacy_config_backfills_tilt_keys(self):
+        legacy = {
+            "version": 9,
+            "active_profile": "default",
+            "profiles": {"default": {"label": "Default", "apps": [], "mappings": {}}},
+            "settings": {},
+        }
+        migrated = config._migrate(legacy)
+        for key in config.TILT_GESTURE_KEYS:
+            self.assertEqual(migrated["profiles"]["default"]["mappings"][key], "none")
+
+
 class GestureHoldFloorTests(unittest.TestCase):
     def test_default_hold_floor_is_80ms(self):
         migrated = config._migrate({"version": 1, "profiles": {}, "settings": {}})

--- a/tests/test_config_gestures.py
+++ b/tests/test_config_gestures.py
@@ -1,0 +1,153 @@
+import json
+import unittest
+
+from core import config
+
+
+def _cfg_with_mappings(mappings):
+    """A DEFAULT_CONFIG deep copy with extra mappings applied to the default profile."""
+    cfg = json.loads(json.dumps(config.DEFAULT_CONFIG))
+    cfg["profiles"]["default"]["mappings"].update(mappings)
+    return cfg
+
+
+class PerButtonGestureSchemaTests(unittest.TestCase):
+    def test_twelve_namespaced_keys_exist_and_validate(self):
+        self.assertEqual(len(config.PER_BUTTON_GESTURE_KEYS), 12)
+        for owner in ("back", "forward", "middle"):
+            for direction in ("left", "right", "up", "down"):
+                key = f"gesture_{owner}_{direction}"
+                with self.subTest(key=key):
+                    self.assertIn(key, config.PER_BUTTON_GESTURE_KEYS)
+                    self.assertIn(key, config.PROFILE_BUTTON_NAMES)
+                    # Deliberately NOT in BUTTON_TO_EVENTS: the kernel emits the
+                    # generic gesture_swipe_<dir> tagged with gesture_owner, so
+                    # a namespaced event string is never dispatched. These keys
+                    # resolve via gesture_bindings_for() instead.
+                    self.assertNotIn(key, config.BUTTON_TO_EVENTS)
+                    self.assertEqual(
+                        config.DEFAULT_CONFIG["profiles"]["default"]["mappings"][key],
+                        "none",
+                    )
+
+
+class GestureOwnersTests(unittest.TestCase):
+    def test_default_config_has_zero_gesture_owners(self):
+        cfg = _cfg_with_mappings({})
+        self.assertEqual(config.gesture_owners(cfg), set())
+
+    def test_one_bound_direction_marks_its_owner(self):
+        cfg = _cfg_with_mappings({"gesture_forward_up": "mission_control"})
+        self.assertEqual(config.gesture_owners(cfg), {"forward"})
+
+    def test_multiple_owners_bound_independently(self):
+        cfg = _cfg_with_mappings({
+            "gesture_back_left": "browser_back",
+            "gesture_middle_right": "browser_forward",
+        })
+        self.assertEqual(config.gesture_owners(cfg), {"back", "middle"})
+
+    def test_gesture_bindings_for_returns_swipe_keyed_dict(self):
+        cfg = _cfg_with_mappings({
+            "gesture_forward_up": "mission_control",
+            "gesture_forward_down": "app_expose",
+        })
+        self.assertEqual(
+            config.gesture_bindings_for(cfg, "forward"),
+            {
+                "swipe_left": "none",
+                "swipe_right": "none",
+                "swipe_up": "mission_control",
+                "swipe_down": "app_expose",
+            },
+        )
+
+    def test_gesture_bindings_for_unbound_owner_is_all_none(self):
+        cfg = _cfg_with_mappings({"gesture_forward_up": "mission_control"})
+        self.assertEqual(
+            config.gesture_bindings_for(cfg, "back"),
+            {"swipe_left": "none", "swipe_right": "none", "swipe_up": "none", "swipe_down": "none"},
+        )
+
+
+class GestureHoldFloorTests(unittest.TestCase):
+    def test_default_hold_floor_is_80ms(self):
+        migrated = config._migrate({"version": 1, "profiles": {}, "settings": {}})
+        self.assertEqual(migrated["settings"]["gesture_hold_floor_ms"], 80)
+
+    def test_hold_floor_preserves_a_valid_custom_value(self):
+        migrated = config._migrate(
+            {"version": 9, "profiles": {}, "settings": {"gesture_hold_floor_ms": 120}}
+        )
+        self.assertEqual(migrated["settings"]["gesture_hold_floor_ms"], 120)
+
+    def test_hold_floor_clamped_to_zero_minimum(self):
+        migrated = config._migrate(
+            {"version": 9, "profiles": {}, "settings": {"gesture_hold_floor_ms": -50}}
+        )
+        self.assertEqual(migrated["settings"]["gesture_hold_floor_ms"], 0)
+
+
+class GestureBackCompatTests(unittest.TestCase):
+    def test_preexisting_config_with_no_owner_keys_loads_with_zero_owners(self):
+        # Simulates a config saved by pre-#001 Mouser: no per-button gesture
+        # keys anywhere in the mappings dict.
+        legacy = {
+            "version": 9,
+            "active_profile": "default",
+            "profiles": {
+                "default": {
+                    "label": "Default",
+                    "apps": [],
+                    "mappings": {
+                        "middle": "none",
+                        "xbutton1": "alt_tab",
+                        "xbutton2": "alt_tab",
+                    },
+                }
+            },
+            "settings": {},
+        }
+
+        migrated = config._migrate(legacy)
+
+        self.assertEqual(config.gesture_owners(migrated), set())
+        for key in config.PER_BUTTON_GESTURE_KEYS:
+            self.assertEqual(migrated["profiles"]["default"]["mappings"][key], "none")
+
+    def test_legacy_global_gesture_keys_still_resolve_and_are_not_owners(self):
+        # A config with the OLD global gesture_left/right/up/down keys bound
+        # (the MX Master HID-thumb-button path) must keep working exactly as
+        # before, and must NOT be mistaken for a per-button owner.
+        legacy = {
+            "version": 3,
+            "active_profile": "default",
+            "profiles": {
+                "default": {
+                    "label": "Default",
+                    "apps": [],
+                    "mappings": {
+                        "gesture": "gesture_click_action",
+                        "gesture_left": "mission_control",
+                        "gesture_right": "app_expose",
+                        "gesture_up": "desktop_left",
+                        "gesture_down": "desktop_right",
+                    },
+                }
+            },
+            "settings": {},
+        }
+
+        migrated = config._migrate(legacy)
+
+        mappings = migrated["profiles"]["default"]["mappings"]
+        self.assertEqual(mappings["gesture"], "gesture_click_action")
+        self.assertEqual(mappings["gesture_left"], "mission_control")
+        self.assertEqual(mappings["gesture_right"], "app_expose")
+        self.assertEqual(mappings["gesture_up"], "desktop_left")
+        self.assertEqual(mappings["gesture_down"], "desktop_right")
+        self.assertEqual(config.gesture_owners(migrated), set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_device_layouts.py
+++ b/tests/test_device_layouts.py
@@ -148,6 +148,47 @@ class DeviceLayoutTests(unittest.TestCase):
     def test_mx_anywhere_2s_has_no_self_fallback(self):
         self.assertEqual(_FAMILY_FALLBACKS.get("mx_anywhere_2s"), "mx_anywhere")
 
+    def test_mx_anywhere_2s_exposes_per_button_gesture_keys_in_capability_model(self):
+        # Issue #005: back/forward/middle must be reachable as gesture owners
+        # once the event-tap flag (issue #002) is wired in.
+        device = next(d for d in KNOWN_LOGI_DEVICES if d.key == "mx_anywhere_2s")
+
+        self.assertTrue(device.supports_event_tap_gestures)
+        for owner in ("back", "forward", "middle"):
+            for direction in ("left", "right", "up", "down"):
+                self.assertIn(f"gesture_{owner}_{direction}", device.supported_buttons)
+
+        # No dedicated "gesture" hotspot on the 2S -- per-button gesture mode
+        # is reached via each button's own hotspot (middle/xbutton1/xbutton2),
+        # not a separate affordance (issue #005 technical decision).
+        layout = get_device_layout("mx_anywhere_2s")
+        hotspot_keys = {hotspot["buttonKey"] for hotspot in layout["hotspots"]}
+        self.assertNotIn("gesture", hotspot_keys)
+
+    def test_mx_master_layouts_untouched_by_2s_gesture_affordance_work(self):
+        # Regression guard for issue #005: MX Master family layouts and specs
+        # must be byte-identical -- this feature is 2S-only.
+        expected_hotspot_keys = {
+            "mx_master_4": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+            "mx_master_3s": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+            "mx_master_3": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+            "mx_master_2s": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+            "mx_master_classic": ["middle", "xbutton1", "xbutton2", "gesture", "hscroll_left", "mode_shift"],
+        }
+        for layout_key, expected_keys in expected_hotspot_keys.items():
+            with self.subTest(layout=layout_key):
+                layout = LOGI_DEVICE_LAYOUTS[layout_key]
+                self.assertEqual(
+                    [hotspot["buttonKey"] for hotspot in layout["hotspots"]],
+                    expected_keys,
+                )
+
+        for device in KNOWN_LOGI_DEVICES:
+            if device.key.startswith("mx_master"):
+                with self.subTest(device=device.key):
+                    self.assertFalse(device.supports_event_tap_gestures)
+                    self.assertNotIn("gesture_back_left", device.supported_buttons)
+
     def test_mx_vertical_layout_is_interactive(self):
         layout = get_device_layout("mx_vertical")
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -590,6 +590,23 @@ def _connected_mouse_hook_cls(device):
     return _ConnectedFakeMouseHook
 
 
+def _fully_eligible_device_with_button_and_tilt():
+    """Device eligible for BOTH button owners and tilt owners -- mirrors the
+    real mx_anywhere_2s spec (supports_event_tap_gestures AND
+    supports_tilt_gestures both True). Used to regression-test that the two
+    owner kinds route into separate configure_gestures() params, never mixed."""
+    return SimpleNamespace(
+        supported_buttons=(
+            *_fully_eligible_device().supported_buttons,
+            *(
+                f"gesture_{owner}_{direction}"
+                for owner in ("tilt_left", "tilt_right")
+                for direction in _ALL_GESTURE_DIRECTIONS
+            ),
+        )
+    )
+
+
 class EngineGestureDispatchTests(unittest.TestCase):
     """Issue 004: configure_gestures wiring + per-owner direction dispatch.
 
@@ -912,6 +929,160 @@ class EngineGestureRearmOnConnectTests(unittest.TestCase):
                 ))
 
         execute_action_mock.assert_called_once_with("mission_control")
+
+
+class EngineTiltGestureTests(unittest.TestCase):
+    """Tilt (horizontal-scroll) slide gestures: the engine feeds
+    _active_tilt_owners to configure_gestures(tilt_owners=, tilt_release_ms=),
+    gated the same way as button owners (bound direction + settings.
+    gesture_owner_enabled + device eligibility, here on supports_tilt_gestures
+    rather than supports_event_tap_gestures), and routes a gesture_swipe_<dir>
+    event tagged gesture_owner="tilt_left"/"tilt_right" through the same
+    owner_bindings dict as button owners. A tilt TAP arrives as a plain
+    HSCROLL_LEFT/RIGHT event, already covered by EngineHorizontalScrollTests."""
+
+    _TILT_ONLY_DEVICE = SimpleNamespace(
+        supported_buttons=(
+            "middle", "xbutton1", "xbutton2",
+            "hscroll_left", "hscroll_right",
+            "gesture_tilt_left_left", "gesture_tilt_left_right",
+            "gesture_tilt_left_up", "gesture_tilt_left_down",
+            "gesture_tilt_right_left", "gesture_tilt_right_right",
+            "gesture_tilt_right_up", "gesture_tilt_right_down",
+        )
+    )
+    # Per-button-event-tap eligible, but NOT tilt-eligible (no
+    # supports_tilt_gestures) -- e.g. config carried over from an MX Anywhere 2S.
+    _NO_TILT_DEVICE = SimpleNamespace(
+        supported_buttons=(
+            "middle", "xbutton1", "xbutton2",
+            "gesture_forward_left", "gesture_forward_right",
+            "gesture_forward_up", "gesture_forward_down",
+        )
+    )
+
+    def _cfg(self, enabled=None, **mapping_overrides):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["profiles"]["default"]["mappings"].update(mapping_overrides)
+        if enabled is not None:
+            cfg["settings"]["gesture_owner_enabled"] = dict(enabled)
+        return cfg
+
+    def _make_engine(self, cfg, device=None):
+        from core.engine import Engine
+
+        hook_cls = _connected_mouse_hook_cls(device) if device is not None else _FakeMouseHook
+        with (
+            patch("core.engine.MouseHook", hook_cls),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=cfg),
+        ):
+            return Engine()
+
+    def test_bound_enabled_and_eligible_tilt_owner_arms(self):
+        cfg = self._cfg(enabled={"tilt_left": True}, gesture_tilt_left_up="mission_control")
+        engine = self._make_engine(cfg, device=self._TILT_ONLY_DEVICE)
+
+        gesture_cfg = engine.hook._gesture_config
+        self.assertEqual(gesture_cfg["tilt_owners"], {"tilt_left"})
+        self.assertEqual(gesture_cfg["owners"], set())
+        self.assertIs(gesture_cfg["enabled"], True)
+        self.assertIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_tilt_owner_stays_off_when_enable_toggle_is_off(self):
+        cfg = self._cfg(enabled={"tilt_left": False}, gesture_tilt_left_up="mission_control")
+        engine = self._make_engine(cfg, device=self._TILT_ONLY_DEVICE)
+
+        self.assertEqual(engine.hook._gesture_config["tilt_owners"], set())
+        self.assertNotIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_tilt_owner_stays_off_when_enable_flag_absent(self):
+        # No settings.gesture_owner_enabled key at all -- default is off.
+        cfg = self._cfg(gesture_tilt_left_up="mission_control")
+        engine = self._make_engine(cfg, device=self._TILT_ONLY_DEVICE)
+
+        self.assertEqual(engine.hook._gesture_config["tilt_owners"], set())
+
+    def test_tilt_owner_stays_off_with_no_device_connected(self):
+        cfg = self._cfg(enabled={"tilt_left": True}, gesture_tilt_left_up="mission_control")
+        engine = self._make_engine(cfg, device=None)
+
+        self.assertEqual(engine.hook._gesture_config["tilt_owners"], set())
+
+    def test_tilt_owner_does_not_leak_onto_non_tilt_eligible_device(self):
+        # Regression: a device with per-button event-tap support but no
+        # supports_tilt_gestures must not arm a tilt owner even if bound+enabled.
+        cfg = self._cfg(enabled={"tilt_left": True}, gesture_tilt_left_up="mission_control")
+        engine = self._make_engine(cfg, device=self._NO_TILT_DEVICE)
+
+        self.assertEqual(engine.hook._gesture_config["tilt_owners"], set())
+        self.assertNotIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_tilt_release_ms_threads_through_to_configure_gestures(self):
+        cfg = self._cfg(enabled={"tilt_left": True}, gesture_tilt_left_up="mission_control")
+        cfg["settings"]["tilt_gesture_release_ms"] = 250
+        engine = self._make_engine(cfg, device=self._TILT_ONLY_DEVICE)
+
+        self.assertEqual(engine.hook._gesture_config["tilt_release_ms"], 250)
+
+    def test_tilt_release_ms_defaults_when_unset(self):
+        from core.config import TILT_GESTURE_RELEASE_MS_DEFAULT
+
+        cfg = self._cfg(enabled={"tilt_left": True}, gesture_tilt_left_up="mission_control")
+        engine = self._make_engine(cfg, device=self._TILT_ONLY_DEVICE)
+
+        self.assertEqual(
+            engine.hook._gesture_config["tilt_release_ms"], TILT_GESTURE_RELEASE_MS_DEFAULT
+        )
+
+    def test_button_and_tilt_owners_do_not_cross_leak(self):
+        """Regression: gesture_owners() returns the button+tilt union, so a
+        device eligible for BOTH kinds with one owner of each bound+enabled
+        must route each into its OWN configure_gestures() param, never mixed
+        into the other's set."""
+        cfg = self._cfg(
+            enabled={"forward": True, "tilt_left": True},
+            gesture_forward_up="mission_control",
+            gesture_tilt_left_down="app_expose",
+        )
+        engine = self._make_engine(cfg, device=_fully_eligible_device_with_button_and_tilt())
+
+        gesture_cfg = engine.hook._gesture_config
+        self.assertEqual(gesture_cfg["owners"], {"forward"})
+        self.assertEqual(gesture_cfg["tilt_owners"], {"tilt_left"})
+
+    def test_tilt_swipe_tagged_event_routes_to_bound_action(self):
+        """The tilt kernel fires gesture_swipe_<dir> tagged
+        gesture_owner="tilt_left"/"tilt_right" on a slide -- routed by the
+        same _make_owner_gesture_handler as button owners, keyed on
+        gesture_tilt_left_up's bound action."""
+        cfg = self._cfg(enabled={"tilt_left": True}, gesture_tilt_left_up="mission_control")
+        engine = self._make_engine(cfg, device=self._TILT_ONLY_DEVICE)
+        handlers = engine.hook.registered["gesture_swipe_up"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(SimpleNamespace(
+                    event_type=MouseEvent.GESTURE_SWIPE_UP,
+                    raw_data={"delta_x": 80, "delta_y": 0, "source": "tilt", "gesture_owner": "tilt_left"},
+                ))
+
+        execute_action_mock.assert_called_once_with("mission_control")
+
+    def test_tilt_owner_without_binding_for_direction_does_not_fire(self):
+        # tilt_left only binds "up" -- a "down" swipe tagged tilt_left has no action.
+        cfg = self._cfg(enabled={"tilt_left": True}, gesture_tilt_left_up="mission_control")
+        engine = self._make_engine(cfg, device=self._TILT_ONLY_DEVICE)
+        handlers = engine.hook.registered["gesture_swipe_down"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(SimpleNamespace(
+                    event_type=MouseEvent.GESTURE_SWIPE_DOWN,
+                    raw_data={"delta_x": 0, "delta_y": 80, "source": "tilt", "gesture_owner": "tilt_left"},
+                ))
+
+        execute_action_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,11 +1,58 @@
 import copy
+import sys
+import types
 import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from core.config import DEFAULT_CONFIG
-from core.mouse_hook import MouseEvent
-from core.mouse_hook_types import HidRuntimeState
+def _ensure_core_engine_importable():
+    """Make `core.engine` importable in this sandbox (no PyObjC/objc).
+
+    core.engine does `from core.mouse_hook import ...` (platform dispatch)
+    and `from core.app_detector import AppDetector`, both of which pull in
+    the native macOS hook at module load. Every test in this file patches
+    both classes out anyway (_FakeMouseHook / _FakeAppDetector), so stub
+    the two modules just long enough to import core.engine once — it's
+    then cached for the rest of the session — and remove the stubs again
+    immediately after, so any *other* test file that imports
+    core.mouse_hook / core.app_detector directly still sees the real
+    (missing-PyObjC) failure, unaffected by this workaround.
+    """
+    try:
+        import core.engine  # noqa: F401
+        return
+    except ImportError:
+        pass
+
+    from core.mouse_hook_types import MouseEvent as _MouseEvent
+
+    stubbed = []
+    for name, attr, extra in (
+        ("core.mouse_hook", "MouseHook", {"MouseEvent": _MouseEvent}),
+        ("core.app_detector", "AppDetector", {}),
+    ):
+        if name in sys.modules:
+            continue
+        stub = types.ModuleType(name)
+        setattr(stub, attr, object)
+        for key, value in extra.items():
+            setattr(stub, key, value)
+        sys.modules[name] = stub
+        stubbed.append(name)
+
+    try:
+        import core.engine  # noqa: F401
+    finally:
+        for name in stubbed:
+            del sys.modules[name]
+
+
+_ensure_core_engine_importable()
+
+from core.config import DEFAULT_CONFIG, GESTURE_HOLD_FLOOR_MS_DEFAULT
+# core.mouse_hook_types (not core.mouse_hook — see _ensure_core_engine_importable
+# above) so this import is objc-free regardless of whether the sandbox stub ran.
+from core.mouse_hook_types import HidRuntimeState, MouseEvent
 
 
 class _FakeMouseHook:
@@ -18,6 +65,7 @@ class _FakeMouseHook:
         self._hid_gesture = None
         self.start_called = False
         self.stop_called = False
+        self.registered = {}
 
     def set_debug_callback(self, cb):
         self._debug_callback = cb
@@ -38,10 +86,10 @@ class _FakeMouseHook:
         pass
 
     def register(self, event_type, callback):
-        pass
+        self.registered.setdefault(event_type, []).append(callback)
 
     def reset_bindings(self):
-        pass
+        self.registered = {}
 
     def start(self):
         self.start_called = True
@@ -511,6 +559,359 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
 
         engine.hook._hid_gesture.read_battery.assert_called_once_with()
         engine.hook._hid_gesture.read_smart_shift.assert_not_called()
+
+
+_ALL_GESTURE_OWNERS = ("back", "forward", "middle")
+_ALL_GESTURE_DIRECTIONS = ("left", "right", "up", "down")
+
+
+def _fully_eligible_device():
+    """A device whose supported_buttons cover every owner's 4 directions --
+    used as the default device for tests that exercise ROUTING, not the
+    finding #1 enable/eligibility gate itself (covered separately below)."""
+    return SimpleNamespace(
+        supported_buttons=tuple(
+            f"gesture_{owner}_{direction}"
+            for owner in _ALL_GESTURE_OWNERS
+            for direction in _ALL_GESTURE_DIRECTIONS
+        )
+    )
+
+
+def _connected_mouse_hook_cls(device):
+    """A _FakeMouseHook subclass pre-wired with a connected device, so
+    Engine.__init__'s synchronous _setup_hooks() call sees it (there is no
+    window to inject the device after construction)."""
+    class _ConnectedFakeMouseHook(_FakeMouseHook):
+        def __init__(self):
+            super().__init__()
+            self.connected_device = device
+            self.device_connected = device is not None
+    return _ConnectedFakeMouseHook
+
+
+class EngineGestureDispatchTests(unittest.TestCase):
+    """Issue 004: configure_gestures wiring + per-owner direction dispatch.
+
+    These tests are about ROUTING, not the arming gate (finding #1, covered
+    by EngineGestureArmingGateTests below) -- so every owner is enabled and
+    the fake device is eligible for all of them by default.
+    """
+
+    _DEFAULT_DEVICE = object()  # sentinel: distinguish "use the default eligible device" from device=None
+
+    def _make_engine(self, cfg, device=_DEFAULT_DEVICE):
+        from core.engine import Engine
+
+        if device is self._DEFAULT_DEVICE:
+            device = _fully_eligible_device()
+        hook_cls = _connected_mouse_hook_cls(device) if device is not None else _FakeMouseHook
+        with (
+            patch("core.engine.MouseHook", hook_cls),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=cfg),
+        ):
+            return Engine()
+
+    def _cfg(self, **mapping_overrides):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["profiles"]["default"]["mappings"].update(mapping_overrides)
+        cfg["settings"]["gesture_owner_enabled"] = {owner: True for owner in _ALL_GESTURE_OWNERS}
+        return cfg
+
+    def _owner_event(self, owner, dx=0, dy=-80):
+        return SimpleNamespace(
+            event_type=MouseEvent.GESTURE_SWIPE_UP,
+            raw_data={"delta_x": dx, "delta_y": dy, "source": "event_tap", "gesture_owner": owner},
+        )
+
+    def test_configure_gestures_receives_owner_set_and_default_hold_floor(self):
+        cfg = self._cfg(gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg)
+
+        gesture_cfg = engine.hook._gesture_config
+        self.assertEqual(gesture_cfg["owners"], {"forward"})
+        self.assertEqual(gesture_cfg["hold_floor_ms"], GESTURE_HOLD_FLOOR_MS_DEFAULT)
+        self.assertIs(gesture_cfg["enabled"], True)
+
+    def test_configure_gestures_threads_custom_hold_floor(self):
+        cfg = self._cfg(gesture_forward_up="mission_control")
+        cfg["settings"]["gesture_hold_floor_ms"] = 150
+        engine = self._make_engine(cfg)
+
+        self.assertEqual(engine.hook._gesture_config["hold_floor_ms"], 150)
+
+    def test_zero_owners_disables_gestures_with_empty_owner_set(self):
+        engine = self._make_engine(self._cfg())
+
+        gesture_cfg = engine.hook._gesture_config
+        self.assertEqual(gesture_cfg["owners"], set())
+        self.assertIs(gesture_cfg["enabled"], False)
+
+    def test_hid_direction_only_still_enables_gestures_with_empty_owners(self):
+        engine = self._make_engine(self._cfg(gesture_up="mission_control"))
+
+        gesture_cfg = engine.hook._gesture_config
+        self.assertEqual(gesture_cfg["owners"], set())
+        self.assertIs(gesture_cfg["enabled"], True)
+
+    def test_owner_gesture_dispatches_to_namespaced_action(self):
+        engine = self._make_engine(self._cfg(gesture_forward_up="mission_control"))
+        handlers = engine.hook.registered["gesture_swipe_up"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(self._owner_event("forward"))
+
+        execute_action_mock.assert_called_once_with("mission_control")
+
+    def test_two_owners_same_direction_fire_their_own_actions(self):
+        engine = self._make_engine(self._cfg(
+            gesture_forward_up="mission_control",
+            gesture_back_up="app_expose",
+        ))
+        handlers = engine.hook.registered["gesture_swipe_up"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(self._owner_event("forward"))
+            for handler in handlers:
+                handler(self._owner_event("back"))
+
+        execute_action_mock.assert_has_calls(
+            [unittest.mock.call("mission_control"), unittest.mock.call("app_expose")]
+        )
+        self.assertEqual(execute_action_mock.call_count, 2)
+
+    def test_owner_direction_without_binding_does_not_fire(self):
+        # forward only binds "up" — a "down" swipe from forward has no action.
+        engine = self._make_engine(self._cfg(gesture_forward_up="mission_control"))
+        handlers = engine.hook.registered["gesture_swipe_down"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(SimpleNamespace(
+                    event_type=MouseEvent.GESTURE_SWIPE_DOWN,
+                    raw_data={"delta_x": 0, "delta_y": 80, "source": "event_tap", "gesture_owner": "forward"},
+                ))
+
+        execute_action_mock.assert_not_called()
+
+    def test_hid_gesture_button_still_routes_when_owners_configured(self):
+        """Regression guard: MX Master HID gesture path still fires from its
+        own (non-owner-tagged) events once per-owner routing is also wired."""
+        engine = self._make_engine(self._cfg(
+            gesture_up="app_expose",
+            gesture_forward_up="mission_control",
+        ))
+        handlers = engine.hook.registered["gesture_swipe_up"]
+        self.assertEqual(len(handlers), 2)
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(SimpleNamespace(
+                    event_type=MouseEvent.GESTURE_SWIPE_UP,
+                    raw_data={"delta_x": 0, "delta_y": -80, "source": "hid_rawxy"},
+                ))
+
+        execute_action_mock.assert_called_once_with("app_expose")
+
+    def test_owner_tagged_event_does_not_also_fire_hid_direction_action(self):
+        """The generic gesture_up binding must not double-fire on an
+        owner-tagged (event-tap) swipe — only the owner routing should."""
+        engine = self._make_engine(self._cfg(
+            gesture_up="app_expose",
+            gesture_forward_up="mission_control",
+        ))
+        handlers = engine.hook.registered["gesture_swipe_up"]
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(self._owner_event("forward"))
+
+        execute_action_mock.assert_called_once_with("mission_control")
+
+    def test_no_owner_routing_registered_when_owners_empty(self):
+        engine = self._make_engine(self._cfg(gesture_up="app_expose"))
+
+        self.assertNotIn("gesture_swipe_down", engine.hook.registered)
+        self.assertNotIn("gesture_swipe_left", engine.hook.registered)
+        self.assertNotIn("gesture_swipe_right", engine.hook.registered)
+        # gesture_swipe_up IS registered here, but only by the HID-direction path.
+        self.assertEqual(len(engine.hook.registered["gesture_swipe_up"]), 1)
+
+
+class EngineGestureArmingGateTests(unittest.TestCase):
+    """Finding #1 (adversarial review, 2026-07-03): arming a per-button
+    event-tap gesture must be gated by settings.gesture_owner_enabled AND
+    device eligibility, not just by config bindings -- else the OFF switch
+    has no runtime effect and a per-button gesture leaks onto a device that
+    can't host it (e.g. config carried over to an MX Master)."""
+
+    _MX_ANYWHERE_2S = SimpleNamespace(
+        supported_buttons=(
+            "middle", "xbutton1", "xbutton2",
+            "gesture_forward_left", "gesture_forward_right",
+            "gesture_forward_up", "gesture_forward_down",
+        )
+    )
+    _MX_MASTER_3S = SimpleNamespace(supported_buttons=("middle", "xbutton1", "xbutton2"))
+
+    def _cfg(self, enabled=None, **mapping_overrides):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["profiles"]["default"]["mappings"].update(mapping_overrides)
+        if enabled is not None:
+            cfg["settings"]["gesture_owner_enabled"] = dict(enabled)
+        return cfg
+
+    def _make_engine(self, cfg, device=None):
+        from core.engine import Engine
+
+        hook_cls = _connected_mouse_hook_cls(device) if device is not None else _FakeMouseHook
+        with (
+            patch("core.engine.MouseHook", hook_cls),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=cfg),
+        ):
+            return Engine()
+
+    def test_bound_owner_stays_off_when_enable_toggle_is_off(self):
+        cfg = self._cfg(enabled={"forward": False}, gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=self._MX_ANYWHERE_2S)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+        self.assertNotIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_bound_owner_stays_off_when_enable_flag_absent(self):
+        # No settings.gesture_owner_enabled key at all -- default is off
+        # (matches ui.backend "gesture mode off by default").
+        cfg = self._cfg(gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=self._MX_ANYWHERE_2S)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+
+    def test_bound_and_enabled_owner_stays_off_with_no_device_connected(self):
+        cfg = self._cfg(enabled={"forward": True}, gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=None)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+
+    def test_bound_and_enabled_owner_does_not_leak_onto_ineligible_device(self):
+        # Regression: MX Master 3S has no per-button event-tap gesture support --
+        # config carried over from another device must not arm it here.
+        cfg = self._cfg(enabled={"forward": True}, gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=self._MX_MASTER_3S)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+        self.assertNotIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_bound_enabled_and_eligible_owner_arms(self):
+        cfg = self._cfg(enabled={"forward": True}, gesture_forward_up="mission_control")
+        engine = self._make_engine(cfg, device=self._MX_ANYWHERE_2S)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], {"forward"})
+        self.assertIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_second_owner_off_does_not_block_first_owner_that_is_on(self):
+        cfg = self._cfg(
+            enabled={"forward": True, "back": False},
+            gesture_forward_up="mission_control",
+            gesture_back_up="app_expose",
+        )
+        engine = self._make_engine(cfg, device=_fully_eligible_device())
+
+        self.assertEqual(engine.hook._gesture_config["owners"], {"forward"})
+
+
+class EngineGestureRearmOnConnectTests(unittest.TestCase):
+    """Hardware bugs A/B (fixed live, 2026-07): __init__'s _setup_hooks() runs
+    before the device is connected, so _active_gesture_owners computes empty
+    and nothing ever arms. _on_connection_change recomputes on the
+    hid-features-ready rising edge -- and must reset_bindings() first so a
+    second connect cycle doesn't stack a duplicate handler (the owner action
+    firing 2-3x)."""
+
+    _DEVICE = SimpleNamespace(
+        supported_buttons=(
+            "middle", "xbutton1", "xbutton2",
+            "gesture_forward_left", "gesture_forward_right",
+            "gesture_forward_up", "gesture_forward_down",
+        )
+    )
+
+    def _cfg(self):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["profiles"]["default"]["mappings"]["gesture_forward_up"] = "mission_control"
+        cfg["settings"]["gesture_owner_enabled"] = {"forward": True}
+        return cfg
+
+    def _make_engine(self):
+        from core.engine import Engine
+
+        with (
+            patch("core.engine.MouseHook", _FakeMouseHook),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=self._cfg()),
+        ):
+            return Engine()
+
+    def _connect_device(self, engine):
+        engine.hook.connected_device = self._DEVICE
+        engine.hook.device_connected = True
+        engine.hook._hid_gesture = SimpleNamespace(connected_device=self._DEVICE)
+
+    def _disconnect_device(self, engine):
+        engine.hook.connected_device = None
+        engine.hook.device_connected = False
+        engine.hook._hid_gesture = SimpleNamespace(connected_device=None)
+
+    @staticmethod
+    def _thread_factory(instances):
+        def factory(*args, **kwargs):
+            thread = _RecordedThread(*args, **kwargs)
+            instances.append(thread)
+            return thread
+        return factory
+
+    def test_owner_arms_once_device_becomes_ready_after_construction(self):
+        """Bug A: constructed with no device connected, the owner stays
+        unarmed until a hid-features-ready connection-change recomputes it."""
+        engine = self._make_engine()
+        self.assertEqual(engine.hook._gesture_config["owners"], set())
+        self.assertNotIn("gesture_swipe_up", engine.hook.registered)
+
+        with patch("core.engine.threading.Thread", side_effect=self._thread_factory([])):
+            self._connect_device(engine)
+            engine._on_connection_change(True)
+
+        self.assertEqual(engine.hook._gesture_config["owners"], {"forward"})
+        self.assertIn("gesture_swipe_up", engine.hook.registered)
+
+    def test_reconnect_cycle_does_not_stack_duplicate_handlers(self):
+        """Bug B: a disconnect/reconnect cycle must reset_bindings() before
+        re-registering, so the owner action fires exactly once, not 2-3x."""
+        engine = self._make_engine()
+        threads = []
+
+        with patch("core.engine.threading.Thread", side_effect=self._thread_factory(threads)):
+            self._connect_device(engine)
+            engine._on_connection_change(True)
+            self._disconnect_device(engine)
+            engine._on_connection_change(False)
+            self._connect_device(engine)
+            engine._on_connection_change(True)
+
+        handlers = engine.hook.registered["gesture_swipe_up"]
+        self.assertEqual(len(handlers), 1)
+
+        with patch("core.engine.execute_action") as execute_action_mock:
+            for handler in handlers:
+                handler(SimpleNamespace(
+                    event_type=MouseEvent.GESTURE_SWIPE_UP,
+                    raw_data={"delta_x": 0, "delta_y": -80, "source": "event_tap", "gesture_owner": "forward"},
+                ))
+
+        execute_action_mock.assert_called_once_with("mission_control")
 
 
 if __name__ == "__main__":

--- a/tests/test_event_tap_gesture.py
+++ b/tests/test_event_tap_gesture.py
@@ -355,5 +355,110 @@ class EventTapGestureStateTransitionTests(unittest.TestCase):
                 self.assertEqual(self.quartz.posted_events, [])  # no native replay
 
 
+_TILT_RIGHT_PULSE = 1 * 65536  # fixed-point h_delta = +1.0 -> tilt_right
+_TILT_LEFT_PULSE = -1 * 65536  # fixed-point h_delta = -1.0 -> tilt_left
+
+
+class TiltGestureStateTransitionTests(unittest.TestCase):
+    """Tilt (hscroll) gesture: armed off the hscroll pulse stream instead of
+    a button down/up, resolved by the same decide_gesture on release. Drives
+    the real macOS callback (_maybe_arm_tilt_gesture / _finish_tilt_gesture)
+    via the fake-Quartz harness above."""
+
+    def setUp(self):
+        MouseHook, quartz = _load_mouse_hook_macos()
+        self.quartz = quartz
+        self.hook = MouseHook()
+        self.hook.configure_gestures(
+            enabled=True, threshold=50, deadzone=40,
+            timeout_ms=3000, cooldown_ms=500, owners=set(),
+            hold_floor_ms=80,
+            tilt_owners={"tilt_left", "tilt_right"}, tilt_release_ms=150,
+        )
+
+    def _scroll(self, h_fixed):
+        ev = _FakeCGEvent()
+        ev.fields[self.quartz.kCGScrollWheelEventFixedPtDeltaAxis2] = h_fixed
+        return self.hook._event_tap_callback(
+            None, self.quartz.kCGEventScrollWheel, ev, None
+        )
+
+    def _move(self, dx, dy):
+        ev = _FakeCGEvent()
+        ev.fields[self.quartz.kCGMouseEventDeltaX] = dx
+        ev.fields[self.quartz.kCGMouseEventDeltaY] = dy
+        return self.hook._event_tap_callback(
+            None, self.quartz.kCGEventMouseMoved, ev, None
+        )
+
+    def _fire_tilt_release(self):
+        """Cancel the live threading.Timer and drive the real timeout handler
+        as if release_ms had already elapsed -- avoids a real sleep."""
+        timer = self.hook._tilt_release_timer
+        if timer is not None:
+            timer.cancel()
+        self.hook._tilt_last_pulse_at = time.monotonic() - (
+            self.hook._tilt_release_ms / 1000.0 + 0.05
+        )
+        self.hook._on_tilt_release_timeout()
+
+    def test_single_pulse_then_silence_is_a_tap_fires_hscroll(self):
+        result = self._scroll(_TILT_RIGHT_PULSE)
+
+        self.assertIsNone(result)  # swallowed -- gesture armed
+        self.assertTrue(self.hook._gesture_active)
+        self.assertEqual(self.hook._gesture_owner, "tilt_right")
+
+        self._fire_tilt_release()
+
+        self.assertFalse(self.hook._gesture_active)
+        self.assertIsNone(self.hook._gesture_owner)
+        fired = self.hook._dispatch_queue.get_nowait()
+        self.assertEqual(fired.event_type, MouseEvent.HSCROLL_RIGHT)
+        self.assertEqual(fired.raw_data, 1.0)
+        self.assertTrue(self.hook._dispatch_queue.empty())
+
+    def test_pulse_stream_plus_slide_up_fires_tagged_gesture(self):
+        self._scroll(_TILT_LEFT_PULSE)  # first pulse arms tilt_left
+        self.hook._gesture_press_at = time.monotonic() - 0.2  # outlive hold floor
+        self._scroll(_TILT_LEFT_PULSE)  # a second pulse -- still streaming
+
+        result = self._move(0, -120)  # accumulated slide up
+        self.assertIsNone(result)  # swallowed while gesture active
+
+        # Fire-on-slide-cross: the gesture fires the INSTANT the slide crosses
+        # the threshold (mid-hold), NOT on release -- so it's already queued and
+        # _gesture_triggered is set before the release timer runs. This is what
+        # keeps a fragmenting pulse stream from dropping the gesture.
+        self.assertTrue(self.hook._gesture_triggered)
+        fired = self.hook._dispatch_queue.get_nowait()
+        self.assertEqual(fired.event_type, MouseEvent.GESTURE_SWIPE_UP)
+        self.assertEqual(fired.raw_data["source"], "tilt")
+        self.assertEqual(fired.raw_data["gesture_owner"], "tilt_left")
+
+        self._fire_tilt_release()  # resolves release: gesture already fired -> no tap
+        self.assertFalse(self.hook._gesture_active)
+        self.assertTrue(self.hook._dispatch_queue.empty())
+
+    def test_disabled_tilt_direction_does_not_arm(self):
+        self.hook.configure_gestures(
+            enabled=True, threshold=50, deadzone=40,
+            timeout_ms=3000, cooldown_ms=500, owners=set(),
+            hold_floor_ms=80,
+            tilt_owners={"tilt_right"}, tilt_release_ms=150,  # tilt_left NOT enabled
+        )
+
+        result = self._scroll(_TILT_LEFT_PULSE)
+
+        self.assertIsNotNone(result)  # passed through, not swallowed
+        self.assertFalse(self.hook._gesture_active)
+        self.assertIsNone(self.hook._gesture_owner)
+        # falls through to the tilt's normal (non-gesture) hscroll action
+        fired = self.hook._dispatch_queue.get_nowait()
+        self.assertEqual(fired.event_type, MouseEvent.HSCROLL_LEFT)
+        self.assertEqual(fired.raw_data, 1.0)
+        self.assertTrue(self.hook._dispatch_queue.empty())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_event_tap_gesture.py
+++ b/tests/test_event_tap_gesture.py
@@ -1,0 +1,359 @@
+"""Issue 003 — event-tap gesture activation kernel.
+
+Exercises the pure, objc-free decision helpers that the macOS CGEventTap handler
+calls: the click-vs-gesture release decision (`decide_gesture`) and the
+first-wins arming gate (`should_arm_gesture`). The native tap wiring is verified
+on real hardware (issue 007); these tests pin the logic that decides it.
+
+Also covers the stateful hook transitions (arming / release / abort, finding #4
+of the 2026-07-03 adversarial review) via a tiny fake-Quartz harness: real
+core.mouse_hook_macos is imported against a minimal fake objc/Quartz so the
+actual callback code runs, objc-free, in this sandbox.
+"""
+
+import importlib
+import sys
+import time
+import types
+import unittest
+
+from core.mouse_hook_base import CLICK, GESTURE, decide_gesture, should_arm_gesture
+from core.mouse_hook_types import MouseEvent
+
+# The engine's default gesture tuning (core/config.py DEFAULT_CONFIG settings).
+_THRESHOLD = 50.0
+_DEADZONE = 40.0
+_FLOOR_MS = 80
+
+
+class DecideGestureTests(unittest.TestCase):
+    def test_quick_tap_no_movement_is_a_click(self):
+        decision, direction = decide_gesture(
+            held_ms=200, dx=0, dy=0,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, CLICK)
+        self.assertIsNone(direction)
+
+    def test_sub_deadzone_micro_drift_is_a_click(self):
+        # Held well past the floor, but the slide never clears the threshold.
+        decision, direction = decide_gesture(
+            held_ms=250, dx=12, dy=7,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, CLICK)
+        self.assertIsNone(direction)
+
+    def test_fast_flick_below_hold_floor_is_a_click(self):
+        # A big slide, but released before the hold floor — must NOT misfire (D4).
+        decision, direction = decide_gesture(
+            held_ms=40, dx=0, dy=-200,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, CLICK)
+        self.assertIsNone(direction)
+
+    def test_clean_four_way_gestures_detect_the_direction(self):
+        cases = {
+            (0, -120): MouseEvent.GESTURE_SWIPE_UP,
+            (0, 120): MouseEvent.GESTURE_SWIPE_DOWN,
+            (-120, 0): MouseEvent.GESTURE_SWIPE_LEFT,
+            (120, 0): MouseEvent.GESTURE_SWIPE_RIGHT,
+        }
+        for (dx, dy), expected in cases.items():
+            with self.subTest(dx=dx, dy=dy):
+                decision, direction = decide_gesture(
+                    held_ms=150, dx=dx, dy=dy,
+                    hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+                )
+                self.assertEqual(decision, GESTURE)
+                self.assertEqual(direction, expected)
+
+    def test_boundary_held_exactly_at_floor_is_eligible(self):
+        decision, direction = decide_gesture(
+            held_ms=_FLOOR_MS, dx=120, dy=0,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, GESTURE)
+        self.assertEqual(direction, MouseEvent.GESTURE_SWIPE_RIGHT)
+
+    def test_ambiguous_diagonal_is_a_click_not_a_random_gesture(self):
+        # Equal cross-axis motion → existing cross-axis reject → no direction.
+        decision, direction = decide_gesture(
+            held_ms=150, dx=120, dy=120,
+            hold_floor_ms=_FLOOR_MS, threshold=_THRESHOLD, deadzone=_DEADZONE,
+        )
+        self.assertEqual(decision, CLICK)
+        self.assertIsNone(direction)
+
+
+class ShouldArmGestureTests(unittest.TestCase):
+    def test_owner_button_arms_when_idle(self):
+        self.assertTrue(
+            should_arm_gesture(gesture_active=False, btn_owner="forward",
+                               owners={"forward", "back"})
+        )
+
+    def test_non_owner_button_never_arms(self):
+        self.assertFalse(
+            should_arm_gesture(gesture_active=False, btn_owner="middle",
+                               owners={"forward", "back"})
+        )
+
+    def test_second_owner_passes_through_while_one_is_active(self):
+        # Two-owner overlap: first-held wins, the second must not arm (PRD rule).
+        self.assertFalse(
+            should_arm_gesture(gesture_active=True, btn_owner="back",
+                               owners={"forward", "back"})
+        )
+
+    def test_no_owners_configured_means_feature_off(self):
+        self.assertFalse(
+            should_arm_gesture(gesture_active=False, btn_owner="forward", owners=set())
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fake-Quartz harness: exercises the real core.mouse_hook_macos callback code
+# (arming, release, abort) against a minimal fake objc/Quartz so it runs
+# objc-free in this sandbox. Loaded fresh per test and popped from
+# sys.modules afterwards, so any OTHER test file that imports
+# core.mouse_hook_macos directly still sees the real (missing-PyObjC)
+# ImportError, unaffected by this workaround (mirrors tests/test_engine.py's
+# _ensure_core_engine_importable hygiene).
+# ---------------------------------------------------------------------------
+
+class _FakeCGEvent:
+    """Minimal CGEventRef stand-in: an integer-field store + location."""
+
+    def __init__(self, location=(0.0, 0.0)):
+        self.fields = {}
+        self.location = location
+        self.flags = 0
+
+
+class _NullContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def _build_fake_quartz():
+    """A fake Quartz module exposing just the surface core.mouse_hook_macos
+    touches, backed by _FakeCGEvent so the real callback code runs unmodified."""
+    mod = types.ModuleType("Quartz")
+
+    const_names = [
+        "kCGEventMouseMoved", "kCGEventOtherMouseDragged",
+        "kCGEventOtherMouseDown", "kCGEventOtherMouseUp", "kCGEventScrollWheel",
+        "kCGMouseEventDeltaX", "kCGMouseEventDeltaY", "kCGMouseEventButtonNumber",
+        "kCGEventSourceUserData",
+        "kCGScrollWheelEventFixedPtDeltaAxis1", "kCGScrollWheelEventFixedPtDeltaAxis2",
+        "kCGScrollWheelEventPointDeltaAxis1", "kCGScrollWheelEventPointDeltaAxis2",
+        "kCGScrollWheelEventDeltaAxis1", "kCGScrollWheelEventDeltaAxis2",
+        "kCGScrollWheelEventScrollPhase", "kCGScrollWheelEventMomentumPhase",
+        "kCGScrollEventUnitPixel", "kCGHIDEventTap",
+        "kCGEventSourceStateHIDSystemState",
+        "kCGSessionEventTap", "kCGHeadInsertEventTap", "kCGEventTapOptionDefault",
+        "kCFRunLoopCommonModes",
+    ]
+    for i, cname in enumerate(const_names):
+        setattr(mod, cname, i + 1)
+
+    mod.posted_events = []
+    mod.modifier_flags = 0
+
+    mod.CGEventGetIntegerValueField = lambda event, field: event.fields.get(field, 0)
+    mod.CGEventSetIntegerValueField = lambda event, field, value: event.fields.__setitem__(field, value)
+    mod.CGEventGetFlags = lambda event: event.flags
+    mod.CGEventSetFlags = lambda event, flags: setattr(event, "flags", flags)
+    mod.CGEventGetLocation = lambda event: event.location
+    mod.CGEventCreate = lambda source: _FakeCGEvent()
+    mod.CGEventSourceFlagsState = lambda state_id: mod.modifier_flags
+    mod.CGEventPost = lambda tap, event: mod.posted_events.append(event)
+    mod.CGEventTapEnable = lambda tap, enable: None
+    mod.CGEventMaskBit = lambda bit: 1 << int(bit)
+
+    def _create_mouse_event(source, mouse_type, point, button):
+        ev = _FakeCGEvent(location=point)
+        ev.fields[mod.kCGMouseEventButtonNumber] = button
+        return ev
+
+    mod.CGEventCreateMouseEvent = _create_mouse_event
+    return mod
+
+
+def _load_mouse_hook_macos():
+    """Import a FRESH core.mouse_hook_macos backed by a fake objc/Quartz and
+    return (MouseHook, fake_quartz_module). Saves and restores any real objc /
+    Quartz / core.mouse_hook_macos already in sys.modules, so this works whether
+    or not PyObjC is installed and never corrupts other test files: on Linux/CI
+    the real modules are absent; on a real Mac they ARE loaded (e.g. by
+    tests/test_engine.py) and MUST be forced aside, else this imports the real
+    objc-backed module and the fake-CGEvent assertions run against a live tap."""
+    name = "core.mouse_hook_macos"
+    quartz = _build_fake_quartz()
+    fake_objc = types.ModuleType("objc")
+    fake_objc.autorelease_pool = lambda: _NullContext()
+
+    sentinel = object()
+    saved = {k: sys.modules.get(k, sentinel) for k in ("objc", "Quartz", name)}
+    sys.modules["objc"] = fake_objc
+    sys.modules["Quartz"] = quartz
+    sys.modules.pop(name, None)  # force a fresh, fake-backed import
+    try:
+        module = importlib.import_module(name)
+        MouseHook = module.MouseHook  # capture before restoring real modules
+    finally:
+        for key, value in saved.items():
+            if value is sentinel:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+    return MouseHook, quartz
+
+
+_MIDDLE_BTN = 2
+_BACK_BTN = 3
+_FORWARD_BTN = 4
+
+
+class EventTapGestureStateTransitionTests(unittest.TestCase):
+    """Finding #4: the callback's owner-state transitions (arm / release /
+    abort) driven through the real macOS callback code via the fake-Quartz
+    harness above."""
+
+    def setUp(self):
+        MouseHook, quartz = _load_mouse_hook_macos()
+        self.quartz = quartz
+        self.hook = MouseHook()
+        self.hook.configure_gestures(
+            enabled=True, threshold=50, deadzone=40,
+            timeout_ms=3000, cooldown_ms=500, owners={"forward", "back"},
+            hold_floor_ms=80,
+        )
+
+    def _down(self, btn):
+        ev = _FakeCGEvent()
+        ev.fields[self.quartz.kCGMouseEventButtonNumber] = btn
+        return self.hook._event_tap_callback(None, self.quartz.kCGEventOtherMouseDown, ev, None)
+
+    def _up(self, btn):
+        ev = _FakeCGEvent()
+        ev.fields[self.quartz.kCGMouseEventButtonNumber] = btn
+        return self.hook._event_tap_callback(None, self.quartz.kCGEventOtherMouseUp, ev, None)
+
+    def _move(self, dx, dy):
+        ev = _FakeCGEvent()
+        ev.fields[self.quartz.kCGMouseEventDeltaX] = dx
+        ev.fields[self.quartz.kCGMouseEventDeltaY] = dy
+        return self.hook._event_tap_callback(None, self.quartz.kCGEventMouseMoved, ev, None)
+
+    def test_down_then_quick_up_resets_owner_and_dispatches_owner_click(self):
+        result = self._down(_FORWARD_BTN)
+        self.assertIsNone(result)  # down is swallowed/deferred
+        self.assertEqual(self.hook._gesture_owner, "forward")
+        self.assertTrue(self.hook._gesture_active)
+
+        result = self._up(_FORWARD_BTN)  # released well under the 80ms floor
+
+        self.assertIsNone(result)
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+        self.assertEqual(self.quartz.posted_events, [])  # no native replay (Bug C)
+        fired = [self.hook._dispatch_queue.get_nowait(), self.hook._dispatch_queue.get_nowait()]
+        self.assertEqual(
+            [ev.event_type for ev in fired],
+            [MouseEvent.XBUTTON2_DOWN, MouseEvent.XBUTTON2_UP],
+        )
+
+    def test_down_slide_up_fires_tagged_event_and_resets(self):
+        self._down(_FORWARD_BTN)
+        self.hook._gesture_press_at = time.monotonic() - 0.2  # outlive the hold floor
+        self._move(120, 0)  # swallowed, accumulated
+
+        result = self._up(_FORWARD_BTN)
+
+        self.assertIsNone(result)
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+        fired = self.hook._dispatch_queue.get_nowait()
+        self.assertEqual(fired.event_type, MouseEvent.GESTURE_SWIPE_RIGHT)
+        self.assertEqual(fired.raw_data["gesture_owner"], "forward")
+        self.assertEqual(len(self.quartz.posted_events), 0)  # no click replay
+
+    def test_missed_up_then_move_does_not_stay_frozen_past_timeout(self):
+        self.hook.configure_gestures(
+            enabled=True, threshold=50, deadzone=40,
+            timeout_ms=250, cooldown_ms=500, owners={"forward", "back"},
+            hold_floor_ms=80,
+        )
+        self._down(_FORWARD_BTN)
+        self.hook._gesture_press_at = time.monotonic() - 1.0  # older than the timeout
+
+        result = self._move(50, 0)
+
+        # Cursor is no longer frozen: the move is NOT swallowed.
+        self.assertIsNotNone(result)
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+
+        # The shared should_arm_gesture gate is unstuck: a different owner
+        # can arm right away.
+        result = self._down(_BACK_BTN)
+        self.assertIsNone(result)
+        self.assertEqual(self.hook._gesture_owner, "back")
+
+    def test_tap_disabled_event_aborts_a_pending_gesture(self):
+        self._down(_FORWARD_BTN)
+
+        self.hook._event_tap_callback(
+            None, 0xFFFFFFFE, _FakeCGEvent(), None  # _kCGEventTapDisabledByTimeout
+        )
+
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+
+    def test_stop_aborts_a_pending_gesture(self):
+        self._down(_FORWARD_BTN)
+
+        self.hook.stop()
+
+        self.assertIsNone(self.hook._gesture_owner)
+        self.assertFalse(self.hook._gesture_active)
+
+    def test_tap_dispatches_owner_click_pair_not_native_replay(self):
+        """Bug C: a tap of ANY armed owner button fires that button's own
+        (DOWN, UP) MouseEvent pair via the dispatch queue (dual-mode) --
+        never a Quartz.CGEventPost native replay (macOS ignores raw button
+        4/3, so a native replay would be a dead click)."""
+        self.hook.configure_gestures(
+            enabled=True, threshold=50, deadzone=40,
+            timeout_ms=3000, cooldown_ms=500, owners={"forward", "back", "middle"},
+            hold_floor_ms=80,
+        )
+        cases = {
+            _MIDDLE_BTN: (MouseEvent.MIDDLE_DOWN, MouseEvent.MIDDLE_UP),
+            _BACK_BTN: (MouseEvent.XBUTTON1_DOWN, MouseEvent.XBUTTON1_UP),
+            _FORWARD_BTN: (MouseEvent.XBUTTON2_DOWN, MouseEvent.XBUTTON2_UP),
+        }
+        for btn, (expected_down, expected_up) in cases.items():
+            with self.subTest(btn=btn):
+                self._down(btn)
+                self._up(btn)  # quick tap, well under the hold floor
+
+                fired = [
+                    self.hook._dispatch_queue.get_nowait(),
+                    self.hook._dispatch_queue.get_nowait(),
+                ]
+                self.assertEqual(
+                    [ev.event_type for ev in fired], [expected_down, expected_up]
+                )
+                self.assertEqual(self.quartz.posted_events, [])  # no native replay
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -377,6 +377,26 @@ class LogiDeviceRegistryTests(unittest.TestCase):
             with self.subTest(device=device.key):
                 self.assertFalse(device.supports_event_tap_gestures)
 
+    def test_mx_anywhere_2s_spec_supports_tilt_gestures(self):
+        device = resolve_device(product_id=0xB01A)
+
+        self.assertIsNotNone(device)
+        self.assertTrue(device.supports_tilt_gestures)
+        for owner in ("tilt_left", "tilt_right"):
+            for direction in ("left", "right", "up", "down"):
+                key = f"gesture_{owner}_{direction}"
+                with self.subTest(key=key):
+                    self.assertIn(key, device.supported_buttons)
+
+    def test_only_2s_supports_tilt_gestures_and_no_tilt_keys_elsewhere(self):
+        # Opt-in like the event-tap flag; MX Master entries untouched.
+        for device in KNOWN_LOGI_DEVICES:
+            if device.key == "mx_anywhere_2s":
+                continue
+            with self.subTest(device=device.key):
+                self.assertFalse(device.supports_tilt_gestures)
+                self.assertNotIn("gesture_tilt_left_left", device.supported_buttons)
+
 
 class RuntimeSupportedButtonTests(unittest.TestCase):
     @staticmethod
@@ -805,6 +825,58 @@ class RuntimeSupportedButtonTests(unittest.TestCase):
             info.capability_inventory.to_dict()["known_unsupported_controls"],
             [{"cid": "0x01A0", "name": "haptic"}],
         )
+
+    # -- Tilt slide gestures (supports_tilt_gestures capability) --------------
+
+    _TILT_STATIC_BUTTONS = (
+        "middle",
+        "xbutton1",
+        "xbutton2",
+        "hscroll_left",
+        "hscroll_right",
+        "gesture_tilt_left_left",
+        "gesture_tilt_left_up",
+        "gesture_tilt_right_right",
+        "gesture_tilt_right_down",
+    )
+
+    def test_tilt_flag_keeps_tilt_keys(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            self._TILT_STATIC_BUTTONS,
+            [self._control(0x0052, flags=0x0130), self._control(0x0053, flags=0x0130)],
+            supports_tilt_gestures=True,
+        )
+        self.assertIn("gesture_tilt_left_left", buttons)
+        self.assertIn("gesture_tilt_right_down", buttons)
+        self.assertIn("hscroll_left", buttons)
+
+    def test_no_tilt_flag_strips_tilt_keys(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            self._TILT_STATIC_BUTTONS,
+            [self._control(0x0052, flags=0x0130), self._control(0x0053, flags=0x0130)],
+        )
+        self.assertNotIn("gesture_tilt_left_left", buttons)
+        self.assertNotIn("gesture_tilt_right_down", buttons)
+        # OS-level hscroll (the tilt tap target) is unaffected.
+        self.assertIn("hscroll_left", buttons)
+
+    def test_mx_anywhere_2s_exposes_tilt_keys_via_capability_model(self):
+        info = build_connected_device_info(
+            product_id=0xB01A,
+            reprog_controls=[
+                self._control(0x0052, flags=0x0130),
+                self._control(0x0053, flags=0x0130),
+                self._control(0x0056, flags=0x0130),
+            ],
+        )
+
+        self.assertTrue(info.capability_inventory.supports_tilt_gestures)
+        self.assertTrue(info.capability_inventory.to_dict()["supports_tilt_gestures"])
+        for owner in ("tilt_left", "tilt_right"):
+            for direction in ("left", "right", "up", "down"):
+                key = f"gesture_{owner}_{direction}"
+                with self.subTest(key=key):
+                    self.assertIn(key, info.supported_buttons)
 
 
 if __name__ == "__main__":

--- a/tests/test_logi_devices.py
+++ b/tests/test_logi_devices.py
@@ -358,6 +358,25 @@ class LogiDeviceRegistryTests(unittest.TestCase):
         self.assertIsNotNone(device)
         self.assertIs(get_buttons_for_layout("mx_anywhere_2s"), device.supported_buttons)
 
+    def test_mx_anywhere_2s_spec_supports_event_tap_gestures(self):
+        device = resolve_device(product_id=0xB01A)
+
+        self.assertIsNotNone(device)
+        self.assertTrue(device.supports_event_tap_gestures)
+        for owner in ("back", "forward", "middle"):
+            for direction in ("left", "right", "up", "down"):
+                key = f"gesture_{owner}_{direction}"
+                with self.subTest(key=key):
+                    self.assertIn(key, device.supported_buttons)
+
+    def test_other_known_devices_do_not_support_event_tap_gestures(self):
+        # supports_event_tap_gestures is opt-in; only the 2S has it in issue #005.
+        for device in KNOWN_LOGI_DEVICES:
+            if device.key == "mx_anywhere_2s":
+                continue
+            with self.subTest(device=device.key):
+                self.assertFalse(device.supports_event_tap_gestures)
+
 
 class RuntimeSupportedButtonTests(unittest.TestCase):
     @staticmethod
@@ -674,6 +693,92 @@ class RuntimeSupportedButtonTests(unittest.TestCase):
         self.assertIn("gesture_up", info.supported_buttons)
         self.assertIn("hscroll_left", info.supported_buttons)
         self.assertIn("hscroll_right", info.supported_buttons)
+
+    # -- Per-button event-tap gestures (issue #002) --------------------------
+
+    _EVENT_TAP_STATIC_BUTTONS = (
+        "middle",
+        "xbutton1",
+        "xbutton2",
+        "gesture",
+        "gesture_left",
+        "gesture_right",
+        "gesture_up",
+        "gesture_down",
+        "gesture_back_left",
+        "gesture_back_right",
+        "gesture_forward_up",
+        "gesture_forward_down",
+        "gesture_middle_left",
+        "gesture_middle_right",
+    )
+
+    def test_event_tap_only_device_keeps_per_button_gesture_keys_without_rawxy(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            self._EVENT_TAP_STATIC_BUTTONS,
+            [self._control(0x0052, flags=0x0130), self._control(0x0053, flags=0x0130)],
+            supports_event_tap_gestures=True,
+        )
+
+        self.assertIn("gesture_back_left", buttons)
+        self.assertIn("gesture_forward_up", buttons)
+        self.assertIn("gesture_middle_right", buttons)
+        # No divertable HID gesture control present, so the legacy HID path
+        # stays stripped -- the event-tap flag doesn't resurrect it.
+        self.assertNotIn("gesture", buttons)
+        self.assertNotIn("gesture_left", buttons)
+
+    def test_device_with_neither_flag_still_strips_all_gesture_keys(self):
+        buttons = derive_supported_buttons_from_reprog_controls(
+            self._EVENT_TAP_STATIC_BUTTONS,
+            [self._control(0x0052, flags=0x0130), self._control(0x0053, flags=0x0130)],
+        )
+
+        self.assertNotIn("gesture_back_left", buttons)
+        self.assertNotIn("gesture_forward_up", buttons)
+        self.assertNotIn("gesture_middle_right", buttons)
+        self.assertNotIn("gesture", buttons)
+        self.assertNotIn("gesture_left", buttons)
+
+    def test_real_hid_gesture_control_unaffected_by_event_tap_flag(self):
+        # MX Master regression guard: a device with a real divertable RawXY
+        # gesture control keeps working exactly as before, and the (absent)
+        # event-tap flag does not add per-button keys it never declared.
+        buttons = derive_supported_buttons_from_reprog_controls(
+            self._EVENT_TAP_STATIC_BUTTONS,
+            [self._control(0x00D7, flags=0x03A0)],
+            gesture_cids=(0x00D7,),
+            active_gesture_cid=0x00D7,
+            gesture_rawxy_enabled=True,
+            supports_event_tap_gestures=False,
+        )
+
+        self.assertIn("gesture", buttons)
+        self.assertIn("gesture_left", buttons)
+        self.assertIn("gesture_right", buttons)
+        self.assertNotIn("gesture_back_left", buttons)
+        self.assertNotIn("gesture_forward_up", buttons)
+
+    def test_mx_anywhere_2s_exposes_per_button_gesture_keys_via_capability_model(self):
+        info = build_connected_device_info(
+            product_id=0xB01A,
+            reprog_controls=[
+                self._control(0x0052, flags=0x0130),
+                self._control(0x0053, flags=0x0130),
+                self._control(0x0056, flags=0x0130),
+            ],
+        )
+
+        self.assertTrue(info.capability_inventory.supports_event_tap_gestures)
+        for owner in ("back", "forward", "middle"):
+            for direction in ("left", "right", "up", "down"):
+                key = f"gesture_{owner}_{direction}"
+                with self.subTest(key=key):
+                    self.assertIn(key, info.supported_buttons)
+        # No real HID gesture control on the 2S -- the legacy global path
+        # stays inert (stripped), same as before this feature existed.
+        self.assertNotIn("gesture", info.supported_buttons)
+        self.assertNotIn("gesture_left", info.supported_buttons)
 
     def test_mx_master_4_haptic_control_does_not_create_supported_button(self):
         info = build_connected_device_info(

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -20,8 +20,8 @@ from core.accessibility import is_process_trusted
 from core.config import (
     BUTTON_NAMES, load_config, save_config, get_active_mappings,
     PROFILE_BUTTON_NAMES, set_mapping, create_profile, delete_profile,
-    get_icon_for_exe, GESTURE_OWNERS, GESTURE_DIRECTIONS,
-    GESTURE_HOLD_FLOOR_MS_DEFAULT,
+    get_icon_for_exe, BUTTON_GESTURE_OWNERS, TILT_GESTURE_OWNERS, GESTURE_DIRECTIONS,
+    GESTURE_HOLD_FLOOR_MS_DEFAULT, TILT_GESTURE_RELEASE_MS_DEFAULT,
 )
 from core import app_catalog
 from core.device_layouts import get_device_layout, get_manual_layout_choices
@@ -550,7 +550,7 @@ class Backend(QObject):
         gesture on -- mirrors the capability narrowing in core/logi_devices.py."""
         btns = self._effective_supported_buttons
         return [
-            owner for owner in GESTURE_OWNERS
+            owner for owner in BUTTON_GESTURE_OWNERS
             if btns is None or f"gesture_{owner}_left" in btns
         ]
 
@@ -559,7 +559,34 @@ class Backend(QObject):
         """Owners with gesture mode toggled on. Persisted independently of the 4
         direction bindings, so turning gesture mode off never drops them."""
         flags = self._cfg.get("settings", {}).get("gesture_owner_enabled", {})
-        return [owner for owner in GESTURE_OWNERS if flags.get(owner, False)]
+        return [owner for owner in BUTTON_GESTURE_OWNERS if flags.get(owner, False)]
+
+    @Property(list, notify=deviceLayoutChanged)
+    def tiltGestureEligibleOwners(self):
+        """Tilt owners (tilt_left/tilt_right) the connected device can host a
+        tilt slide gesture on -- mirrors gestureEligibleOwners for the hscroll
+        pulse stream instead of a per-button event tap."""
+        btns = self._effective_supported_buttons
+        return [
+            owner for owner in TILT_GESTURE_OWNERS
+            if btns is None or f"gesture_{owner}_left" in btns
+        ]
+
+    @Property(list, notify=settingsChanged)
+    def tiltGestureEnabledOwners(self):
+        """Tilt owners with gesture mode toggled on. Shares gesture_owner_enabled
+        storage with the per-button owners (disjoint key space) -- turning it off
+        never drops the 4 direction bindings, and leaves the hscroll tap untouched."""
+        flags = self._cfg.get("settings", {}).get("gesture_owner_enabled", {})
+        return [owner for owner in TILT_GESTURE_OWNERS if flags.get(owner, False)]
+
+    @Property(int, notify=settingsChanged)
+    def tiltGestureReleaseMs(self):
+        """Max gap (ms) between hscroll pulses before a tilt gesture is treated
+        as released -- the tilt-path sibling of gestureHoldFloorMs."""
+        return int(self._cfg.get("settings", {}).get(
+            "tilt_gesture_release_ms", TILT_GESTURE_RELEASE_MS_DEFAULT
+        ))
 
     @Property(str, notify=settingsChanged)
     def appearanceMode(self):
@@ -1440,7 +1467,7 @@ class Backend(QObject):
         """Toggle gesture mode for a button. Independent of the 4 direction
         bindings -- turning it off leaves them in config untouched, and leaves
         the button's normal single-action mapping untouched too."""
-        if owner not in GESTURE_OWNERS:
+        if owner not in BUTTON_GESTURE_OWNERS:
             return
         flags = self._cfg.setdefault("settings", {}).setdefault("gesture_owner_enabled", {})
         enabled = bool(enabled)
@@ -1455,7 +1482,7 @@ class Backend(QObject):
     @Slot(str, str, result=list)
     def gestureOwnerBindings(self, profileName, owner):
         """Return the 4 direction bindings (gesture_<owner>_<dir>) for a profile."""
-        if owner not in GESTURE_OWNERS:
+        if owner not in BUTTON_GESTURE_OWNERS:
             return []
         profiles = self._cfg.get("profiles", {})
         mappings = profiles.get(profileName, {}).get("mappings", {})
@@ -1472,9 +1499,61 @@ class Backend(QObject):
     @Slot(str, str, str, str)
     def setGestureOwnerBinding(self, profileName, owner, direction, actionId):
         """Set one direction's action for a per-button gesture owner."""
-        if owner not in GESTURE_OWNERS or direction not in GESTURE_DIRECTIONS:
+        if owner not in BUTTON_GESTURE_OWNERS or direction not in GESTURE_DIRECTIONS:
             return
         self.setProfileMapping(profileName, f"gesture_{owner}_{direction}", actionId)
+
+    @Slot(str, bool)
+    def setTiltGestureOwnerEnabled(self, owner, enabled):
+        """Toggle tilt gesture mode for tilt_left/tilt_right. Independent of the
+        4 direction bindings and of the hscroll_left/hscroll_right tap mapping."""
+        if owner not in TILT_GESTURE_OWNERS:
+            return
+        flags = self._cfg.setdefault("settings", {}).setdefault("gesture_owner_enabled", {})
+        enabled = bool(enabled)
+        if flags.get(owner, False) == enabled:
+            return
+        flags[owner] = enabled
+        save_config(self._cfg)
+        if self._engine:
+            self._engine.reload_mappings()
+        self.settingsChanged.emit()
+
+    @Slot(str, str, result=list)
+    def tiltGestureOwnerBindings(self, profileName, owner):
+        """Return the 4 direction bindings (gesture_<owner>_<dir>) for a tilt owner."""
+        if owner not in TILT_GESTURE_OWNERS:
+            return []
+        profiles = self._cfg.get("profiles", {})
+        mappings = profiles.get(profileName, {}).get("mappings", {})
+        result = []
+        for direction in GESTURE_DIRECTIONS:
+            aid = mappings.get(f"gesture_{owner}_{direction}", "none")
+            result.append({
+                "direction": direction,
+                "actionId": aid,
+                "actionLabel": _action_label(aid),
+            })
+        return result
+
+    @Slot(str, str, str, str)
+    def setTiltGestureOwnerBinding(self, profileName, owner, direction, actionId):
+        """Set one direction's action for a tilt gesture owner."""
+        if owner not in TILT_GESTURE_OWNERS or direction not in GESTURE_DIRECTIONS:
+            return
+        self.setProfileMapping(profileName, f"gesture_{owner}_{direction}", actionId)
+
+    @Slot(int)
+    def setTiltGestureReleaseMs(self, value):
+        """Clamp mirrors core.config._migrate's floor (>=50ms)."""
+        clamped = max(50, int(value))
+        if clamped == self.tiltGestureReleaseMs:
+            return
+        self._cfg.setdefault("settings", {})["tilt_gesture_release_ms"] = clamped
+        save_config(self._cfg)
+        if self._engine:
+            self._engine.reload_mappings()
+        self.settingsChanged.emit()
 
     @Slot(str)
     def setAppearanceMode(self, mode):

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -20,7 +20,8 @@ from core.accessibility import is_process_trusted
 from core.config import (
     BUTTON_NAMES, load_config, save_config, get_active_mappings,
     PROFILE_BUTTON_NAMES, set_mapping, create_profile, delete_profile,
-    get_icon_for_exe,
+    get_icon_for_exe, GESTURE_OWNERS, GESTURE_DIRECTIONS,
+    GESTURE_HOLD_FLOOR_MS_DEFAULT,
 )
 from core import app_catalog
 from core.device_layouts import get_device_layout, get_manual_layout_choices
@@ -78,6 +79,12 @@ def _action_label(action_id):
     if action_id.startswith("custom:"):
         return custom_action_label(action_id)
     return ACTIONS.get(action_id, {}).get("label", "Do Nothing")
+
+
+# Physical hotspot button -> the per-button gesture owner name it can host
+# (issue #001 namespaced config keys). "gesture" (the HID thumb button) isn't
+# an owner here -- it keeps its own always-on 4-direction panel.
+_GESTURE_OWNER_FOR_BUTTON = {"xbutton1": "back", "xbutton2": "forward", "middle": "middle"}
 
 
 def _qt_shortcut_modifier_name(name):
@@ -529,6 +536,30 @@ class Backend(QObject):
     @Property(int, notify=settingsChanged)
     def gestureThreshold(self):
         return int(self._cfg.get("settings", {}).get("gesture_threshold", 50))
+
+    @Property(int, notify=settingsChanged)
+    def gestureHoldFloorMs(self):
+        """Min hold time (ms) before a slide arms a per-button gesture (issue #001)."""
+        return int(self._cfg.get("settings", {}).get(
+            "gesture_hold_floor_ms", GESTURE_HOLD_FLOOR_MS_DEFAULT
+        ))
+
+    @Property(list, notify=deviceLayoutChanged)
+    def gestureEligibleOwners(self):
+        """Owners (back/forward/middle) the connected device can host a per-button
+        gesture on -- mirrors the capability narrowing in core/logi_devices.py."""
+        btns = self._effective_supported_buttons
+        return [
+            owner for owner in GESTURE_OWNERS
+            if btns is None or f"gesture_{owner}_left" in btns
+        ]
+
+    @Property(list, notify=settingsChanged)
+    def gestureEnabledOwners(self):
+        """Owners with gesture mode toggled on. Persisted independently of the 4
+        direction bindings, so turning gesture mode off never drops them."""
+        flags = self._cfg.get("settings", {}).get("gesture_owner_enabled", {})
+        return [owner for owner in GESTURE_OWNERS if flags.get(owner, False)]
 
     @Property(str, notify=settingsChanged)
     def appearanceMode(self):
@@ -1386,6 +1417,64 @@ class Backend(QObject):
         if self._engine:
             self._engine.reload_mappings()
         self.settingsChanged.emit()
+
+    @Slot(int)
+    def setGestureHoldFloorMs(self, value):
+        clamped = max(0, int(value))
+        if clamped == self.gestureHoldFloorMs:
+            return
+        self._cfg.setdefault("settings", {})["gesture_hold_floor_ms"] = clamped
+        save_config(self._cfg)
+        if self._engine:
+            self._engine.reload_mappings()
+        self.settingsChanged.emit()
+
+    @Slot(str, result=str)
+    def gestureOwnerForButton(self, buttonKey):
+        """Resolve a hotspot button key (xbutton1/xbutton2/middle) to its gesture
+        owner name, or "" if that button can't own a per-button gesture."""
+        return _GESTURE_OWNER_FOR_BUTTON.get(buttonKey, "")
+
+    @Slot(str, bool)
+    def setGestureOwnerEnabled(self, owner, enabled):
+        """Toggle gesture mode for a button. Independent of the 4 direction
+        bindings -- turning it off leaves them in config untouched, and leaves
+        the button's normal single-action mapping untouched too."""
+        if owner not in GESTURE_OWNERS:
+            return
+        flags = self._cfg.setdefault("settings", {}).setdefault("gesture_owner_enabled", {})
+        enabled = bool(enabled)
+        if flags.get(owner, False) == enabled:
+            return
+        flags[owner] = enabled
+        save_config(self._cfg)
+        if self._engine:
+            self._engine.reload_mappings()
+        self.settingsChanged.emit()
+
+    @Slot(str, str, result=list)
+    def gestureOwnerBindings(self, profileName, owner):
+        """Return the 4 direction bindings (gesture_<owner>_<dir>) for a profile."""
+        if owner not in GESTURE_OWNERS:
+            return []
+        profiles = self._cfg.get("profiles", {})
+        mappings = profiles.get(profileName, {}).get("mappings", {})
+        result = []
+        for direction in GESTURE_DIRECTIONS:
+            aid = mappings.get(f"gesture_{owner}_{direction}", "none")
+            result.append({
+                "direction": direction,
+                "actionId": aid,
+                "actionLabel": _action_label(aid),
+            })
+        return result
+
+    @Slot(str, str, str, str)
+    def setGestureOwnerBinding(self, profileName, owner, direction, actionId):
+        """Set one direction's action for a per-button gesture owner."""
+        if owner not in GESTURE_OWNERS or direction not in GESTURE_DIRECTIONS:
+            return
+        self.setProfileMapping(profileName, f"gesture_{owner}_{direction}", actionId)
 
     @Slot(str)
     def setAppearanceMode(self, mode):

--- a/ui/qml/MousePage.qml
+++ b/ui/qml/MousePage.qml
@@ -110,6 +110,7 @@ Item {
         selectedButtonName = ""
         selectedActionId = ""
         refreshSelectedGestureBindings()
+        refreshTiltGestureBindings()
     }
 
     function appMatchesSearch(app, query) {
@@ -394,6 +395,36 @@ Item {
         return selectedGestureBindingsState[direction] || "none"
     }
 
+    // ── Tilt (horizontal-scroll) slide gesture state ──────────────────
+    // Unlike the per-button owners above, one hotspot (selectedButton ==
+    // "hscroll_left") hosts TWO tilt owners -- tilt_left and tilt_right --
+    // each independently toggleable, so there's no single selectedGestureOwner.
+    readonly property bool tiltLeftEligible: backend.tiltGestureEligibleOwners.indexOf("tilt_left") !== -1
+    readonly property bool tiltRightEligible: backend.tiltGestureEligibleOwners.indexOf("tilt_right") !== -1
+    readonly property bool tiltLeftEnabled: backend.tiltGestureEnabledOwners.indexOf("tilt_left") !== -1
+    readonly property bool tiltRightEnabled: backend.tiltGestureEnabledOwners.indexOf("tilt_right") !== -1
+    property var tiltLeftBindingsState: ({})
+    property var tiltRightBindingsState: ({})
+
+    function refreshTiltGestureBindings() {
+        var l = backend.tiltGestureOwnerBindings(selectedProfile, "tilt_left")
+        var ls = ({})
+        for (var i = 0; i < l.length; i++)
+            ls[l[i].direction] = l[i].actionId
+        tiltLeftBindingsState = ls
+
+        var r = backend.tiltGestureOwnerBindings(selectedProfile, "tilt_right")
+        var rs = ({})
+        for (var j = 0; j < r.length; j++)
+            rs[r[j].direction] = r[j].actionId
+        tiltRightBindingsState = rs
+    }
+
+    function tiltBindingActionId(owner, direction) {
+        var state = owner === "tilt_left" ? tiltLeftBindingsState : tiltRightBindingsState
+        return state[direction] || "none"
+    }
+
     function selectButton(key) {
         if (selectedButton === key) {
             selectedButton = ""
@@ -430,6 +461,7 @@ Item {
         function onMappingsChanged() {
             refreshSelectedProfileMappings()
             refreshSelectedGestureBindings()
+            refreshTiltGestureBindings()
             if (selectedButton === "") return
             var mapping = mappingFor(selectedButton)
             if (mapping) {
@@ -1368,6 +1400,224 @@ Item {
                                                 }
                                                 backend.setProfileMapping(
                                                     selectedProfile, "hscroll_right", aid)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Tilt-left slide gesture: toggle + 4-direction panel.
+                            // Mirrors the per-button gesture panel below, but the
+                            // hotspot is the hscroll pulse stream (tilt_left owner)
+                            // rather than a HID event-tap button, and the tap action
+                            // above (scroll left) keeps firing on a quick tap either way.
+                            Column {
+                                width: parent.width
+                                spacing: 14
+                                visible: selectedButton === "hscroll_left" && tiltLeftEligible
+
+                                RowLayout {
+                                    width: parent.width
+                                    spacing: 12
+
+                                    Column {
+                                        Layout.fillWidth: true
+                                        spacing: 3
+
+                                        Text {
+                                            text: "Tilt left gesture mode"
+                                            font { family: uiState.fontFamily; pixelSize: 13; bold: true }
+                                            color: theme.textPrimary
+                                        }
+                                        Text {
+                                            width: parent.width
+                                            wrapMode: Text.WordWrap
+                                            text: "Hold the tilt left and slide for a directional action. A quick tap still scrolls left."
+                                            font { family: uiState.fontFamily; pixelSize: 11 }
+                                            color: theme.textSecondary
+                                        }
+                                    }
+
+                                    Switch {
+                                        checked: tiltLeftEnabled
+                                        text: checked ? s["mouse.on"] : s["mouse.off"]
+                                        Material.accent: theme.accent
+                                        onToggled: backend.setTiltGestureOwnerEnabled("tilt_left", checked)
+                                    }
+                                }
+
+                                Text {
+                                    visible: tiltLeftEnabled
+                                    width: parent.width
+                                    wrapMode: Text.WordWrap
+                                    text: "While tilt left gesture mode is on, horizontal scroll left is suppressed on that direction -- only a quick tap still scrolls."
+                                    font { family: uiState.fontFamily; pixelSize: 11 }
+                                    color: theme.textDim
+                                }
+
+                                Column {
+                                    width: parent.width
+                                    spacing: 14
+                                    visible: tiltLeftEnabled
+
+                                    Rectangle {
+                                        width: parent.width
+                                        height: 1
+                                        color: theme.border
+                                    }
+
+                                    Text {
+                                        text: s["mouse.swipe_actions"]
+                                        font { family: uiState.fontFamily; pixelSize: 11;
+                                               capitalization: Font.AllUppercase; letterSpacing: 1 }
+                                        color: theme.textDim
+                                    }
+
+                                    Repeater {
+                                        model: ["left", "right", "up", "down"]
+                                        delegate: RowLayout {
+                                            width: parent.width
+                                            spacing: 12
+
+                                            Text {
+                                                text: modelData === "left" ? s["mouse.swipe_left"]
+                                                      : modelData === "right" ? s["mouse.swipe_right"]
+                                                      : modelData === "up" ? s["mouse.swipe_up"]
+                                                      : s["mouse.swipe_down"]
+                                                Layout.preferredWidth: 100
+                                                font { family: uiState.fontFamily; pixelSize: 12 }
+                                                color: theme.textPrimary
+                                            }
+
+                                            ComboBox {
+                                                Layout.fillWidth: true
+                                                model: backend.allActions
+                                                textRole: "label"
+                                                delegate: actionComboDelegate
+                                                Material.accent: theme.accent
+                                                font { family: uiState.fontFamily; pixelSize: 11 }
+                                                currentIndex: actionIndexForId(tiltBindingActionId("tilt_left", modelData))
+                                                displayText: isCustomAction(tiltBindingActionId("tilt_left", modelData))
+                                                             ? customLabel(tiltBindingActionId("tilt_left", modelData))
+                                                             : (lm.strings, lm.trAction(currentText))
+                                                onActivated: function(index) {
+                                                    var aid = backend.allActions[index].id
+                                                    if (aid === "__custom__") {
+                                                        keyCaptureDialog.open(
+                                                            selectedProfile,
+                                                            "gesture_tilt_left_" + modelData)
+                                                        return
+                                                    }
+                                                    backend.setTiltGestureOwnerBinding(
+                                                        selectedProfile, "tilt_left", modelData, aid)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Tilt-right slide gesture: same shape as tilt-left above.
+                            Column {
+                                width: parent.width
+                                spacing: 14
+                                visible: selectedButton === "hscroll_left" && tiltRightEligible
+
+                                RowLayout {
+                                    width: parent.width
+                                    spacing: 12
+
+                                    Column {
+                                        Layout.fillWidth: true
+                                        spacing: 3
+
+                                        Text {
+                                            text: "Tilt right gesture mode"
+                                            font { family: uiState.fontFamily; pixelSize: 13; bold: true }
+                                            color: theme.textPrimary
+                                        }
+                                        Text {
+                                            width: parent.width
+                                            wrapMode: Text.WordWrap
+                                            text: "Hold the tilt right and slide for a directional action. A quick tap still scrolls right."
+                                            font { family: uiState.fontFamily; pixelSize: 11 }
+                                            color: theme.textSecondary
+                                        }
+                                    }
+
+                                    Switch {
+                                        checked: tiltRightEnabled
+                                        text: checked ? s["mouse.on"] : s["mouse.off"]
+                                        Material.accent: theme.accent
+                                        onToggled: backend.setTiltGestureOwnerEnabled("tilt_right", checked)
+                                    }
+                                }
+
+                                Text {
+                                    visible: tiltRightEnabled
+                                    width: parent.width
+                                    wrapMode: Text.WordWrap
+                                    text: "While tilt right gesture mode is on, horizontal scroll right is suppressed on that direction -- only a quick tap still scrolls."
+                                    font { family: uiState.fontFamily; pixelSize: 11 }
+                                    color: theme.textDim
+                                }
+
+                                Column {
+                                    width: parent.width
+                                    spacing: 14
+                                    visible: tiltRightEnabled
+
+                                    Rectangle {
+                                        width: parent.width
+                                        height: 1
+                                        color: theme.border
+                                    }
+
+                                    Text {
+                                        text: s["mouse.swipe_actions"]
+                                        font { family: uiState.fontFamily; pixelSize: 11;
+                                               capitalization: Font.AllUppercase; letterSpacing: 1 }
+                                        color: theme.textDim
+                                    }
+
+                                    Repeater {
+                                        model: ["left", "right", "up", "down"]
+                                        delegate: RowLayout {
+                                            width: parent.width
+                                            spacing: 12
+
+                                            Text {
+                                                text: modelData === "left" ? s["mouse.swipe_left"]
+                                                      : modelData === "right" ? s["mouse.swipe_right"]
+                                                      : modelData === "up" ? s["mouse.swipe_up"]
+                                                      : s["mouse.swipe_down"]
+                                                Layout.preferredWidth: 100
+                                                font { family: uiState.fontFamily; pixelSize: 12 }
+                                                color: theme.textPrimary
+                                            }
+
+                                            ComboBox {
+                                                Layout.fillWidth: true
+                                                model: backend.allActions
+                                                textRole: "label"
+                                                delegate: actionComboDelegate
+                                                Material.accent: theme.accent
+                                                font { family: uiState.fontFamily; pixelSize: 11 }
+                                                currentIndex: actionIndexForId(tiltBindingActionId("tilt_right", modelData))
+                                                displayText: isCustomAction(tiltBindingActionId("tilt_right", modelData))
+                                                             ? customLabel(tiltBindingActionId("tilt_right", modelData))
+                                                             : (lm.strings, lm.trAction(currentText))
+                                                onActivated: function(index) {
+                                                    var aid = backend.allActions[index].id
+                                                    if (aid === "__custom__") {
+                                                        keyCaptureDialog.open(
+                                                            selectedProfile,
+                                                            "gesture_tilt_right_" + modelData)
+                                                        return
+                                                    }
+                                                    backend.setTiltGestureOwnerBinding(
+                                                        selectedProfile, "tilt_right", modelData, aid)
+                                                }
                                             }
                                         }
                                     }

--- a/ui/qml/MousePage.qml
+++ b/ui/qml/MousePage.qml
@@ -109,6 +109,7 @@ Item {
         selectedButton = ""
         selectedButtonName = ""
         selectedActionId = ""
+        refreshSelectedGestureBindings()
     }
 
     function appMatchesSearch(app, query) {
@@ -367,11 +368,38 @@ Item {
                                              || gestureUpActionId !== "none"
                                              || gestureDownActionId !== "none"
 
+    // ── Per-button slide gesture state (issue #006, config keys from #001) ──
+    // selectedButton is a hotspot key ("xbutton1"/"xbutton2"/"middle"/...);
+    // selectedGestureOwner is "" unless that hotspot can own a per-button gesture.
+    readonly property string selectedGestureOwner: backend.gestureOwnerForButton(selectedButton)
+    readonly property bool selectedGestureOwnerEligible: selectedGestureOwner !== ""
+                                             && backend.gestureEligibleOwners.indexOf(selectedGestureOwner) !== -1
+    readonly property bool selectedGestureOwnerEnabled: selectedGestureOwner !== ""
+                                             && backend.gestureEnabledOwners.indexOf(selectedGestureOwner) !== -1
+    property var selectedGestureBindingsState: ({})
+
+    function refreshSelectedGestureBindings() {
+        if (selectedGestureOwner === "") {
+            selectedGestureBindingsState = {}
+            return
+        }
+        var bindings = backend.gestureOwnerBindings(selectedProfile, selectedGestureOwner)
+        var state = ({})
+        for (var i = 0; i < bindings.length; i++)
+            state[bindings[i].direction] = bindings[i].actionId
+        selectedGestureBindingsState = state
+    }
+
+    function gestureBindingActionId(direction) {
+        return selectedGestureBindingsState[direction] || "none"
+    }
+
     function selectButton(key) {
         if (selectedButton === key) {
             selectedButton = ""
             selectedButtonName = ""
             selectedActionId = ""
+            refreshSelectedGestureBindings()
             return
         }
         var mapping = mappingFor(key)
@@ -379,6 +407,7 @@ Item {
             selectedButton = key
             selectedButtonName = lm.trButton(mapping.name)
             selectedActionId = mapping.actionId
+            refreshSelectedGestureBindings()
         }
     }
 
@@ -400,6 +429,7 @@ Item {
         target: backend
         function onMappingsChanged() {
             refreshSelectedProfileMappings()
+            refreshSelectedGestureBindings()
             if (selectedButton === "") return
             var mapping = mappingFor(selectedButton)
             if (mapping) {
@@ -491,6 +521,7 @@ Item {
                 selectedButton = ""
                 selectedButtonName = ""
                 selectedActionId = ""
+                refreshSelectedGestureBindings()
             }
         }
     }
@@ -1577,6 +1608,117 @@ Item {
                                 }
                             }
 
+                            // Per-button slide gesture: toggle + 4-direction panel
+                            // (issue #006). Reuses the swipe-panel layout above, but
+                            // attached to whichever eligible button (back/forward/
+                            // middle) is selected, via the namespaced gesture_<owner>_
+                            // <dir> keys (issue #001) instead of the HID gesture keys.
+                            Column {
+                                width: parent.width
+                                spacing: 14
+                                visible: selectedGestureOwnerEligible
+
+                                RowLayout {
+                                    width: parent.width
+                                    spacing: 12
+
+                                    Column {
+                                        Layout.fillWidth: true
+                                        spacing: 3
+
+                                        Text {
+                                            text: "Gesture mode"
+                                            font { family: uiState.fontFamily; pixelSize: 13; bold: true }
+                                            color: theme.textPrimary
+                                        }
+                                        Text {
+                                            width: parent.width
+                                            wrapMode: Text.WordWrap
+                                            text: "Hold and slide for a directional action. A quick tap still runs the normal action above."
+                                            font { family: uiState.fontFamily; pixelSize: 11 }
+                                            color: theme.textSecondary
+                                        }
+                                    }
+
+                                    Switch {
+                                        checked: selectedGestureOwnerEnabled
+                                        text: checked ? s["mouse.on"] : s["mouse.off"]
+                                        Material.accent: theme.accent
+                                        onToggled: backend.setGestureOwnerEnabled(selectedGestureOwner, checked)
+                                    }
+                                }
+
+                                Text {
+                                    visible: selectedGestureOwner === "middle" && selectedGestureOwnerEnabled
+                                    width: parent.width
+                                    wrapMode: Text.WordWrap
+                                    text: "Middle-click gets a brief hold delay while gesture mode is on, so Mouser can tell a click from a slide. If you use middle-click for paste or open-in-new-tab, expect a short delay before it fires. Middle-button drag/autoscroll is swallowed while gesture mode is on."
+                                    font { family: uiState.fontFamily; pixelSize: 11 }
+                                    color: theme.textDim
+                                }
+
+                                Column {
+                                    width: parent.width
+                                    spacing: 14
+                                    visible: selectedGestureOwnerEnabled
+
+                                    Rectangle {
+                                        width: parent.width
+                                        height: 1
+                                        color: theme.border
+                                    }
+
+                                    Text {
+                                        text: s["mouse.swipe_actions"]
+                                        font { family: uiState.fontFamily; pixelSize: 11;
+                                               capitalization: Font.AllUppercase; letterSpacing: 1 }
+                                        color: theme.textDim
+                                    }
+
+                                    Repeater {
+                                        model: ["left", "right", "up", "down"]
+                                        delegate: RowLayout {
+                                            width: parent.width
+                                            spacing: 12
+
+                                            Text {
+                                                text: modelData === "left" ? s["mouse.swipe_left"]
+                                                      : modelData === "right" ? s["mouse.swipe_right"]
+                                                      : modelData === "up" ? s["mouse.swipe_up"]
+                                                      : s["mouse.swipe_down"]
+                                                Layout.preferredWidth: 100
+                                                font { family: uiState.fontFamily; pixelSize: 12 }
+                                                color: theme.textPrimary
+                                            }
+
+                                            ComboBox {
+                                                Layout.fillWidth: true
+                                                model: backend.allActions
+                                                textRole: "label"
+                                                delegate: actionComboDelegate
+                                                Material.accent: theme.accent
+                                                font { family: uiState.fontFamily; pixelSize: 11 }
+                                                currentIndex: actionIndexForId(gestureBindingActionId(modelData))
+                                                displayText: isCustomAction(gestureBindingActionId(modelData))
+                                                             ? customLabel(gestureBindingActionId(modelData))
+                                                             : (lm.strings, lm.trAction(currentText))
+                                                onActivated: function(index) {
+                                                    var aid = backend.allActions[index].id
+                                                    if (aid === "__custom__") {
+                                                        keyCaptureDialog.open(
+                                                            selectedProfile,
+                                                            "gesture_" + selectedGestureOwner + "_" + modelData)
+                                                        return
+                                                    }
+                                                    backend.setGestureOwnerBinding(
+                                                        selectedProfile, selectedGestureOwner, modelData, aid)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
                             // Single button: categorized chips
                             Column {
                                 width: parent.width
@@ -1585,6 +1727,7 @@ Item {
                                          && selectedButton !== "hscroll_left"
                                          && !(selectedButton === "gesture"
                                               && backend.supportsGestureDirections)
+                                         && !(selectedGestureOwnerEligible && selectedGestureOwnerEnabled)
 
                                 Repeater {
                                     model: backend.actionCategories


### PR DESCRIPTION
> ⚠️ **Stacked on #228.** This branch builds on the per-button event-tap gesture
> engine from #228, which isn't on `master` yet — so this PR's diff currently
> shows **both** #228's button-gesture commit *and* this tilt commit. **The change
> owned by this PR is the single commit `eeac596` "Add tilt (horizontal-scroll)
> slide gestures"** — please review that one. Once #228 merges I'll rebase this so
> only the tilt diff remains.

## Tilt (horizontal-scroll) slide gestures

Extends the per-button gesture feature (#228) to the wheel tilt: hold a tilt
direction (left/right) and slide up/down/left/right to fire a bound action; a
quick tilt-tap still fires its normal horizontal-scroll action once (debounced).

### How it works
The tilt has no button down/up, so it arms off the horizontal-scroll pulse
stream and releases ~150ms after the last pulse (above the ~110ms inter-pulse
gap, so a held stream keeps the gesture armed instead of fragmenting). Gestures
fire the instant the slide crosses the threshold (mid-hold), not on release, so
a fragmenting pulse stream can't drop them; the release timer only resolves the
tap case.

### Scope & caveats (being upfront)
- **Opt-in per tilt direction**, gated by a `supports_tilt_gestures` catalog flag
  set only on the MX Anywhere 2S (the tested device). No mouse is opted in
  implicitly.
- **Off by default** — a tilt direction only arms with a bound direction + the UI
  toggle on + a tilt-eligible device.
- **macOS only** (mirrors #228). Windows/Linux share the same gap — clean follow-up.
- Reuses #228's direction engine, routing, config keys, and gesture UI panel.
- The button-gesture and MX Master HID++ paths are unchanged.

### Testing
- Unit-tested (objc-free, runs in CI): config schema, capability gating, engine
  routing, and the kernel's arm / fire-on-slide / tap-on-release / release-timer
  state machine via a fake-Quartz harness.
- Hardware-verified on a real MX Anywhere 2S: hold+slide in all 4 directions,
  quick tap fires the hscroll action, no misfire, no regression to button
  gestures or to normal horizontal scroll when disabled.
