### PR TITLE
fix(macos): close IOHIDManager to stop reconnect memory and port leak (#238)

### DIFF
--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -172,6 +172,15 @@ def _candidate_signature(info) -> dict:
     }
 
 
+def _candidate_cooldown_key(info) -> tuple:
+    """Hashable interface identity for the REPROG_V4-absent cooldown map."""
+    sig = _candidate_signature(info)
+    return (
+        sig["pid"], sig["usage_page"], sig["usage"],
+        sig["transport"], sig["source"], sig["path"],
+    )
+
+
 def _candidate_match_score(info, cached_candidate) -> int:
     """Ranking score for a candidate against the cached identity tuple.
     0 = no match, 1 = PID+usage match, 2 = +same source backend,
@@ -351,6 +360,8 @@ if sys.platform == "darwin":
         _iokit.IOHIDManagerSetDeviceMatching.argtypes = [c_void_p, c_void_p]
         _iokit.IOHIDManagerOpen.argtypes = [c_void_p, c_int]
         _iokit.IOHIDManagerOpen.restype = c_int
+        _iokit.IOHIDManagerClose.argtypes = [c_void_p, c_int]
+        _iokit.IOHIDManagerClose.restype = c_int
         _iokit.IOHIDManagerCopyDevices.argtypes = [c_void_p]
         _iokit.IOHIDManagerCopyDevices.restype = c_void_p
 
@@ -477,6 +488,23 @@ if _MAC_NATIVE_OK:
             finally:
                 _cf.CFRelease(key)
 
+        @staticmethod
+        def _close_manager(manager):
+            """Balance IOHIDManagerOpen before releasing the CF wrapper.
+
+            IOHIDManagerClose releases the IOKit user-client (its Mach ports)
+            and the enclosed-device opens; a bare CFRelease does not, so the
+            manager object and roughly two Mach ports leak on every open. This
+            was the dominant leak in issue #238: tens of thousands of live
+            IOHIDManager objects after a day of reconnect churn."""
+            if not manager:
+                return
+            try:
+                _iokit.IOHIDManagerClose(manager, 0)
+            except Exception:
+                pass
+            _cf.CFRelease(manager)
+
         @classmethod
         def enumerate_infos(cls):
             infos = []
@@ -539,12 +567,24 @@ if _MAC_NATIVE_OK:
                 if matching:
                     _cf.CFRelease(matching)
                 if manager:
-                    _cf.CFRelease(manager)
+                    cls._close_manager(manager)
                 for item in matching_refs:
                     _cf.CFRelease(item)
             return infos
 
         def open(self):
+            """Exception-safe open. On any partial failure, release every
+            CoreFoundation object allocated so far so a failed open cannot
+            leak the manager, matching dict, matching refs, or the retained
+            device. ``close()`` is idempotent and guards each field, so a
+            failed open is safe to unwind through it (issue #238)."""
+            try:
+                self._open()
+            except Exception:
+                self.close()
+                raise
+
+        def _open(self):
             keys = [
                 self._cfstring("VendorID"),
                 self._cfstring("ProductID"),
@@ -641,7 +681,7 @@ if _MAC_NATIVE_OK:
                 _cf.CFRelease(self._matching)
                 self._matching = None
             if self._manager:
-                _cf.CFRelease(self._manager)
+                self._close_manager(self._manager)
                 self._manager = None
             for item in self._matching_refs:
                 _cf.CFRelease(item)
@@ -708,6 +748,15 @@ if _MAC_NATIVE_OK:
                     if deadline is not None:
                         continue
                     return b""
+
+        def __del__(self):
+            # Backstop: an instance discarded without an explicit close() (for
+            # example a caller that drops a half-open device) must not leak
+            # IOKit resources. close() is idempotent; never raise from __del__.
+            try:
+                self.close()
+            except Exception:
+                pass
 
 # ── Constants ─────────────────────────────────────────────────────
 LOGI_VID       = 0x046D
@@ -923,6 +972,12 @@ def _control_present(controls, cid: int) -> bool:
 class HidGestureListener:
     """Background thread: diverts the gesture button and listens via HID++."""
 
+    # Cooldown before an interface that opened but exposed no REPROG_V4 is
+    # re-probed, so a stable set of incompatible interfaces is not re-scanned
+    # every pass during a reconnect storm. Bypassed when it is the only
+    # candidate so a woken device reconnects promptly (issue #238).
+    _REPROG_ABSENT_COOLDOWN_S = 10.0
+
     def __init__(self, on_down=None, on_up=None, on_move=None,
                  on_connect=None, on_disconnect=None, extra_diverts=None,
                  on_wheel=None, on_thumbwheel=None,
@@ -1001,6 +1056,8 @@ class HidGestureListener:
         self._smart_shift_slot_lock = threading.Lock()
         self._smart_shift_event = threading.Event()
         self._reconnect_requested = False
+        # signature -> monotonic deadline; see _REPROG_ABSENT_COOLDOWN_S.
+        self._reprog_absent_until = {}
         self._pending_battery = None
         self._battery_result = None
         self._battery_event = threading.Event()
@@ -2778,7 +2835,31 @@ class HidGestureListener:
                   f"usage=0x{usage:04X} transport={transport or '-'} "
                   f"source={source} product={product} path={path or '-'}")
 
+        # REPROG_V4-absent cooldown (issue #238): skip interfaces that recently
+        # opened but exposed no REPROG_V4, so a stable set of incompatible
+        # interfaces is not re-probed on every pass. Never skip when *all*
+        # candidates are cooling down, so a sole (e.g. just-woken) device is
+        # still probed; the connect backoff throttles that case instead.
+        now = time.monotonic()
+        self._reprog_absent_until = {
+            k: t for k, t in self._reprog_absent_until.items() if t > now
+        }
+        cooled = {
+            _candidate_cooldown_key(info)
+            for info in infos
+            if _candidate_cooldown_key(info) in self._reprog_absent_until
+        }
+        skip_cooled = bool(cooled) and len(cooled) < len(infos)
+
         for info in infos:
+            cand_key = _candidate_cooldown_key(info)
+            if skip_cooled and cand_key in cooled:
+                print(
+                    "[HidGesture] Skipping recently-incompatible interface "
+                    f"PID=0x{int(info.get('product_id', 0) or 0):04X} "
+                    "(no REPROG_V4; cooling down)"
+                )
+                continue
             pid = info.get("product_id", 0)
             up = info.get("usage_page", 0)
             usage = info.get("usage", 0)
@@ -3131,6 +3212,7 @@ class HidGestureListener:
                             )
                         except Exception as exc:
                             print(f"[HidGesture] Cache write skipped: {exc}")
+                        self._reprog_absent_until.pop(cand_key, None)
                         return True
                     continue     # divert failed -- try next receiver slot
             if not reprog_found:
@@ -3139,6 +3221,9 @@ class HidGestureListener:
                     f"on tested devIdx values PID=0x{int(pid or 0):04X} "
                     f"UP=0x{opened_up:04X} usage=0x{opened_usage:04X} "
                     f"transport={opened_transport or '-'} source={source}"
+                )
+                self._reprog_absent_until[cand_key] = (
+                    time.monotonic() + self._REPROG_ABSENT_COOLDOWN_S
                 )
 
             # Couldn't use this interface -- close and try next
