### PR TITLE
fix(macos): refresh desktop when cycling across displays

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -116,8 +116,6 @@ class Engine:
         self._last_native_invert_target = (False, False)
         self._last_hid_features_ready = bool(self.hid_features_ready)
         self._hid_replay_requested_this_launch = False
-        self._desktop_info_cache = None
-        self._desktop_info_ts = 0.0
         self._desktop_direction = "right"
         self._replay_inflight = False
         self._replay_pending_rerun = False
@@ -862,12 +860,11 @@ class Engine:
             print("[Engine] cycle_desktops only supported on macOS")
             return
 
-        # Get desktop info (cached for 5 seconds to avoid subprocess per press)
-        now = time.time()
-        if self._desktop_info_cache is None or (now - self._desktop_info_ts) > 5.0:
-            self._desktop_info_cache = self._get_macos_desktop_info()
-            self._desktop_info_ts = now
-        desktop_count, current = self._desktop_info_cache
+        # Resolve the active display and space on every press.  The cursor can
+        # move between displays without changing the foreground application;
+        # caching this tuple would reuse the previous display for a few
+        # seconds and incorrectly skip a valid switch on the new display.
+        desktop_count, current = self._get_macos_desktop_info()
 
         # Only one desktop — nothing to cycle
         if desktop_count <= 1:
@@ -898,7 +895,6 @@ class Engine:
             execute_action("space_left")
 
         self._desktop_direction = direction
-        self._desktop_info_cache = (desktop_count, next_pos)
 
     def _make_hscroll_handler(self, action_id):
         def handler(event):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -288,6 +288,34 @@ class EngineHorizontalScrollTests(unittest.TestCase):
         self.assertTrue(engine._app_detector.start_called)
 
 
+class EngineDesktopCycleTests(unittest.TestCase):
+    def _make_engine(self):
+        from core.engine import Engine
+
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        with (
+            patch("core.engine.MouseHook", _FakeMouseHook),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=cfg),
+        ):
+            return Engine()
+
+    def test_cycle_desktops_refreshes_display_after_cursor_moves(self):
+        engine = self._make_engine()
+        desktop_info = Mock(side_effect=[(1, 1), (2, 1)])
+
+        with (
+            patch("core.engine.sys.platform", "darwin"),
+            patch.object(engine, "_get_macos_desktop_info", desktop_info),
+            patch("core.engine.execute_action") as execute_action_mock,
+        ):
+            engine._cycle_desktops()  # Secondary display: one desktop, skip.
+            engine._cycle_desktops()  # Main display: refresh and switch.
+
+        self.assertEqual(desktop_info.call_count, 2)
+        execute_action_mock.assert_called_once_with("space_right")
+
+
 class EngineReplayPhaseOneTests(unittest.TestCase):
     def _make_engine(self):
         from core.engine import Engine


### PR DESCRIPTION
## Summary

- Refresh macOS desktop/display information on every Cycle Desktops press.
- Prevent stale 5-second display cache from skipping a valid Mode Shift action after moving between monitors.
- Add a regression test for switching from a single-space secondary display to the main display.

## Validation

- `python -m unittest -q tests.test_engine` (24 tests passed).
- Full suite has unrelated environment/platform failures involving macOS permissions, screenshot directories, single-instance IPC, and wheel inversion mocks.