### PR TITLE
split macOS daemon from on-demand Qt UI

### DIFF
--- a/Mouser-mac.spec
+++ b/Mouser-mac.spec
@@ -11,6 +11,7 @@ environment supports it:
 
 import os
 import json
+import shutil
 import subprocess
 
 ROOT = os.path.abspath(".")
@@ -92,8 +93,8 @@ def _write_build_info(version: str) -> str:
 APP_VERSION = _load_app_version()
 BUILD_INFO_DATA = _write_build_info(APP_VERSION)
 
-a = Analysis(
-    ["main_qml.py"],
+ui_analysis = Analysis(
+    ["mouser_ui_launcher.py"],
     pathex=[ROOT],
     binaries=[],
     datas=[
@@ -265,18 +266,99 @@ def is_unwanted(path_or_toc_entry):
     return False
 
 # Filter Analysis.toc lists (binaries and datas)
-a.binaries = [b for b in a.binaries if not is_unwanted(b)]
-a.datas = [d for d in a.datas if not is_unwanted(d)]
+ui_analysis.binaries = [b for b in ui_analysis.binaries if not is_unwanted(b)]
+ui_analysis.datas = [d for d in ui_analysis.datas if not is_unwanted(d)]
 
-pyz = PYZ(a.pure)
+ui_pyz = PYZ(ui_analysis.pure)
 
 exe_kwargs = {}
 if TARGET_ARCH:
     exe_kwargs["target_arch"] = TARGET_ARCH
 
-exe = EXE(
-    pyz,
-    a.scripts,
+ui_exe = EXE(
+    ui_pyz,
+    ui_analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name="MouserUI",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    icon=ICON_PATH,
+    **exe_kwargs,
+)
+
+ui_coll = COLLECT(
+    ui_exe,
+    ui_analysis.binaries,
+    ui_analysis.zipfiles,
+    ui_analysis.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="MouserUI",
+)
+
+ui_app = BUNDLE(
+    ui_coll,
+    name="MouserUI.app",
+    icon=ICON_PATH,
+    bundle_identifier=f"{BUNDLE_ID}.ui",
+    info_plist={
+        "CFBundleDisplayName": "Mouser UI",
+        "CFBundleName": "MouserUI",
+        "CFBundleShortVersionString": APP_VERSION,
+        "CFBundleVersion": APP_VERSION,
+        "LSMinimumSystemVersion": "12.0",
+        "LSUIElement": True,
+        "NSHighResolutionCapable": True,
+    },
+)
+
+daemon_analysis = Analysis(
+    ["mouser_daemon_launcher.py"],
+    pathex=[ROOT],
+    binaries=[],
+    datas=[
+        (os.path.join(ROOT, "images"), "images"),
+        (BUILD_INFO_DATA, "."),
+    ],
+    hiddenimports=["hid", "logging.handlers"],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        "PySide6",
+        "main_qml",
+        "ui.actions_ring_overlay",
+        "ui.actions_ring_worker",
+        "ui.screenshot_worker",
+        "unittest",
+        "xmlrpc",
+        "pydoc",
+        "doctest",
+        "tkinter",
+        "test",
+        "distutils",
+        "setuptools",
+        "ensurepip",
+        "lib2to3",
+        "idlelib",
+        "turtledemo",
+        "turtle",
+        "sqlite3",
+        "multiprocessing",
+    ],
+    noarchive=False,
+)
+
+daemon_pyz = PYZ(daemon_analysis.pure)
+
+daemon_exe = EXE(
+    daemon_pyz,
+    daemon_analysis.scripts,
     [],
     exclude_binaries=True,
     name="Mouser",
@@ -289,11 +371,11 @@ exe = EXE(
     **exe_kwargs,
 )
 
-coll = COLLECT(
-    exe,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
+daemon_coll = COLLECT(
+    daemon_exe,
+    daemon_analysis.binaries,
+    daemon_analysis.zipfiles,
+    daemon_analysis.datas,
     strip=False,
     upx=False,
     upx_exclude=[],
@@ -301,7 +383,7 @@ coll = COLLECT(
 )
 
 app = BUNDLE(
-    coll,
+    daemon_coll,
     name="Mouser.app",
     icon=ICON_PATH,
     bundle_identifier=BUNDLE_ID,
@@ -314,4 +396,15 @@ app = BUNDLE(
         "LSUIElement": True,
         "NSHighResolutionCapable": True,
     },
+)
+
+ui_helper_destination = os.path.join(
+    ROOT, "dist", "Mouser.app", "Contents", "Helpers", "MouserUI.app"
+)
+if os.path.exists(ui_helper_destination):
+    shutil.rmtree(ui_helper_destination)
+shutil.copytree(
+    os.path.join(ROOT, "dist", "MouserUI.app"),
+    ui_helper_destination,
+    symlinks=True,
 )

--- a/build_macos_app.sh
+++ b/build_macos_app.sh
@@ -153,6 +153,7 @@ run_pyinstaller() {
 
 sign_ad_hoc() {
   echo "Signing mode: ad-hoc"
+  xattr -cr "$ROOT_DIR/dist/Mouser.app"
   codesign --force --deep --sign - "$ROOT_DIR/dist/Mouser.app"
 }
 

--- a/core/local_control.py
+++ b/core/local_control.py
@@ -1,0 +1,94 @@
+"""Small Unix-domain control channel used without importing Qt."""
+from __future__ import annotations
+
+import getpass
+import hashlib
+import os
+import socket
+import tempfile
+import threading
+
+
+def control_socket_path(name: str) -> str:
+    identity = f"{getpass.getuser()}\0{name}".encode("utf-8", errors="replace")
+    suffix = hashlib.sha256(identity).hexdigest()[:16]
+    filename = f"mouser-{name}-{suffix}.sock"
+    candidate = os.path.join(tempfile.gettempdir(), filename)
+    if len(candidate.encode("utf-8")) >= 100:
+        candidate = os.path.join("/tmp", filename)
+    return candidate
+
+
+def send_control_message(name: str, message: str, timeout: float = 0.4) -> bool:
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as connection:
+            connection.settimeout(timeout)
+            connection.connect(control_socket_path(name))
+            connection.sendall(message.encode("utf-8") + b"\n")
+        return True
+    except OSError:
+        return False
+
+
+class LocalControlServer:
+    def __init__(self, name: str, callback):
+        self.name = name
+        self.path = control_socket_path(name)
+        self._callback = callback
+        self._closed = threading.Event()
+        self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._thread = threading.Thread(
+            target=self._serve,
+            daemon=True,
+            name=f"MouserControl-{name}",
+        )
+
+    def start(self) -> None:
+        if send_control_message(self.name, "ping", timeout=0.15):
+            raise RuntimeError(f"control server already active: {self.name}")
+        try:
+            os.unlink(self.path)
+        except FileNotFoundError:
+            pass
+        try:
+            self._socket.bind(self.path)
+            self._socket.listen(4)
+            self._socket.settimeout(0.5)
+        except BaseException:
+            self._socket.close()
+            raise
+        self._thread.start()
+
+    def close(self) -> None:
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        try:
+            self._socket.close()
+        except OSError:
+            pass
+        if self._thread is not threading.current_thread():
+            self._thread.join(timeout=1.5)
+        try:
+            os.unlink(self.path)
+        except FileNotFoundError:
+            pass
+
+    def _serve(self) -> None:
+        while not self._closed.is_set():
+            try:
+                connection, _ = self._socket.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            with connection:
+                try:
+                    payload = connection.recv(4096)
+                    message = payload.partition(b"\n")[0].decode(
+                        "utf-8", errors="replace"
+                    )
+                    if message and message != "ping":
+                        self._callback(message)
+                except Exception as exc:
+                    print(f"[LocalControl] {self.name}: {exc}")

--- a/core/macos_daemon.py
+++ b/core/macos_daemon.py
@@ -1,0 +1,298 @@
+"""Lightweight macOS daemon using AppKit without importing Qt."""
+from __future__ import annotations
+
+from collections import deque
+import os
+import signal
+import subprocess
+import sys
+import threading
+import webbrowser
+
+import objc
+from AppKit import (
+    NSApplication,
+    NSApplicationActivationPolicyAccessory,
+    NSControlStateValueOff,
+    NSControlStateValueOn,
+    NSImage,
+    NSMenu,
+    NSMenuItem,
+    NSStatusBar,
+    NSVariableStatusItemLength,
+)
+from Foundation import NSObject, NSTimer
+from PyObjCTools import AppHelper
+
+from core.accessibility import is_process_trusted
+from core.config import load_config, save_config
+from core.engine import Engine
+from core.local_control import LocalControlServer, send_control_message
+from core.on_demand_ui import RingWorkerClient, launch_screenshot_worker, process_command
+from core.process_bridge import DaemonBridgeServer
+
+
+def _root_dir() -> str:
+    if getattr(sys, "frozen", False):
+        return getattr(
+            sys,
+            "_MEIPASS",
+            os.path.abspath(os.path.join(os.path.dirname(sys.executable), "..", "Resources")),
+        )
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+ROOT = _root_dir()
+
+
+def _settings_command() -> list[str]:
+    return process_command("--settings-process")
+
+
+class DaemonRuntime:
+    def __init__(self):
+        self.config = load_config()
+        self.engine = Engine()
+        self.battery_level = -1
+        self.debug_lines = deque(maxlen=500)
+        self.settings_process = None
+        self.control_server = LocalControlServer("daemon", self._control_message)
+        self.ring = RingWorkerClient(
+            on_select=self.engine.ring_toggle_select,
+            on_cancel=self.engine.ring_toggle_dismiss,
+            on_hover=self.engine.ring_hover,
+        )
+        self.engine.set_battery_callback(self._battery_changed)
+        self.engine.set_debug_callback(self._debug_message)
+        self.engine.set_status_callback(self._status_message)
+        self.engine.set_ring_show_callback(self.ring.show)
+        self.engine.set_ring_hide_callback(self.ring.hide)
+        self.engine.set_ring_sector_callback(lambda: self.ring.current_sector)
+        self.engine.set_ring_move_callback(self.ring.move)
+        self.engine.set_debug_enabled(
+            bool(self.config.get("settings", {}).get("debug_mode", False))
+        )
+
+        from core.key_simulator import set_screenshot_action_handler
+
+        set_screenshot_action_handler(self._screenshot)
+        self.bridge = DaemonBridgeServer(
+            self.engine,
+            on_shutdown=self.request_quit,
+            on_config_sync=self._sync_config,
+            state_provider=self._state,
+        )
+        self.delegate = None
+        self._engine_started = False
+        self._stopped = False
+        self._stop_lock = threading.Lock()
+
+    def start(self) -> None:
+        self.control_server.start()
+        self.bridge.start()
+
+    def start_engine(self) -> None:
+        if self._engine_started:
+            return
+        self._engine_started = True
+        self.engine.start()
+        print("[Mouser] Accessibility granted -- lightweight engine started")
+
+    def show_settings(self) -> None:
+        if send_control_message("settings", "show", timeout=0.2):
+            return
+        process = self.settings_process
+        if process is not None and process.poll() is None:
+            return
+        self.settings_process = subprocess.Popen(
+            _settings_command(),
+            cwd=ROOT,
+            env=self.bridge.child_environment(),
+            close_fds=True,
+        )
+
+    def close_settings(self) -> None:
+        send_control_message("settings", "quit", timeout=0.2)
+
+    def request_quit(self) -> None:
+        delegate = self.delegate
+        if delegate is not None:
+            AppHelper.callAfter(delegate.terminate)
+
+    def stop(self) -> None:
+        with self._stop_lock:
+            if self._stopped:
+                return
+            self._stopped = True
+        self.close_settings()
+        self.ring.close()
+        self.bridge.close()
+        if self._engine_started:
+            self.engine.stop()
+        self.control_server.close()
+        print("[Mouser] lightweight daemon shut down cleanly")
+
+    def set_enabled(self, enabled: bool) -> None:
+        self.engine.set_enabled(enabled)
+
+    def set_debug(self, enabled: bool) -> None:
+        self.engine.set_debug_enabled(enabled)
+        self.config.setdefault("settings", {})["debug_mode"] = bool(enabled)
+        save_config(self.config)
+
+    def _control_message(self, message: str) -> None:
+        if message == "quit":
+            self.request_quit()
+        else:
+            AppHelper.callAfter(self.show_settings)
+
+    def _sync_config(self, config) -> None:
+        self.config = config
+        self.engine.cfg = config
+
+    def _battery_changed(self, level) -> None:
+        self.battery_level = int(level)
+
+    def _debug_message(self, message) -> None:
+        self.debug_lines.append(str(message))
+
+    @staticmethod
+    def _status_message(message) -> None:
+        if message:
+            print(f"[Mouser] {message}")
+
+    def _state(self) -> dict:
+        return {
+            "battery_level": self.battery_level,
+            "debug_lines": list(self.debug_lines),
+        }
+
+    def _screenshot(self, action_id: str) -> None:
+        launch_screenshot_worker(action_id, self.bridge.child_environment())
+
+
+class MouserAppDelegate(NSObject):
+    def initWithRuntime_(self, runtime):
+        self = objc.super(MouserAppDelegate, self).init()
+        if self is None:
+            return None
+        self.runtime = runtime
+        self.status_item = None
+        self.menu = None
+        self.toggle_item = None
+        self.debug_item = None
+        self.accessibility_timer = None
+        return self
+
+    def applicationDidFinishLaunching_(self, _notification):
+        self._install_status_item()
+        self.runtime.start()
+        if is_process_trusted(prompt=True):
+            self.runtime.start_engine()
+        else:
+            print("[Mouser] Waiting for Accessibility permission")
+            self.accessibility_timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+                2.0,
+                self,
+                "pollAccessibility:",
+                None,
+                True,
+            )
+
+    def applicationWillTerminate_(self, _notification):
+        self.runtime.stop()
+
+    def pollAccessibility_(self, _timer):
+        if not is_process_trusted():
+            return
+        self.accessibility_timer.invalidate()
+        self.accessibility_timer = None
+        self.runtime.start_engine()
+
+    def openSettings_(self, _sender):
+        self.runtime.show_settings()
+
+    def toggleEnabled_(self, _sender):
+        self.runtime.set_enabled(not self.runtime.engine.enabled)
+        self._refresh_menu()
+
+    def toggleDebug_(self, _sender):
+        enabled = not bool(self.runtime.config.get("settings", {}).get("debug_mode", False))
+        self.runtime.set_debug(enabled)
+        self._refresh_menu()
+        if enabled:
+            self.runtime.show_settings()
+
+    def openReleases_(self, _sender):
+        webbrowser.open("https://github.com/TomBadash/Mouser/releases")
+
+    def quitMouser_(self, _sender):
+        self.terminate()
+
+    def menuWillOpen_(self, _menu):
+        self._refresh_menu()
+
+    def terminate(self):
+        NSApplication.sharedApplication().terminate_(None)
+
+    def _install_status_item(self):
+        self.status_item = NSStatusBar.systemStatusBar().statusItemWithLength_(
+            NSVariableStatusItemLength
+        )
+        button = self.status_item.button()
+        icon_path = os.path.join(ROOT, "images", "logo_icon.png")
+        image = NSImage.alloc().initWithContentsOfFile_(icon_path)
+        if image is not None:
+            image.setSize_((18.0, 18.0))
+            image.setTemplate_(True)
+            button.setImage_(image)
+        else:
+            button.setTitle_("M")
+        button.setToolTip_("Mouser")
+
+        self.menu = NSMenu.alloc().initWithTitle_("Mouser")
+        self.menu.setDelegate_(self)
+        self._add_item("Open Settings", "openSettings:")
+        self.toggle_item = self._add_item("", "toggleEnabled:")
+        self.debug_item = self._add_item("Debug Mode", "toggleDebug:")
+        self.menu.addItem_(NSMenuItem.separatorItem())
+        self._add_item("Latest Release", "openReleases:")
+        self.menu.addItem_(NSMenuItem.separatorItem())
+        self._add_item("Quit Mouser", "quitMouser:")
+        self.status_item.setMenu_(self.menu)
+        self._refresh_menu()
+
+    def _add_item(self, title: str, selector: str):
+        item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            title,
+            selector,
+            "",
+        )
+        item.setTarget_(self)
+        self.menu.addItem_(item)
+        return item
+
+    def _refresh_menu(self):
+        enabled = self.runtime.engine.enabled
+        self.toggle_item.setTitle_("Disable Remapping" if enabled else "Enable Remapping")
+        debug_enabled = bool(
+            self.runtime.config.get("settings", {}).get("debug_mode", False)
+        )
+        self.debug_item.setState_(
+            NSControlStateValueOn if debug_enabled else NSControlStateValueOff
+        )
+
+
+def main() -> int:
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    if send_control_message("daemon", "show", timeout=0.2):
+        return 0
+
+    application = NSApplication.sharedApplication()
+    application.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+    runtime = DaemonRuntime()
+    delegate = MouserAppDelegate.alloc().initWithRuntime_(runtime)
+    runtime.delegate = delegate
+    application.setDelegate_(delegate)
+    application.run()
+    return 0

--- a/core/on_demand_ui.py
+++ b/core/on_demand_ui.py
@@ -1,0 +1,125 @@
+"""Launch Qt-dependent tools only while they are being used."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+
+
+def process_command(flag: str, *arguments: str) -> list[str]:
+    if getattr(sys, "frozen", False):
+        helper = os.path.abspath(
+            os.path.join(
+                os.path.dirname(sys.executable),
+                "..",
+                "Helpers",
+                "MouserUI.app",
+                "Contents",
+                "MacOS",
+                "MouserUI",
+            )
+        )
+        return [helper, flag, *arguments]
+    launcher = os.path.join(os.path.dirname(os.path.dirname(__file__)), "mouser_launcher.py")
+    return [sys.executable, launcher, flag, *arguments]
+
+
+def launch_screenshot_worker(action_id: str, environment=None) -> None:
+    subprocess.Popen(
+        process_command("--screenshot-process", action_id),
+        env=dict(os.environ if environment is None else environment),
+        close_fds=True,
+    )
+
+
+class RingWorkerClient:
+    def __init__(self, *, on_select, on_cancel, on_hover):
+        self._on_select = on_select
+        self._on_cancel = on_cancel
+        self._on_hover = on_hover
+        self._process = None
+        self._write_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._current_sector = -1
+
+    @property
+    def current_sector(self) -> int:
+        with self._state_lock:
+            return self._current_sector
+
+    def show(self, slots, interactive=False) -> None:
+        with self._state_lock:
+            self._current_sector = -1
+        self._send({"command": "show", "slots": list(slots), "interactive": bool(interactive)})
+
+    def hide(self) -> None:
+        self._send({"command": "hide"}, start=False)
+
+    def move(self, dx: int, dy: int) -> None:
+        self._send({"command": "move", "dx": int(dx), "dy": int(dy)}, start=False)
+
+    def close(self) -> None:
+        self._send({"command": "quit"}, start=False)
+        process = self._process
+        if process is not None:
+            try:
+                process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+        self._process = None
+
+    def _ensure_process(self):
+        process = self._process
+        if process is not None and process.poll() is None:
+            return process
+        process = subprocess.Popen(
+            process_command("--ring-process"),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            close_fds=True,
+        )
+        self._process = process
+        threading.Thread(
+            target=self._read_events,
+            args=(process,),
+            daemon=True,
+            name="MouserRingEvents",
+        ).start()
+        return process
+
+    def _send(self, payload, *, start=True) -> None:
+        with self._write_lock:
+            process = self._ensure_process() if start else self._process
+            if process is None or process.poll() is not None or process.stdin is None:
+                return
+            try:
+                process.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+                process.stdin.flush()
+            except (BrokenPipeError, OSError):
+                self._process = None
+
+    def _read_events(self, process) -> None:
+        if process.stdout is None:
+            return
+        for line in process.stdout:
+            try:
+                event = json.loads(line)
+            except (TypeError, ValueError):
+                continue
+            event_name = event.get("event")
+            sector = int(event.get("sector", -1))
+            if event_name == "sector":
+                with self._state_lock:
+                    self._current_sector = sector
+            elif event_name == "hover":
+                self._on_hover(sector)
+            elif event_name == "select":
+                self._on_select(sector)
+            elif event_name == "cancel":
+                self._on_cancel()
+        if self._process is process:
+            self._process = None

--- a/core/process_bridge.py
+++ b/core/process_bridge.py
@@ -1,0 +1,450 @@
+"""Authenticated loopback RPC between Mouser's daemon and settings UI."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+import json
+import os
+import secrets
+import socket
+import threading
+import time
+from types import SimpleNamespace
+
+BRIDGE_HOST = "127.0.0.1"
+BRIDGE_PORT_ENV = "MOUSER_DAEMON_PORT"
+BRIDGE_TOKEN_ENV = "MOUSER_DAEMON_TOKEN"
+MAX_MESSAGE_BYTES = 4 * 1024 * 1024
+
+
+def _load_config():
+    from core.config import load_config
+
+    return load_config()
+
+
+class BridgeError(RuntimeError):
+    pass
+
+
+def _json_safe(value):
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if is_dataclass(value):
+        return _json_safe(asdict(value))
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_safe(item) for item in value]
+    if hasattr(value, "__dict__"):
+        return {
+            str(key): _json_safe(item)
+            for key, item in vars(value).items()
+            if not str(key).startswith("_")
+        }
+    return str(value)
+
+
+def _namespace(value):
+    if isinstance(value, dict):
+        return SimpleNamespace(**{key: _namespace(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_namespace(item) for item in value]
+    return value
+
+
+def _read_message(connection):
+    chunks = bytearray()
+    while True:
+        block = connection.recv(65536)
+        if not block:
+            break
+        chunks.extend(block)
+        if len(chunks) > MAX_MESSAGE_BYTES:
+            raise BridgeError("bridge message exceeds size limit")
+        if b"\n" in block:
+            break
+    line, _, _ = bytes(chunks).partition(b"\n")
+    if not line:
+        raise BridgeError("empty bridge message")
+    return json.loads(line.decode("utf-8"))
+
+
+def _write_message(connection, payload):
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n"
+    connection.sendall(encoded)
+
+
+class DaemonBridgeServer:
+    _ALLOWED_METHODS = {
+        "dump_device_info",
+        "play_haptic_waveform",
+        "reload_mappings",
+        "ring_hover",
+        "ring_toggle_dismiss",
+        "ring_toggle_select",
+        "set_debug_enabled",
+        "set_debug_events_enabled",
+        "set_dpi",
+        "set_enabled",
+        "set_force_sensitivity",
+        "set_frontend_visible",
+        "set_haptic_level",
+        "set_smart_shift",
+        "set_ui_passthrough",
+        "start",
+        "stop",
+    }
+
+    def __init__(
+        self,
+        engine,
+        *,
+        on_shutdown=None,
+        on_config_sync=None,
+        state_provider=None,
+    ):
+        self._engine = engine
+        self._on_shutdown = on_shutdown
+        self._on_config_sync = on_config_sync
+        self._state_provider = state_provider
+        self._token = secrets.token_urlsafe(32)
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self._socket.bind((BRIDGE_HOST, 0))
+            self._socket.listen(8)
+            self._socket.settimeout(0.5)
+        except BaseException:
+            self._socket.close()
+            raise
+        self._port = int(self._socket.getsockname()[1])
+        self._closed = threading.Event()
+        self._thread = threading.Thread(
+            target=self._serve,
+            daemon=True,
+            name="MouserDaemonBridge",
+        )
+
+    @property
+    def port(self):
+        return self._port
+
+    @property
+    def token(self):
+        return self._token
+
+    def child_environment(self, base=None):
+        environment = dict(os.environ if base is None else base)
+        environment[BRIDGE_PORT_ENV] = str(self._port)
+        environment[BRIDGE_TOKEN_ENV] = self._token
+        return environment
+
+    def start(self):
+        self._thread.start()
+
+    def close(self):
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        try:
+            self._socket.close()
+        except OSError:
+            pass
+        if self._thread is not threading.current_thread():
+            self._thread.join(timeout=2)
+
+    def _serve(self):
+        while not self._closed.is_set():
+            try:
+                connection, _ = self._socket.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            threading.Thread(
+                target=self._handle_connection,
+                args=(connection,),
+                daemon=True,
+                name="MouserDaemonRequest",
+            ).start()
+
+    def _handle_connection(self, connection):
+        with connection:
+            try:
+                request = _read_message(connection)
+                if not secrets.compare_digest(str(request.get("token", "")), self._token):
+                    raise BridgeError("authentication failed")
+                result = self._dispatch(
+                    str(request.get("method", "")),
+                    list(request.get("args", [])),
+                    dict(request.get("kwargs", {})),
+                )
+                response = {"ok": True, "result": _json_safe(result)}
+            except Exception as exc:
+                response = {"ok": False, "error": str(exc)}
+            _write_message(connection, response)
+
+    def _dispatch(self, method, args, kwargs):
+        if method == "get_state":
+            return self._state()
+        if method == "sync_config":
+            config = _load_config()
+            self._engine.cfg = config
+            if self._on_config_sync is not None:
+                self._on_config_sync(config)
+            return True
+        if method == "shutdown_daemon":
+            if self._on_shutdown is not None:
+                self._on_shutdown()
+            return True
+        if method not in self._ALLOWED_METHODS:
+            raise BridgeError(f"method is not allowed: {method}")
+        target = getattr(self._engine, method, None)
+        if target is None or not callable(target):
+            raise BridgeError(f"engine method is unavailable: {method}")
+        return target(*args, **kwargs)
+
+    def _state(self):
+        settings = getattr(self._engine, "cfg", {}).get("settings", {})
+        force_range = getattr(self._engine, "force_sensing_range", None)
+        state = {
+            "active_profile": getattr(self._engine, "current_profile", None)
+                or getattr(self._engine, "_current_profile", "default"),
+            "connected_device": _json_safe(
+                getattr(self._engine, "connected_device", None)
+            ),
+            "device_connected": bool(
+                getattr(self._engine, "device_connected", False)
+            ),
+            "dpi": settings.get("dpi"),
+            "enabled": bool(getattr(self._engine, "enabled", True)),
+            "force_sensing_range": _json_safe(force_range),
+            "force_sensing_supported": bool(
+                getattr(self._engine, "force_sensing_supported", False)
+            ),
+            "haptic_supported": bool(
+                getattr(self._engine, "haptic_supported", False)
+            ),
+            "hid_features_ready": bool(
+                getattr(self._engine, "hid_features_ready", False)
+            ),
+            "smart_shift": {
+                "mode": settings.get("smart_shift_mode", "ratchet"),
+                "enabled": bool(settings.get("smart_shift_enabled", False)),
+                "threshold": int(settings.get("smart_shift_threshold", 25)),
+            },
+            "smart_shift_supported": bool(
+                getattr(self._engine, "smart_shift_supported", False)
+            ),
+        }
+        if self._state_provider is not None:
+            state.update(_json_safe(self._state_provider()) or {})
+        return state
+
+
+class RemoteEngine:
+    def __init__(self, port, token, *, poll_interval=0.75, timeout=3.0):
+        self._port = int(port)
+        self._token = str(token)
+        self._timeout = float(timeout)
+        self._poll_interval = float(poll_interval)
+        self._state = {}
+        self._state_lock = threading.Lock()
+        self._callbacks = {}
+        self._closed = threading.Event()
+        self._last_error = ""
+        self._refresh_state(notify=False)
+        self._poll_thread = threading.Thread(
+            target=self._poll,
+            daemon=True,
+            name="MouserSettingsStatePoll",
+        )
+        self._poll_thread.start()
+
+    @classmethod
+    def from_environment(cls):
+        port = os.environ.get(BRIDGE_PORT_ENV, "")
+        token = os.environ.get(BRIDGE_TOKEN_ENV, "")
+        if not port or not token:
+            raise BridgeError("settings process was not launched by the Mouser daemon")
+        return cls(port, token)
+
+    def close(self):
+        self._closed.set()
+        if self._poll_thread is not threading.current_thread():
+            self._poll_thread.join(timeout=2)
+
+    def _request(self, method, *args, **kwargs):
+        request = {
+            "token": self._token,
+            "method": method,
+            "args": list(args),
+            "kwargs": kwargs,
+        }
+        try:
+            with socket.create_connection(
+                (BRIDGE_HOST, self._port), timeout=self._timeout
+            ) as connection:
+                connection.settimeout(self._timeout)
+                _write_message(connection, request)
+                response = _read_message(connection)
+        except OSError as exc:
+            raise BridgeError(f"daemon is unavailable: {exc}") from exc
+        if not response.get("ok"):
+            raise BridgeError(str(response.get("error", "daemon request failed")))
+        return response.get("result")
+
+    def _poll(self):
+        while not self._closed.wait(self._poll_interval):
+            try:
+                self._refresh_state(notify=True)
+                self._last_error = ""
+            except BridgeError as exc:
+                message = str(exc)
+                if message != self._last_error:
+                    self._last_error = message
+                    self._emit("status", message)
+
+    def _refresh_state(self, *, notify):
+        state = self._request("get_state") or {}
+        with self._state_lock:
+            previous = self._state
+            self._state = state
+        if not notify or not previous:
+            return
+        if state.get("active_profile") != previous.get("active_profile"):
+            self._emit("profile", state.get("active_profile", "default"))
+        if state.get("device_connected") != previous.get("device_connected"):
+            self._emit("connection", bool(state.get("device_connected")))
+        if state.get("dpi") != previous.get("dpi") and state.get("dpi") is not None:
+            self._emit("dpi", int(state["dpi"]))
+        if state.get("smart_shift") != previous.get("smart_shift"):
+            self._emit("smart_shift", state.get("smart_shift", {}))
+        if state.get("battery_level") != previous.get("battery_level"):
+            level = state.get("battery_level")
+            if level is not None and int(level) >= 0:
+                self._emit("battery", int(level))
+        debug_lines = list(state.get("debug_lines") or [])
+        previous_lines = list(previous.get("debug_lines") or [])
+        if debug_lines != previous_lines:
+            if previous_lines and debug_lines[:len(previous_lines)] == previous_lines:
+                added_lines = debug_lines[len(previous_lines):]
+            else:
+                added_lines = debug_lines[-1:]
+            for line in added_lines:
+                self._emit("debug", str(line))
+
+    def _snapshot(self):
+        with self._state_lock:
+            return dict(self._state)
+
+    def _emit(self, name, *args):
+        callback = self._callbacks.get(name)
+        if callback is not None:
+            callback(*args)
+
+    @property
+    def cfg(self):
+        return _load_config()
+
+    @cfg.setter
+    def cfg(self, _value):
+        self._request("sync_config")
+
+    @property
+    def connected_device(self):
+        value = self._snapshot().get("connected_device")
+        return _namespace(value) if value else None
+
+    @property
+    def device_connected(self):
+        return bool(self._snapshot().get("device_connected", False))
+
+    @property
+    def enabled(self):
+        return bool(self._snapshot().get("enabled", True))
+
+    @property
+    def force_sensing_range(self):
+        value = self._snapshot().get("force_sensing_range")
+        return tuple(value) if isinstance(value, list) else value
+
+    @property
+    def force_sensing_supported(self):
+        return bool(self._snapshot().get("force_sensing_supported", False))
+
+    @property
+    def haptic_supported(self):
+        return bool(self._snapshot().get("haptic_supported", False))
+
+    @property
+    def hid_features_ready(self):
+        return bool(self._snapshot().get("hid_features_ready", False))
+
+    @property
+    def smart_shift_supported(self):
+        return bool(self._snapshot().get("smart_shift_supported", False))
+
+    def _set_callback(self, name, callback):
+        self._callbacks[name] = callback
+
+    def set_profile_change_callback(self, callback):
+        self._set_callback("profile", callback)
+
+    def set_connection_change_callback(self, callback):
+        self._set_callback("connection", callback)
+
+    def set_dpi_read_callback(self, callback):
+        self._set_callback("dpi", callback)
+
+    def set_smart_shift_read_callback(self, callback):
+        self._set_callback("smart_shift", callback)
+
+    def set_status_callback(self, callback):
+        self._set_callback("status", callback)
+
+    def set_battery_callback(self, callback):
+        self._set_callback("battery", callback)
+
+    def set_debug_callback(self, callback):
+        self._set_callback("debug", callback)
+
+    def set_gesture_event_callback(self, callback):
+        self._set_callback("gesture", callback)
+
+    def set_ring_show_callback(self, callback):
+        self._set_callback("ring_show", callback)
+
+    def set_ring_hide_callback(self, callback):
+        self._set_callback("ring_hide", callback)
+
+    def set_ring_sector_callback(self, callback):
+        self._set_callback("ring_sector", callback)
+
+    def set_ring_move_callback(self, callback):
+        self._set_callback("ring_move", callback)
+
+    def shutdown_daemon(self):
+        return self._request("shutdown_daemon")
+
+    def __getattr__(self, name):
+        if name in DaemonBridgeServer._ALLOWED_METHODS:
+            return lambda *args, **kwargs: self._request(name, *args, **kwargs)
+        raise AttributeError(name)
+
+
+def wait_for_bridge(port, token, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            remote = RemoteEngine(port, token, poll_interval=60)
+            remote.close()
+            return True
+        except BridgeError as exc:
+            last_error = exc
+            time.sleep(0.05)
+    if last_error is not None:
+        raise last_error
+    return False

--- a/main_qml.py
+++ b/main_qml.py
@@ -14,6 +14,7 @@ import os
 import signal
 import hashlib
 import getpass
+import subprocess
 import time
 from urllib.parse import parse_qs, unquote
 
@@ -49,10 +50,22 @@ _t1 = _time.perf_counter()
 from PySide6.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QFileIconProvider, QMessageBox
 from PySide6.QtGui import QAction, QColor, QGuiApplication, QIcon, QPainter, QPixmap, QWindow
 from PySide6.QtCore import QObject, Property, QCoreApplication, QRectF, Qt, QUrl, Signal, QFileInfo, QEvent, QTimer
-from PySide6.QtQml import QQmlApplicationEngine
-from PySide6.QtQuick import QQuickImageProvider
 from PySide6.QtSvg import QSvgRenderer
 from PySide6.QtNetwork import QLocalServer, QLocalSocket, QAbstractSocket
+
+_SETTINGS_PROCESS = "--settings-process" in sys.argv
+if _SETTINGS_PROCESS:
+    from PySide6.QtQml import QQmlApplicationEngine
+    from PySide6.QtQuick import QQuickImageProvider
+else:
+    QQmlApplicationEngine = None
+
+    class QQuickImageProvider:
+        class ImageType:
+            Pixmap = 0
+
+        def __init__(self, *_args, **_kwargs):
+            pass
 _t2 = _time.perf_counter()
 
 # Ensure PySide6 QML plugins are found
@@ -64,6 +77,7 @@ os.environ.setdefault("QT_PLUGIN_PATH", os.path.join(_pyside_dir, "plugins"))
 _t3 = _time.perf_counter()
 from core.config import load_config, save_config
 from core.engine import Engine
+from core.process_bridge import DaemonBridgeServer, RemoteEngine
 from core.hid_gesture import set_backend_preference as set_hid_backend_preference
 from core.accessibility import is_process_trusted
 from core.startup import linux_runtime_icon_path, sync_linux_icon_theme
@@ -109,6 +123,9 @@ def _parse_cli_args(argv):
             force_show = True
             i += 1
             continue
+        if arg == "--settings-process":
+            i += 1
+            continue
         qt_argv.append(arg)
         i += 1
     return qt_argv, hid_backend, start_hidden, force_show
@@ -123,15 +140,23 @@ def _single_instance_server_name() -> str:
     return f"mouser_instance_{digest}"
 
 
-def _try_activate_existing_instance(server_name: str, timeout_ms: int = 500) -> bool:
+def _send_local_instance_message(
+    server_name: str,
+    message: bytes = _SINGLE_INSTANCE_ACTIVATE_MSG,
+    timeout_ms: int = 500,
+) -> bool:
     sock = QLocalSocket()
     sock.connectToServer(server_name)
     if not sock.waitForConnected(timeout_ms):
         return False
-    sock.write(_SINGLE_INSTANCE_ACTIVATE_MSG)
+    sock.write(message)
     sock.waitForBytesWritten(timeout_ms)
     sock.disconnectFromServer()
     return True
+
+
+def _try_activate_existing_instance(server_name: str, timeout_ms: int = 500) -> bool:
+    return _send_local_instance_message(server_name, timeout_ms=timeout_ms)
 
 
 def _drain_local_activate_socket(sock: QLocalSocket | None) -> None:
@@ -140,6 +165,15 @@ def _drain_local_activate_socket(sock: QLocalSocket | None) -> None:
     sock.waitForReadyRead(300)
     sock.readAll()
     sock.deleteLater()
+
+
+def _read_local_instance_message(sock: QLocalSocket | None) -> bytes:
+    if not sock:
+        return b""
+    sock.waitForReadyRead(300)
+    message = bytes(sock.readAll())
+    sock.deleteLater()
+    return message
 
 
 def _single_instance_acquire(app: QApplication, server_name: str):
@@ -1000,40 +1034,7 @@ def _schedule_tray_minimized_notice(tray, locale_mgr) -> None:
     QTimer.singleShot(400, _tray_minimized_notice)
 
 
-def main():
-    # Re-exec through a `Mouser`-named symlink BEFORE anything Qt or
-    # AppKit related runs. Necessary because macOS reads the Dock label /
-    # Cmd+Tab caption from the executable basename at process creation;
-    # there is no in-process API to rename a Mach-O image after the fact.
-    # No-op when already relaunched, on non-macOS platforms, or when the
-    # symlink can't be created.
-    _maybe_relaunch_with_mouser_process_name()
-
-    _print_startup_times()
-    _t5 = _time.perf_counter()
-    if len(sys.argv) >= 3 and sys.argv[1] == "--mouser-apply-update":
-        from core.update_installer import apply_windows_update_from_state
-
-        raise SystemExit(apply_windows_update_from_state(sys.argv[2]))
-    argv, hid_backend, start_hidden, force_show = _parse_cli_args(sys.argv)
-    cfg = load_config()
-    cfg_settings = cfg.get("settings", {})
-    launch_hidden = (
-        not force_show
-        and (start_hidden or bool(cfg_settings.get("start_minimized", False)))
-    )
-    if hid_backend:
-        try:
-            set_hid_backend_preference(hid_backend)
-        except ValueError as exc:
-            raise SystemExit(f"Invalid --hid-backend setting: {exc}") from exc
-
-    # Also: also mutate the bundle's display name keys so
-    # surfaces that read from `[NSBundle mainBundle]` (application menu
-    # first item, Force Quit, notification banners) say "Mouser" too.
-    _rename_macos_bundle_for_dock()
-    _configure_windows_app_user_model_id()
-
+def _create_application(argv, *, quit_on_last_window_closed):
     QCoreApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
     app = QApplication(argv)
     app.setApplicationName("Mouser")
@@ -1043,123 +1044,122 @@ def main():
     if sys.platform == "linux":
         sync_linux_icon_theme()
     app.setWindowIcon(_app_icon())
-    app.setQuitOnLastWindowClosed(False)
-    _configure_macos_app_mode()
-    _install_macos_dock_icon()
-    ui_state = UiState(app)
+    app.setQuitOnLastWindowClosed(quit_on_last_window_closed)
+    return app
 
-    print(f"[Mouser] Version: {APP_VERSION} ({APP_BUILD_MODE})")
-    print(f"[Mouser] Commit: {APP_COMMIT_DISPLAY}")
-    print(f"[Mouser] Launch path: {_runtime_launch_path()}")
 
-    # ── Locale Manager ─────────────────────────────────────────
-    initial_lang = cfg_settings.get("language", "en")
-    locale_mgr = LocaleManager(language=initial_lang)
-
-    # macOS: allow Ctrl+C in terminal to quit the app
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
-
-    if sys.platform == "darwin":
-        # SIGUSR1 thread dump (useful for debugging on macOS)
-        import traceback
-        def _dump_threads(sig, frame):
-            import threading
-            for t in threading.enumerate():
-                print(f"\n--- {t.name} ---")
-                if t.ident:
-                    traceback.print_stack(sys._current_frames().get(t.ident))
-        signal.signal(signal.SIGUSR1, _dump_threads)
-
-    server_name = _single_instance_server_name()
-    single_server, single_exit = _single_instance_acquire(app, server_name)
-    if single_exit is not None:
-        sys.exit(single_exit)
-
-    _t6 = _time.perf_counter()
-    # ── Engine (created but started AFTER UI is visible) ───────
-    engine = Engine()
-
-    _t7 = _time.perf_counter()
-    # ── QML Backend ────────────────────────────────────────────
-    backend = Backend(engine, root_dir=ROOT)
-    ui_state.appearanceMode = backend.appearanceMode
-    backend.settingsChanged.connect(
-        lambda: setattr(ui_state, "appearanceMode", backend.appearanceMode)
-    )
+def _install_screenshot_controller(app, backend):
     if sys.platform == "win32":
         from core.key_simulator import set_screenshot_action_handler
         from ui.windows_screenshot import WindowsScreenshotController
 
-        screenshot_controller = WindowsScreenshotController(
+        controller = WindowsScreenshotController(
             status_callback=backend.statusMessage.emit,
             path_factory=backend.next_screenshot_file_path,
             parent=app,
         )
-        app._mouser_screenshot_controller = screenshot_controller
-        set_screenshot_action_handler(screenshot_controller.request_action)
     elif sys.platform == "linux":
         from core.key_simulator import set_screenshot_action_handler
         from ui.linux_screenshot import LinuxScreenshotController
 
-        screenshot_controller = LinuxScreenshotController(
+        controller = LinuxScreenshotController(
             status_callback=backend.statusMessage.emit,
             path_factory=backend.next_screenshot_file_path,
             parent=app,
         )
-        app._mouser_screenshot_controller = screenshot_controller
-        set_screenshot_action_handler(screenshot_controller.request_action)
-    elif sys.platform == "darwin":
+    else:
         from core.key_simulator import (
             execute_screenshot_shortcut,
             set_screenshot_action_handler,
         )
         from ui.macos_screenshot import MacScreenshotController
 
-        screenshot_controller = MacScreenshotController(
+        controller = MacScreenshotController(
             status_callback=backend.statusMessage.emit,
             path_factory=backend.next_screenshot_file_path,
             has_custom_directory=backend.has_custom_screenshot_directory,
             fallback_action=execute_screenshot_shortcut,
             parent=app,
         )
-        app._mouser_screenshot_controller = screenshot_controller
-        set_screenshot_action_handler(screenshot_controller.request_action)
+    app._mouser_screenshot_controller = controller
+    set_screenshot_action_handler(controller.request_action)
 
-    # ── QML Engine ─────────────────────────────────────────────
-    qml_engine = QQmlApplicationEngine()
+
+def _settings_process_command():
+    if getattr(sys, "frozen", False):
+        return [sys.executable, "--settings-process"]
+    return [sys.executable, os.path.abspath(__file__), "--settings-process"]
+
+
+def _load_settings_qml(qml_engine, backend, ui_state, locale_mgr):
     qml_engine.addImageProvider("appicons", AppIconProvider(ROOT))
     qml_engine.addImageProvider("systemicons", SystemIconProvider())
     qml_engine.rootContext().setContextProperty("backend", backend)
     qml_engine.rootContext().setContextProperty("uiState", ui_state)
     qml_engine.rootContext().setContextProperty("lm", locale_mgr)
-    qml_engine.rootContext().setContextProperty("launchHidden", launch_hidden)
+    qml_engine.rootContext().setContextProperty("launchHidden", False)
+    qml_engine.rootContext().setContextProperty("standaloneSettingsProcess", True)
     qml_engine.rootContext().setContextProperty("appVersion", APP_VERSION)
     qml_engine.rootContext().setContextProperty("appBuildMode", APP_BUILD_MODE)
     qml_engine.rootContext().setContextProperty("appCommit", APP_COMMIT_DISPLAY)
     qml_engine.rootContext().setContextProperty(
-        "appLaunchPath", _runtime_launch_path().replace("\\", "/"))
-
-    qml_path = os.path.join(ROOT, "ui", "qml", "Main.qml")
-    qml_engine.load(QUrl.fromLocalFile(qml_path))
-    _t8 = _time.perf_counter()
-
+        "appLaunchPath", _runtime_launch_path().replace("\\", "/")
+    )
+    qml_engine.load(QUrl.fromLocalFile(os.path.join(ROOT, "ui", "qml", "Main.qml")))
     if not qml_engine.rootObjects():
-        print("[Mouser] FATAL: Failed to load QML")
-        sys.exit(1)
+        raise RuntimeError("failed to load Mouser settings QML")
+    return qml_engine.rootObjects()[0]
 
-    root_window = qml_engine.rootObjects()[0]
 
-    def show_main_window():
-        # Promote BEFORE show so the window registers with WindowServer's
-        # foreground-app surfaces (Dock + Cmd+Tab + Mission Control) at
-        # creation time on macOS. visibilityChanged below also catches the
-        # transition (idempotent), so promotion is correct on the initial
-        # launch path where this function is never called.
+def _run_settings_process():
+    if QQmlApplicationEngine is None:
+        raise RuntimeError("Qt Quick was not loaded for the settings process")
+    _maybe_relaunch_with_mouser_process_name()
+    argv, _, _, _ = _parse_cli_args(sys.argv)
+    _rename_macos_bundle_for_dock()
+    _configure_windows_app_user_model_id()
+    app = _create_application(argv, quit_on_last_window_closed=True)
+    _set_macos_activation_policy(regular=True)
+    _install_macos_dock_icon()
+
+    cfg = load_config()
+    locale_mgr = LocaleManager(language=cfg.get("settings", {}).get("language", "en"))
+    remote_engine = RemoteEngine.from_environment()
+    backend = Backend(remote_engine, root_dir=ROOT)
+    ui_state = UiState(app)
+    ui_state.appearanceMode = backend.appearanceMode
+    backend.settingsChanged.connect(
+        lambda: setattr(ui_state, "appearanceMode", backend.appearanceMode)
+    )
+
+    def sync_daemon_config():
+        remote_engine.cfg = backend._cfg
+
+    backend.settingsChanged.connect(sync_daemon_config)
+    backend.mappingsChanged.connect(sync_daemon_config)
+    backend.hapticChanged.connect(sync_daemon_config)
+    backend.profilesChanged.connect(sync_daemon_config)
+    backend.activeProfileChanged.connect(sync_daemon_config)
+    backend.smartShiftChanged.connect(sync_daemon_config)
+    backend.forceSensingChanged.connect(sync_daemon_config)
+
+    def save_language():
+        saved_cfg = load_config()
+        saved_cfg.setdefault("settings", {})["language"] = locale_mgr.language
+        save_config(saved_cfg)
+        remote_engine.cfg = saved_cfg
+
+    locale_mgr.languageChanged.connect(save_language)
+    qml_engine = QQmlApplicationEngine()
+    root_window = _load_settings_qml(
+        qml_engine, backend, ui_state, locale_mgr
+    )
+
+    def show_window():
         _set_macos_activation_policy(regular=True)
         root_window.showNormal()
         root_window.raise_()
         root_window.requestActivate()
-        _schedule_macos_dock_icon_refresh()
         _activate_macos_window()
 
     def _on_window_visibility_changed(visibility):
@@ -1184,7 +1184,7 @@ def main():
             QWindow.Visibility.Hidden,
             QWindow.Visibility.Minimized,
         )
-        engine.set_frontend_visible(frontend_visible)
+        remote_engine.set_frontend_visible(frontend_visible)
         if sys.platform != "darwin":
             return
         _set_macos_activation_policy(regular=has_window_surface)
@@ -1209,51 +1209,134 @@ def main():
             lambda *_: _allow_macos_session_quit_if_requested(_MACOS_QUIT_FILTER)
         )
 
-    def _on_second_instance_activate():
-        _drain_local_activate_socket(single_server.nextPendingConnection())
-        show_main_window()
+    import queue
+    from core.local_control import LocalControlServer
 
-    single_server.newConnection.connect(_on_second_instance_activate)
+    commands = queue.Queue()
+    settings_server = LocalControlServer("settings", commands.put)
+    try:
+        settings_server.start()
+    except RuntimeError:
+        remote_engine.close()
+        return 0
 
-    print(f"[Startup] QApp create:      {(_t6-_t5)*1000:7.1f} ms")
-    print(f"[Startup] Engine create:    {(_t7-_t6)*1000:7.1f} ms")
-    print(f"[Startup] QML load:         {(_t8-_t7)*1000:7.1f} ms")
-    print(f"[Startup] TOTAL to window:  {(_t8-_t0)*1000:7.1f} ms")
+    def handle_settings_messages():
+        while True:
+            try:
+                message = commands.get_nowait()
+            except queue.Empty:
+                return
+            if message == "quit":
+                app.quit()
+            else:
+                show_window()
 
-    # ── Accessibility check (macOS) ──────────────────────────────
+    command_timer = QTimer(app)
+    command_timer.setInterval(100)
+    command_timer.timeout.connect(handle_settings_messages)
+    command_timer.start()
+    show_window()
+    try:
+        return app.exec()
+    finally:
+        settings_server.close()
+        remote_engine.close()
+
+
+def _run_daemon():
+    _maybe_relaunch_with_mouser_process_name()
+    _print_startup_times()
+    argv, hid_backend, start_hidden, force_show = _parse_cli_args(sys.argv)
+    cfg = load_config()
+    settings = cfg.get("settings", {})
+    launch_hidden = not force_show and (
+        start_hidden or bool(settings.get("start_minimized", False))
+    )
+    if hid_backend:
+        try:
+            set_hid_backend_preference(hid_backend)
+        except ValueError as exc:
+            raise SystemExit(f"Invalid --hid-backend setting: {exc}") from exc
+
+    _rename_macos_bundle_for_dock()
+    _configure_windows_app_user_model_id()
+    app = _create_application(argv, quit_on_last_window_closed=False)
+    _configure_macos_app_mode()
+    _install_macos_dock_icon()
+    locale_mgr = LocaleManager(
+        language=settings.get("language", "en")
+    )
+
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    server_name = _single_instance_server_name()
+    single_server, single_exit = _single_instance_acquire(app, server_name)
+    if single_exit is not None:
+        return single_exit
+
+    engine = Engine()
+    backend = Backend(engine, root_dir=ROOT)
+    _install_screenshot_controller(app, backend)
     accessibility_granted = _check_accessibility(locale_mgr)
-
-    # ── Start engine AFTER window is ready (deferred) ──────────
     _schedule_engine_start(engine, accessibility_granted=accessibility_granted)
+    bridge = DaemonBridgeServer(
+        engine,
+        on_shutdown=QCoreApplication.quit,
+        on_config_sync=lambda config: setattr(backend, "_cfg", config),
+        state_provider=lambda: {
+            "battery_level": backend.batteryLevel,
+            "debug_lines": list(backend._debug_lines),
+        },
+    )
+    bridge.start()
 
-    # ── System Tray ────────────────────────────────────────────
+    settings_server_name = f"{server_name}_settings"
+    settings_process = {"process": None}
+
+    def show_settings():
+        if _try_activate_existing_instance(settings_server_name, timeout_ms=150):
+            return
+        process = settings_process["process"]
+        if process is not None and process.poll() is None:
+            return
+        settings_process["process"] = subprocess.Popen(
+            _settings_process_command(),
+            cwd=ROOT,
+            env=bridge.child_environment(),
+        )
+
+    def handle_second_instance():
+        _drain_local_activate_socket(single_server.nextPendingConnection())
+        show_settings()
+
+    single_server.newConnection.connect(handle_second_instance)
+
     tray = QSystemTrayIcon(_tray_icon(), app)
     tray.setToolTip("Mouser")
-
     tray_menu = QMenu()
-
     open_action = QAction(locale_mgr.tr("tray.open_settings"), tray_menu)
-    open_action.triggered.connect(show_main_window)
+    open_action.triggered.connect(show_settings)
     tray_menu.addAction(open_action)
 
-    toggle_action = QAction(locale_mgr.tr("tray.disable_remapping"), tray_menu)
+    toggle_action = QAction("", tray_menu)
+
+    def sync_toggle_action():
+        toggle_action.setText(
+            locale_mgr.tr("tray.disable_remapping") if engine.enabled
+            else locale_mgr.tr("tray.enable_remapping")
+        )
 
     def toggle_remapping():
-        enabled = not engine.enabled
-        engine.set_enabled(enabled)
-        toggle_action.setText(
-            locale_mgr.tr("tray.disable_remapping") if enabled
-            else locale_mgr.tr("tray.enable_remapping"))
+        engine.set_enabled(not engine.enabled)
+        sync_toggle_action()
 
     toggle_action.triggered.connect(toggle_remapping)
     tray_menu.addAction(toggle_action)
 
-    debug_action = QAction(locale_mgr.tr("tray.enable_debug"), tray_menu)
+    debug_action = QAction("", tray_menu)
 
     def sync_debug_action():
-        debug_enabled = bool(backend.debugMode)
         debug_action.setText(
-            locale_mgr.tr("tray.disable_debug") if debug_enabled
+            locale_mgr.tr("tray.disable_debug") if backend.debugMode
             else locale_mgr.tr("tray.enable_debug")
         )
 
@@ -1261,28 +1344,31 @@ def main():
         backend.setDebugMode(not backend.debugMode)
         sync_debug_action()
         if backend.debugMode:
-            show_main_window()
+            show_settings()
 
     debug_action.triggered.connect(toggle_debug_mode)
     tray_menu.addAction(debug_action)
-    backend.settingsChanged.connect(sync_debug_action)
-    sync_debug_action()
 
-    check_updates_action = QAction(locale_mgr.tr("tray.check_for_updates"), tray_menu)
+    check_updates_action = QAction(
+        locale_mgr.tr("tray.check_for_updates"), tray_menu
+    )
     check_updates_action.triggered.connect(backend.manualCheckForUpdates)
     tray_menu.addAction(check_updates_action)
-
-    open_release_action = QAction(locale_mgr.tr("tray.open_latest_release"), tray_menu)
+    open_release_action = QAction(
+        locale_mgr.tr("tray.open_latest_release"), tray_menu
+    )
     open_release_action.triggered.connect(backend.openLatestReleasePage)
     tray_menu.addAction(open_release_action)
-
     tray_menu.addSeparator()
-
     quit_action = QAction(locale_mgr.tr("tray.quit"), tray_menu)
 
+    def close_settings():
+        _send_local_instance_message(
+            settings_server_name, b"quit", timeout_ms=150
+        )
+
     def quit_app():
-        if _MACOS_QUIT_FILTER is not None:
-            _MACOS_QUIT_FILTER.allow_quit()
+        close_settings()
         engine.stop()
         tray.hide()
         app.quit()
@@ -1290,30 +1376,21 @@ def main():
     quit_action.triggered.connect(quit_app)
     tray_menu.addAction(quit_action)
 
-    def _update_tray_texts():
-        """Refresh tray menu labels after a language change."""
+    def refresh_tray_state():
+        current = load_config()
+        backend._cfg = current
+        locale_mgr.setLanguage(
+            current.get("settings", {}).get("language", "en")
+        )
         open_action.setText(locale_mgr.tr("tray.open_settings"))
-        quit_action.setText(locale_mgr.tr("tray.quit"))
         check_updates_action.setText(locale_mgr.tr("tray.check_for_updates"))
         open_release_action.setText(locale_mgr.tr("tray.open_latest_release"))
+        quit_action.setText(locale_mgr.tr("tray.quit"))
+        sync_toggle_action()
         sync_debug_action()
-        # Re-sync toggle text based on current engine state
-        toggle_action.setText(
-            locale_mgr.tr("tray.disable_remapping") if engine.enabled
-            else locale_mgr.tr("tray.enable_remapping"))
 
-    def _save_language():
-        """Persist the selected language to config.json."""
-        try:
-            saved_cfg = load_config()
-            saved_cfg.setdefault("settings", {})["language"] = locale_mgr.language
-            save_config(saved_cfg)
-        except Exception as exc:
-            print(f"[Mouser] Failed to save language preference: {exc}")
-
-    locale_mgr.languageChanged.connect(_update_tray_texts)
-    locale_mgr.languageChanged.connect(_save_language)
-
+    tray_menu.aboutToShow.connect(refresh_tray_state)
+    refresh_tray_state()
     backend.updateAvailable.connect(lambda version, url: tray.showMessage(
         "Mouser",
         locale_mgr.tr("tray.update_available").format(version=version),
@@ -1322,36 +1399,39 @@ def main():
     ))
 
     tray.setContextMenu(tray_menu)
-    tray.activated.connect(lambda reason: (
-        show_main_window()
-    ) if reason in (
+    tray.activated.connect(lambda reason: show_settings() if reason in (
         QSystemTrayIcon.ActivationReason.Trigger,
         QSystemTrayIcon.ActivationReason.DoubleClick,
     ) else None)
     tray.show()
 
-    # macOS only: install a native NSStatusItem so the menu-bar icon
-    # can use AppKit's variable-length item path on notched MacBooks
-    # where Qt's square status item can disappear under constrained
-    # menu-bar space. We keep QSystemTrayIcon alive for notifications
-    # and hide only its icon surface to avoid two menu-bar items.
     if sys.platform == "darwin":
-        native_tray = _install_native_macos_status_item(
-            tray_menu, show_main_window
-        )
+        native_tray = _install_native_macos_status_item(tray_menu, show_settings)
         if native_tray is not None:
             tray.setVisible(False)
-
     if launch_hidden and QSystemTrayIcon.isSystemTrayAvailable():
         _schedule_tray_minimized_notice(tray, locale_mgr)
+    else:
+        QTimer.singleShot(0, show_settings)
 
-    # ── Run ────────────────────────────────────────────────────
     try:
-        sys.exit(app.exec())
+        return app.exec()
     finally:
+        close_settings()
+        bridge.close()
         engine.stop()
-        print("[Mouser] Shut down cleanly")
+        print("[Mouser] daemon shut down cleanly")
+
+
+def main():
+    if len(sys.argv) >= 3 and sys.argv[1] == "--mouser-apply-update":
+        from core.update_installer import apply_windows_update_from_state
+
+        return apply_windows_update_from_state(sys.argv[2])
+    if _SETTINGS_PROCESS:
+        return _run_settings_process()
+    return _run_daemon()
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/mouser_daemon_launcher.py
+++ b/mouser_daemon_launcher.py
@@ -1,0 +1,6 @@
+"""Qt-free entry point for the resident macOS daemon."""
+from core.macos_daemon import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mouser_launcher.py
+++ b/mouser_launcher.py
@@ -1,0 +1,28 @@
+"""Minimal process dispatcher that avoids importing Qt in the macOS daemon."""
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    if sys.platform == "darwin" and "--settings-process" not in sys.argv:
+        if "--ring-process" in sys.argv:
+            from ui.actions_ring_worker import main as worker_main
+
+            return worker_main()
+        if "--screenshot-process" in sys.argv:
+            from ui.screenshot_worker import main as worker_main
+
+            return worker_main()
+        if "--mouser-apply-update" not in sys.argv:
+            from core.macos_daemon import main as daemon_main
+
+            return daemon_main()
+
+    from main_qml import main as qt_main
+
+    return qt_main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mouser_ui_launcher.py
+++ b/mouser_ui_launcher.py
@@ -1,0 +1,23 @@
+"""Entry point for short-lived Qt user-interface processes."""
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    if "--ring-process" in sys.argv:
+        from ui.actions_ring_worker import main as worker_main
+
+        return worker_main()
+    if "--screenshot-process" in sys.argv:
+        from ui.screenshot_worker import main as worker_main
+
+        return worker_main()
+
+    from main_qml import main as qt_main
+
+    return qt_main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_local_control.py
+++ b/tests/test_local_control.py
@@ -1,0 +1,52 @@
+import threading
+import time
+import unittest
+import uuid
+import errno
+
+from core.local_control import LocalControlServer, send_control_message
+
+
+class LocalControlTests(unittest.TestCase):
+    def test_round_trip_message(self):
+        name = f"test-{uuid.uuid4().hex}"
+        received = []
+        event = threading.Event()
+
+        def callback(message):
+            received.append(message)
+            event.set()
+
+        server = LocalControlServer(name, callback)
+        try:
+            server.start()
+        except OSError as exc:
+            if exc.errno == errno.EPERM:
+                self.skipTest("sandbox blocks Unix-domain listeners")
+            raise
+        try:
+            self.assertTrue(send_control_message(name, "show"))
+            self.assertTrue(event.wait(1.0))
+            self.assertEqual(received, ["show"])
+        finally:
+            server.close()
+
+    def test_stale_socket_is_reclaimed(self):
+        name = f"test-{uuid.uuid4().hex}"
+        first = LocalControlServer(name, lambda _message: None)
+        try:
+            first.start()
+        except OSError as exc:
+            if exc.errno == errno.EPERM:
+                self.skipTest("sandbox blocks Unix-domain listeners")
+            raise
+        first.close()
+        time.sleep(0.01)
+
+        second = LocalControlServer(name, lambda _message: None)
+        second.start()
+        second.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_bridge.py
+++ b/tests/test_process_bridge.py
@@ -1,0 +1,83 @@
+import socket
+import threading
+import unittest
+
+from core.process_bridge import (
+    DaemonBridgeServer,
+    _read_message,
+    _write_message,
+)
+
+
+class FakeEngine:
+    def __init__(self):
+        self.cfg = {
+            "settings": {
+                "dpi": 1200,
+                "smart_shift_mode": "ratchet",
+                "smart_shift_enabled": False,
+                "smart_shift_threshold": 25,
+            }
+        }
+        self._current_profile = "default"
+        self.connected_device = None
+        self.device_connected = False
+        self.enabled = True
+        self.force_sensing_range = (20, 80)
+        self.force_sensing_supported = True
+        self.haptic_supported = True
+        self.hid_features_ready = True
+        self.smart_shift_supported = True
+        self.last_dpi = None
+
+    def set_dpi(self, value):
+        self.last_dpi = value
+        self.cfg["settings"]["dpi"] = value
+        return value
+
+    def set_enabled(self, enabled):
+        self.enabled = bool(enabled)
+
+
+class ProcessBridgeTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = FakeEngine()
+        self.server = DaemonBridgeServer.__new__(DaemonBridgeServer)
+        self.server._engine = self.engine
+        self.server._on_shutdown = None
+        self.server._state_provider = None
+        self.server._token = "test-token"
+
+    def test_remote_engine_reads_state_and_invokes_whitelisted_method(self):
+        state = self.server._dispatch("get_state", [], {})
+        self.assertTrue(state["haptic_supported"])
+        self.assertEqual(state["force_sensing_range"], [20, 80])
+        self.assertEqual(self.server._dispatch("set_dpi", [2400], {}), 2400)
+        self.assertEqual(self.engine.last_dpi, 2400)
+
+    def test_invalid_token_is_rejected(self):
+        client, server_side = socket.socketpair()
+        worker = threading.Thread(
+            target=self.server._handle_connection,
+            args=(server_side,),
+        )
+        worker.start()
+        with client:
+            _write_message(client, {
+                "token": "wrong",
+                "method": "get_state",
+                "args": [],
+                "kwargs": {},
+            })
+            response = _read_message(client)
+        worker.join(timeout=1)
+        self.assertFalse(response["ok"])
+        self.assertIn("authentication failed", response["error"])
+
+    def test_non_whitelisted_method_is_rejected(self):
+        with self.assertRaisesRegex(Exception, "method is not allowed"):
+            self.server._dispatch("__getattribute__", [], {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_split_policy.py
+++ b/tests/test_process_split_policy.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ProcessSplitPolicyTests(unittest.TestCase):
+    def test_resident_launcher_has_no_qt_import(self):
+        source = (ROOT / "mouser_daemon_launcher.py").read_text(encoding="utf-8")
+        self.assertIn("from core.macos_daemon import main", source)
+        self.assertNotIn("main_qml", source)
+        self.assertNotIn("PySide6", source)
+
+    def test_lightweight_daemon_has_no_qt_or_backend_imports(self):
+        source = (ROOT / "core" / "macos_daemon.py").read_text(encoding="utf-8")
+        self.assertNotIn("from PySide6", source)
+        self.assertNotIn("import PySide6", source)
+        self.assertNotIn("from ui.backend", source)
+
+    def test_daemon_path_does_not_import_qt_quick(self):
+        source = (ROOT / "main_qml.py").read_text(encoding="utf-8")
+        conditional = source.index('if _SETTINGS_PROCESS:')
+        qml_import = source.index('from PySide6.QtQml import QQmlApplicationEngine')
+        daemon_branch = source.index('else:', qml_import)
+        self.assertLess(conditional, qml_import)
+        self.assertLess(qml_import, daemon_branch)
+
+    def test_settings_child_is_launched_with_ui_helper(self):
+        source = (ROOT / "core" / "macos_daemon.py").read_text(encoding="utf-8")
+        self.assertIn('process_command("--settings-process")', source)
+        helper_source = (ROOT / "core" / "on_demand_ui.py").read_text(encoding="utf-8")
+        self.assertIn('"Helpers",', helper_source)
+        self.assertIn('"MouserUI.app",', helper_source)
+        settings_source = (ROOT / "main_qml.py").read_text(encoding="utf-8")
+        self.assertIn('RemoteEngine.from_environment()', settings_source)
+        self.assertIn('bridge = DaemonBridgeServer(', source)
+
+    def test_bundle_uses_separate_daemon_and_ui_analyses(self):
+        source = (ROOT / "Mouser-mac.spec").read_text(encoding="utf-8")
+        self.assertIn('["mouser_daemon_launcher.py"]', source)
+        self.assertIn('["mouser_ui_launcher.py"]', source)
+        self.assertIn('excludes=[\n        "PySide6",', source)
+        self.assertIn('"Contents", "Helpers", "MouserUI.app"', source)
+
+    def test_qt_tools_are_on_demand_workers(self):
+        source = (ROOT / "core" / "on_demand_ui.py").read_text(encoding="utf-8")
+        self.assertNotIn("PySide6", source)
+        self.assertIn('process_command("--ring-process")', source)
+        self.assertIn('process_command("--screenshot-process", action_id)', source)
+
+    def test_settings_window_quits_instead_of_hiding(self):
+        source = (ROOT / "ui" / "qml" / "Main.qml").read_text(encoding="utf-8")
+        self.assertIn('if (standaloneSettingsProcess)', source)
+        self.assertIn('Qt.quit()', source)
+
+    def test_inactive_secondary_pages_are_unloaded(self):
+        source = (ROOT / "ui" / "qml" / "Main.qml").read_text(encoding="utf-8")
+        self.assertNotIn('|| item', source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/actions_ring_worker.py
+++ b/ui/actions_ring_worker.py
@@ -1,0 +1,91 @@
+"""Short-lived Qt process hosting the original Actions Ring overlay."""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+
+from PySide6.QtCore import QObject, QTimer, Signal, Slot
+from PySide6.QtGui import QCursor
+from PySide6.QtWidgets import QApplication
+
+from core.key_simulator import ACTIONS
+from ui.actions_ring_overlay import ActionsRingOverlay, _resolve_ring_label
+
+
+def _write_event(event: str, sector: int | None = None) -> None:
+    payload = {"event": event}
+    if sector is not None:
+        payload["sector"] = int(sector)
+    sys.stdout.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+class CommandBus(QObject):
+    received = Signal(object)
+
+
+class RingWorker(QObject):
+    def __init__(self, app):
+        super().__init__()
+        self._app = app
+        self._overlay = ActionsRingOverlay()
+        self._overlay.action_selected.connect(lambda sector: _write_event("select", sector))
+        self._overlay.cancelled.connect(lambda: _write_event("cancel"))
+        self._overlay.sector_changed.connect(self._sector_changed)
+        self._idle_timer = QTimer(self)
+        self._idle_timer.setSingleShot(True)
+        self._idle_timer.setInterval(5000)
+        self._idle_timer.timeout.connect(app.quit)
+
+    @Slot(object)
+    def handle(self, message) -> None:
+        command = message.get("command")
+        if command == "show":
+            slots = list(message.get("slots", []))
+            labels = [
+                _resolve_ring_label(slot, ACTIONS.get(slot, {}).get("label", slot))
+                for slot in slots
+            ]
+            position = QCursor.pos()
+            self._idle_timer.stop()
+            self._overlay.show_ring(
+                position.x(),
+                position.y(),
+                labels,
+                interactive=bool(message.get("interactive", False)),
+            )
+        elif command == "move":
+            self._overlay.accumulate_rawxy(
+                int(message.get("dx", 0)),
+                int(message.get("dy", 0)),
+            )
+        elif command == "hide":
+            self._overlay.hide_ring()
+            self._idle_timer.start()
+        elif command == "quit":
+            self._app.quit()
+
+    def _sector_changed(self, sector: int) -> None:
+        _write_event("sector", sector)
+        _write_event("hover", sector)
+
+
+def main() -> int:
+    app = QApplication([sys.argv[0]])
+    app.setQuitOnLastWindowClosed(False)
+    bus = CommandBus()
+    worker = RingWorker(app)
+    bus.received.connect(worker.handle)
+
+    def read_commands():
+        for line in sys.stdin:
+            try:
+                message = json.loads(line)
+            except (TypeError, ValueError):
+                continue
+            bus.received.emit(message)
+        bus.received.emit({"command": "quit"})
+
+    threading.Thread(target=read_commands, daemon=True, name="MouserRingCommands").start()
+    return app.exec()

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -1592,6 +1592,8 @@ class Backend(QObject):
                 self._pending_update_plan_path,
                 helper_dir=self._pending_update_helper_dir,
             )
+            if self._engine and hasattr(self._engine, "shutdown_daemon"):
+                self._engine.shutdown_daemon()
         except Exception as exc:
             if engine_stopped and self._engine:
                 try:

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -279,15 +279,15 @@ ApplicationWindow {
                 id: mousePageView
             }
             Loader {
-                active: root.currentPage === 1 || item
+                active: root.currentPage === 1
                 source: "ScrollPage.qml"
             }
             Loader {
-                active: (root.currentPage === 2 || item) && backend.hapticSupported
+                active: root.currentPage === 2 && backend.hapticSupported
                 source: "HapticPage.qml"
             }
             Loader {
-                active: (root.currentPage === 3 || item) && backend.deviceHasActionsRing && backend.actionsRingActive
+                active: root.currentPage === 3 && backend.deviceHasActionsRing && backend.actionsRingActive
                 source: "ActionsRingConfig.qml"
             }
         }
@@ -663,12 +663,17 @@ ApplicationWindow {
         if (!root.visible) {
             return
         }
+        if (standaloneSettingsProcess) {
+            Qt.quit()
+            return
+        }
         root.hide()
     }
 
     onClosing: function(close) {
-        close.accepted = false
-        root.dismiss()
+        close.accepted = standaloneSettingsProcess
+        if (!standaloneSettingsProcess)
+            root.dismiss()
     }
 
     // LSUIElement apps have no platform menu bar binding StandardKey.Close to Cmd-W, and

--- a/ui/screenshot_worker.py
+++ b/ui/screenshot_worker.py
@@ -1,0 +1,51 @@
+"""Short-lived Qt process for macOS screenshot actions."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication
+
+from core.config import load_config
+from core.key_simulator import execute_screenshot_shortcut
+from ui.macos_screenshot import MacScreenshotController
+from ui.screenshot_common import (
+    SCREENSHOT_CLIPBOARD_ACTIONS,
+    screenshot_file_path,
+)
+
+
+def main() -> int:
+    try:
+        action_id = sys.argv[sys.argv.index("--screenshot-process") + 1]
+    except (ValueError, IndexError):
+        return 2
+
+    config = load_config()
+    custom_directory = config.get("settings", {}).get("screenshot_directory", "")
+    if action_id in SCREENSHOT_CLIPBOARD_ACTIONS or not custom_directory:
+        return 0 if execute_screenshot_shortcut(action_id) else 1
+
+    app = QApplication([sys.argv[0]])
+    app.setQuitOnLastWindowClosed(False)
+
+    def target_path() -> Path:
+        return screenshot_file_path(directory=Path(os.path.expanduser(custom_directory)))
+
+    def finished(message: str) -> None:
+        print(f"[Screenshot] {message}")
+        QTimer.singleShot(0, app.quit)
+
+    controller = MacScreenshotController(
+        status_callback=finished,
+        path_factory=target_path,
+        has_custom_directory=lambda: True,
+        fallback_action=execute_screenshot_shortcut,
+        parent=app,
+    )
+    app._mouser_screenshot_controller = controller
+    QTimer.singleShot(0, lambda: controller.request_action(action_id))
+    QTimer.singleShot(310000, app.quit)
+    return app.exec()


### PR DESCRIPTION
## What changed

- replaces the resident macOS Qt tray process with a lightweight AppKit status-item daemon
- runs Settings, the original Actions Ring, and screenshot UI in a separate on-demand `MouserUI.app` helper
- adds authenticated daemon/UI IPC and local single-instance control
- packages the daemon and Qt helper as separate PyInstaller analyses so the daemon never runs the PySide6 runtime hook
- keeps the original Actions Ring visuals and behavior unchanged

## Why

The existing single executable imports QtCore at process startup through PyInstaller's PySide6 runtime hook, even when the settings window is closed. That leaves the complete GUI runtime resident for a background mouse remapper.

This is separate from, and complementary to, the native leaks tracked in #233 and #238. Those fixes keep memory from growing over time; this change reduces the stable baseline by keeping Qt out of the resident process entirely.

On the tested Apple Silicon system, Activity Monitor settled from roughly 280 MB to roughly 48 MB after the split. Settings and the original Actions Ring start only while used and exit afterward.

## Validation

- 13 focused bridge/process-policy tests pass (2 sandbox-dependent Unix-socket tests skipped)
- daemon import-surface check reports no `PySide6` or `ui.backend` modules
- current `master` builds successfully as a dual-app PyInstaller bundle
- the staged app and nested helper pass `codesign --verify --deep --strict`
- the release ZIP passes signature verification after extraction
- MX Master 4 HID connection, remapping, Action Ring, Settings, and Accessibility behavior were tested on macOS

This is intentionally a draft because the process split is substantial and would benefit from maintainer feedback on IPC and packaging boundaries.