@@ -3150,20 +3235,40 @@ class HidGestureListener:
 
         return False
 
+    def _interruptible_sleep(self, seconds):
+        """Sleep up to ``seconds`` in 0.1 s slices, returning early if the
+        listener has been stopped so teardown stays responsive."""
+        for _ in range(int(max(0.0, seconds) / 0.1)):
+            if not self._running:
+                return
+            time.sleep(0.1)
+
     def _main_loop(self):
         """Outer loop: connect → listen → reconnect on error/disconnect."""
         retry_logged = False
+        # Backoff for repeated failed connects. A sleeping or unreachable BLE
+        # mouse can stay enumerable while every open+probe fails; a flat 1.5 s
+        # retry then re-enumerates constantly, which on macOS also multiplies
+        # the per-attempt IOKit work (issue #238). Grow 1.5 s to 30 s on
+        # consecutive failures; reset on any successful connect.
+        _CONNECT_BACKOFF_BASE_S = 1.5
+        _CONNECT_BACKOFF_MAX_S = 30.0
+        connect_backoff_s = _CONNECT_BACKOFF_BASE_S
         while self._running:
             if not self._try_connect():
                 if not retry_logged:
-                    print("[HidGesture] No compatible device; retrying in 1.5 s…")
+                    print(
+                        "[HidGesture] No compatible device; retrying with "
+                        f"backoff up to {_CONNECT_BACKOFF_MAX_S:.0f} s…"
+                    )
                     retry_logged = True
-                for _ in range(15):
-                    if not self._running:
-                        return
-                    time.sleep(0.1)
+                self._interruptible_sleep(connect_backoff_s)
+                connect_backoff_s = min(
+                    connect_backoff_s * 2, _CONNECT_BACKOFF_MAX_S
+                )
                 continue
             retry_logged = False
+            connect_backoff_s = _CONNECT_BACKOFF_BASE_S
 
             self._connected = True
             if self._on_connect:
@@ -3313,4 +3418,4 @@ class HidGestureListener:
                         pass
 
             if self._running:
-                time.sleep(2)
+                self._interruptible_sleep(2)

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -1,7 +1,9 @@
+import contextlib
 import importlib
 import os
 import sys
 import tempfile
+import time
 import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -1202,6 +1204,124 @@ class MxMaster4ConstantTests(unittest.TestCase):
 
     def test_force_sensing_constant(self):
         self.assertEqual(hid_gesture.FEAT_FORCE_SENSING, 0x19C0)
+
+
+class HidReconnectStormTests(unittest.TestCase):
+    """Regression coverage for issue #238: the reconnect/probe throttle.
+
+    These exercise the platform-independent connect logic (via the hidapi
+    fake). The IOKit manager/port leak fix itself is macOS-only and must be
+    validated on-device with `leaks`/`heap`; see the issue for that harness."""
+
+    @staticmethod
+    def _printed_messages(print_mock):
+        return [
+            " ".join(str(arg) for arg in call.args)
+            for call in print_mock.call_args_list
+        ]
+
+    @staticmethod
+    def _info(pid, product, path):
+        return {
+            "product_id": pid,
+            "usage_page": 0xFF00,
+            "usage": 0x0001,
+            "transport": "Bluetooth Low Energy",
+            "source": "hidapi-enumerate",
+            "product_string": product,
+            "path": path,
+        }
+
+    @contextlib.contextmanager
+    def _connecting(self, listener, infos, fake_dev, *, reprog_found=True):
+        def fake_find_feature(feature_id, *, timeout_ms=None):
+            if reprog_found and feature_id == hid_gesture.FEAT_REPROG_V4:
+                return 0x10
+            return None
+
+        cms = (
+            patch.object(hid_gesture, "HIDAPI_OK", True),
+            patch.object(hid_gesture, "_BACKEND_PREFERENCE", "hidapi"),
+            patch.object(hid_gesture, "_HID_API_STYLE", "hidapi"),
+            patch.object(
+                hid_gesture,
+                "_hid",
+                SimpleNamespace(device=lambda: fake_dev),
+                create=True,
+            ),
+            patch.object(hid_gesture, "_load_last_device_cache", return_value=None),
+            patch.object(hid_gesture, "_save_last_device_cache"),
+            patch.object(listener, "_vendor_hid_infos", return_value=infos),
+            patch.object(listener, "_find_feature", side_effect=fake_find_feature),
+            patch.object(listener, "_discover_reprog_controls", return_value=[]),
+            patch.object(listener, "_divert", return_value=True),
+            patch.object(listener, "_divert_extras"),
+        )
+        with contextlib.ExitStack() as stack:
+            for cm in cms:
+                stack.enter_context(cm)
+            yield
+
+    def test_candidate_cooldown_key_is_hashable_and_distinct(self):
+        a = self._info(0xB034, "Iface A", b"/dev/hidraw-a")
+        b = self._info(0xB023, "Iface B", b"/dev/hidraw-b")
+        key_a = hid_gesture._candidate_cooldown_key(a)
+        self.assertEqual(key_a, hid_gesture._candidate_cooldown_key(a))
+        self.assertNotEqual(key_a, hid_gesture._candidate_cooldown_key(b))
+        self.assertIsInstance(hash(key_a), int)
+
+    def test_missing_reprog_records_cooldown(self):
+        listener = hid_gesture.HidGestureListener()
+        info = self._info(0xB034, "MX Master 3S", b"/dev/hidraw-x")
+        fake_dev = _FakeHidDevice()
+        with self._connecting(listener, [info], fake_dev, reprog_found=False):
+            self.assertFalse(listener._try_connect())
+        self.assertIn(
+            hid_gesture._candidate_cooldown_key(info),
+            listener._reprog_absent_until,
+        )
+
+    def test_cooled_interface_is_skipped_when_another_candidate_exists(self):
+        listener = hid_gesture.HidGestureListener()
+        # Name sorts the cooled interface first so the skip branch runs before
+        # the good interface connects.
+        cooled = self._info(0xB025, "AAA Cooled Iface", b"/dev/hidraw-cooled")
+        good = self._info(0xB034, "MX Master 3S", b"/dev/hidraw-good")
+        listener._reprog_absent_until[
+            hid_gesture._candidate_cooldown_key(cooled)
+        ] = time.monotonic() + 999
+        fake_dev = _FakeHidDevice()
+        with self._connecting(listener, [cooled, good], fake_dev):
+            with patch("builtins.print") as print_mock:
+                self.assertTrue(listener._try_connect())
+        # Only the non-cooled interface was opened.
+        fake_dev.open_path.assert_called_once_with(b"/dev/hidraw-good")
+        self.assertTrue(
+            any(
+                "Skipping recently-incompatible interface" in message
+                for message in self._printed_messages(print_mock)
+            )
+        )
+
+    def test_sole_cooled_interface_is_still_probed(self):
+        listener = hid_gesture.HidGestureListener()
+        only = self._info(0xB034, "MX Master 3S", b"/dev/hidraw-only")
+        listener._reprog_absent_until[
+            hid_gesture._candidate_cooldown_key(only)
+        ] = time.monotonic() + 999
+        fake_dev = _FakeHidDevice()
+        with self._connecting(listener, [only], fake_dev):
+            # A lone candidate is never skipped, even while cooling down, so a
+            # just-woken device reconnects without waiting out the cooldown.
+            self.assertTrue(listener._try_connect())
+        fake_dev.open_path.assert_called_once_with(b"/dev/hidraw-only")
+
+    def test_interruptible_sleep_returns_immediately_when_stopped(self):
+        listener = hid_gesture.HidGestureListener()
+        listener._running = False
+        start = time.monotonic()
+        listener._interruptible_sleep(5)
+        self.assertLess(time.monotonic() - start, 0.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #238. On macOS the IOKit HID backend created `IOHIDManager`
instances with `IOHIDManagerOpen` but only ever `CFRelease`d them,
never calling `IOHIDManagerClose`. Close is what frees the IOKit
user-client Mach ports and the enclosed-device opens, so every
enumeration and every open attempt leaked one manager plus ~2 Mach
ports. During repeated BLE discovery/reconnect cycles this grew the
process to ~3.3 GB with ~33k live `IOHIDManager` objects and ~67k Mach
ports, exactly as @maxhis documented with `vmmap`/`heap`/`leaks`.

## Changes

**Block A: stop the leak**
- Declare `IOHIDManagerClose` and add a `_close_manager()` helper that closes before releasing.
- Route `enumerate_infos()` and `_MacNativeHidDevice.close()` through it.
- Make `open()` exception-safe: on any partial failure it unwinds through the idempotent `close()`, so a failed open can no longer leak the manager, matching dict, CF refs, or the retained device (previously the failed-open path only cleared `self._dev`, and the class had no destructor).
- Add a `__del__` backstop.

**Block B: throttle the reconnect/probe storm that amplified the leak**
- Exponential connect backoff (1.5s to 30s, reset on success) via an interruptible sleep helper, replacing the flat 1.5s retry.
- Short per-interface "REPROG_V4 absent" cooldown so a stable set of incompatible interfaces is not re-probed every pass, bypassed when the device is the sole candidate so a just-woken mouse still reconnects promptly.

## Testing

- `tests/test_hid_gesture.py`: 49 passed (44 existing + 5 new regression tests for the throttle logic).
- The IOKit `IOHIDManagerClose` fix is macOS-only and cannot be exercised on non-macOS CI. It should be validated on-device using the `leaks`/`heap` stress steps from #238: after repeated failed discovery cycles the `IOHIDManager` and Mach port counts should stay bounded.

## Not included

The secondary `HIDEvent`/`GPProcessMonitor` autorelease cluster (native read-loop pool and #125 revalidation on macOS 26.4.1) is intentionally out of scope here and can follow separately.

Diagnosis and forensics by @maxhis.
