### PR TITLE
fix(macos): drain autorelease pools around the native HID read-loop pump

### DIFF
--- a/MEMORY_LEAK_PLAN.md
+++ b/MEMORY_LEAK_PLAN.md
@@ -153,6 +153,14 @@ confound.
 6. **Wrap the gesture-thread report-consumption loop and the auxiliary
    threads** (§2.2) with the same helper: reconnect loop, battery poll,
    smart-shift poll. One shared decorator, applied at thread entry points.
+   > **Status:** steps 5–6 are implemented on this branch — `core/hid_gesture.py`
+   > now binds `NSAutoreleasePool` via `libobjc` (ctypes, no PyObjC dependency,
+   > graceful no-op fallback) and drains a pool around each
+   > `CFRunLoopRunInMode` pump iteration in `read()` plus the
+   > `enumerate_infos`/`open`/`write`/`close` entry points, covering every
+   > thread that crosses into IOKit/Foundation at the choke point. Awaiting
+   > on-device validation (step 7).
+
 7. **Validate** with the reporters' existing protocols (they have offered):
    bdhwrsh's scroll-only vs. click-only A/B plus 10 h footprint sampling;
    maxhis' `heap -s`/`leaks --groupByType` before/after — expected result:

--- a/MEMORY_LEAK_PLAN.md
+++ b/MEMORY_LEAK_PLAN.md
@@ -1,0 +1,229 @@
+# Memory Problem — Consolidated Status & Action Plan
+
+*Last updated: 2026-07-21 (master @ `7bae4d5`, app version 3.7.0).*
+
+This document arranges every issue and PR that refers to the long-running
+memory-growth problem, records what each one proved, and lays out the plan for
+the remaining work. The problem is macOS-specific in every confirmed report;
+the leaked memory is native (Foundation/Quartz/IOKit), not Python objects.
+
+---
+
+## 1. Inventory
+
+### Issues
+
+| Issue | Title | State | Status |
+|---|---|---|---|
+| [#150](https://github.com/TomBadash/Mouser/issues/150) | High memory usage, 1.29 GB (macOS 26, MX Master 4, BLE) | **Closed** | Fixed by PR #151 (bounded dispatch backlog), merged 2026-05-12. |
+| [#233](https://github.com/TomBadash/Mouser/issues/233) | High memory usage, grows over time / with click count (v3.6.0–v3.7.0, MX Master 2S/3S, Bluetooth; 4 reporters) | **Open** | Partially fixed by PR #242 (click path confirmed fixed). **Scroll path still leaks** (~7–8 MB/min while scrolling); one tester still hits 700 MB in ~4.5 h on the PR-242 build. |
+| [#238](https://github.com/TomBadash/Mouser/issues/238) | Repeated HID reconnects leak `IOHIDManager` objects + Mach ports → 3.3 GB (macOS 26.4.1, MX Master, BLE) | **Open** | Core leak fixed by PR #240 and **validated on-device** (managers pinned at 2, ports 67,862 → 2,646). A separate `HIDEvent`/`CGEvent`/`GPProcessMonitor` retention path remains (~926 MB after 20 h). |
+
+Near-matches excluded from scope: #134 (Win ARM64 native build — battery/architecture request), PR #180 (DPI persistence), PR #212 (G602 catalog). They matched the keyword search only.
+
+### Pull requests
+
+| PR | Title | State | Addresses | Outcome |
+|---|---|---|---|---|
+| [#125](https://github.com/TomBadash/Mouser/pull/125) | `@_autoreleased` on CGEventTap callback + `get_foreground_exe` | **Merged** 2026-04-24 | ~1.4 GB / 2-day leak | Fixed event-tap *ingestion* and added a pool to the app poller. `GPProcessMonitor` still accumulates despite the pool (see §2.3). |
+| [#151](https://github.com/TomBadash/Mouser/pull/151) | Bound hook dispatch backlogs (512-entry queue, drop-oldest) | **Merged** 2026-05-12 | #150 | Prevents unbounded Python-side event backlog. Cross-platform. |
+| [#240](https://github.com/TomBadash/Mouser/pull/240) | Close `IOHIDManager` + exception-safe open/close + reconnect backoff + REPROG_V4 probe cooldown | **Open** | #238 | **Validated** by two testers (maxhis 20 h run, mizi 32 h run). Manager/port explosion resolved. Residual growth is a different signature. |
+| [#242](https://github.com/TomBadash/Mouser/pull/242) | Autorelease pools on action-execution threads (`_dispatch_worker`, `key_simulator` injection entry points) | **Open** | #233 | **Validated for clicks** (click-only burst: +4 MB ≈ noise, vs. clear growth on v3.7.0). **Not sufficient**: scroll-only test still leaks +19 MB / 2.5 min. |
+| [#243](https://github.com/TomBadash/Mouser/pull/243) | Split macOS daemon from on-demand Qt UI | **Open (draft)** | Baseline footprint (complementary to the leaks) | Resident process drops ~280 MB → ~48 MB by keeping the PySide6 runtime out of the daemon. Substantial architectural change; author requests maintainer feedback on IPC/packaging. |
+
+### How they relate
+
+```
+#150 (closed) ── fixed by ── #151 (merged)          Python-side backlog, done
+#233 (open)  ─┬─ partially fixed by #242 (open)     click path ✅, scroll path ❌
+              └─ remaining: HID read-loop pool      → Phase 1 below
+#238 (open)  ─┬─ core leak fixed by #240 (open)     managers/ports ✅, validated
+              └─ remaining: HIDEvent/GPProcessMonitor retention → Phases 1–2 below
+#125 (merged) ── same residual signature persists on macOS 26.4.1 → Phases 1–2
+#243 (draft)  ── independent baseline reduction     → Phase 4 below
+```
+
+The residual growth reported on **both** open issues after their respective fix
+PRs has the **same heap signature**, so #233 and #238 converge on the same
+remaining root causes.
+
+---
+
+## 2. Evidence synthesis — what is actually still leaking
+
+Post-fix test data (maxhis' 20 h heap capture on the #240 build; bdhwrsh's
+10 h sampling on the #242 build):
+
+| Retained class | Count / size after 20 h | Likely source |
+|---|---|---|
+| `HIDEvent` | 1,572,804 / 168 MB | IOHID input reports delivered on the HID gesture thread |
+| `CGSEventAppendix` + `CGEvent` | ~524k / 96 MB | Quartz event machinery on un-pooled threads |
+| `GPProcessMonitor` → `NSXPCConnection`, `dispatch_queue_t`, … | 8,892 monitors; `leaks` ROOT LEAK, 19.5 MB + supporting tree | `NSWorkspace.frontmostApplication()` polling |
+| `IOHIDManager` | **2 (stable — fixed by #240)** | — |
+
+Behavioral measurements on the #242 build (bdhwrsh, macOS 27 beta, MX Master 3S):
+
+- Idle/asleep 8 h: **flat** (536 MB, zero growth).
+- Active use: **~110 MB/h** linear growth.
+- Scroll-only 2.5 min: **+19 MB**. Click-only ~100 presses: +4 MB (noise).
+- Their config diverts the hi-res wheel (`0x2121`, mul=15) and thumb wheel
+  (`0x2150`, divertedRes=120) — wheel events arrive at far higher rates than
+  clicks, and each diverted notification is an IOHID input report.
+
+### 2.1 Remaining root cause A — HID read-loop pump has no autorelease pool
+
+`_MacNativeHidDevice.read()` pumps the run loop on the **HID gesture thread**
+(`core/hid_gesture.py:700`, `CFRunLoopRunInMode` in 0.05 s slices) and input
+reports are delivered into `_on_input_report` (`core/hid_gesture.py:670`)
+inside that pump. Nothing on that thread ever drains an autorelease pool on
+master:
+
+- PR #125 pooled the *CGEventTap* callback thread — different thread.
+- PR #242 pools the injection entry points (`execute_action`,
+  `inject_scroll`, …) — coverage starts only *after* the gesture recognizer
+  decides to act. The per-report Foundation/IOKit temporaries created by the
+  run-loop delivery itself (the `HIDEvent` cluster) are never drained.
+
+This precisely fits "scroll leaks, clicks don't" on the #242 build: every wheel
+detent produces ~15 diverted reports through this pump. It was explicitly
+declared out of scope in #240 ("native read-loop pool… can follow separately").
+Note that `7bae4d5` (#244) made hi-res scroll *survive* reconnects, which
+increases diverted-wheel traffic — making this fix more urgent, not less.
+
+### 2.2 Remaining root cause B — un-pooled auxiliary threads (defense in depth)
+
+Longer-interval engine threads (battery poll every 1800 s, smart-shift poll
+every 300 s, reconnect loop) touch HID/Foundation without pools. Low rate, so
+they are not the main driver, but they should be wrapped while we are at it so
+no macOS thread that crosses into native frameworks is left bare.
+
+### 2.3 Remaining root cause C — `GPProcessMonitor` XPC tree from 0.3 s app polling
+
+`AppDetector` calls `NSWorkspace.frontmostApplication()` every 0.3 s
+(`core/app_detector.py:364`, poll loop at `:384`) — ~288,000 calls/day. The
+call has been pool-wrapped since #125, yet `leaks` still reports the
+`GPProcessMonitor` tree as a ROOT LEAK: the retention is inside the framework's
+XPC machinery, so pooling alone cannot reclaim it. The only robust mitigation
+is to make detection **event-driven** (NSWorkspace
+`didActivateApplicationNotification`) so the call count collapses from ~288k/day
+to the number of actual app switches.
+
+### 2.4 Open discrepancy to resolve during validation
+
+skinnyshy reports ~430 MB/h growth on the #242 build "even on standby", while
+bdhwrsh measured a flat idle. Possible explanations: different idle definitions
+(display asleep vs. machine in use but untouched), BLE reconnect cycles during
+standby (the #240 fix is **not** in the #242 branch — the two builds each carry
+only their own fix), or diverted-wheel traffic from incidental motion. First
+validation step in Phase 1 is a build containing **both** fixes to remove this
+confound.
+
+---
+
+## 3. Action plan
+
+### Phase 0 — Land the validated fixes (immediately)
+
+1. **Merge #240** (`fix/238-macos-hid-manager-leak`). Two independent on-device
+   validations confirm the manager/port leak is gone; the residual growth is a
+   separate signature. Rebase on master first — both #240 and #244 touch
+   `core/hid_gesture.py`.
+2. **Merge #242**. The click-path fix is confirmed by A/B measurement; it is
+   strictly an improvement. Note in the merge comment that #233 stays open for
+   the scroll path.
+3. **Open a new focused issue** — "macOS: HIDEvent/CGEvent/GPProcessMonitor
+   retention on long-running sessions" — capturing §2's residual signature and
+   linking #233/#238 (maxhis already offered to track it separately). Close
+   #238 once #240 is merged, pointing to the new issue for the remainder;
+   keep #233 open until Phase 1 is validated.
+4. Ask testers to hold further long-run measurements until a master build
+   contains both merges (removes the confound in §2.4).
+
+### Phase 1 — Fix the read-loop leak (target: v3.7.1 hotfix; closes #233)
+
+5. **Pool the HID read-loop pump**: drain an autorelease pool around the
+   `CFRunLoopRunInMode` pump in `_MacNativeHidDevice.read()`
+   (`core/hid_gesture.py:691-710`). Draining once per `read()` call bounds the
+   cost (the call already returns at ≤0.05 s granularity); if profiling shows
+   pool-churn overhead at high wheel rates, drain every N iterations instead.
+   Implementation detail: this file uses raw `ctypes`, not PyObjC — either
+   reuse `objc.autorelease_pool()` guarded by availability (as `key_simulator`
+   does in #242), or bind `NSAutoreleasePool` via `ctypes`/`objc_msgSend` so the
+   native backend keeps working without PyObjC.
+6. **Wrap the gesture-thread report-consumption loop and the auxiliary
+   threads** (§2.2) with the same helper: reconnect loop, battery poll,
+   smart-shift poll. One shared decorator, applied at thread entry points.
+7. **Validate** with the reporters' existing protocols (they have offered):
+   bdhwrsh's scroll-only vs. click-only A/B plus 10 h footprint sampling;
+   maxhis' `heap -s`/`leaks --groupByType` before/after — expected result:
+   `HIDEvent` count bounded, scroll-only delta ≈ click-only delta ≈ noise.
+8. **Release v3.7.1** with #240 + #242 + this fix once two reporters confirm
+   flat memory over ≥24 h.
+
+### Phase 2 — Eliminate the `GPProcessMonitor` accumulation (v3.8)
+
+9. Replace the 0.3 s macOS poll in `AppDetector` with
+   `NSWorkspace.didActivateApplicationNotification` (event-driven; keep the
+   poll as a fallback and on Windows/Linux where no equivalent leak exists).
+   Per-app profiles keep working identically — `_on_change` semantics are
+   unchanged, only the trigger differs.
+10. Re-validate with `leaks --nostacks --groupByType`: the ROOT LEAK
+    `GPProcessMonitor` tree should stop growing entirely.
+
+### Phase 3 — Bound, observe, and prevent regressions
+
+11. **Lightweight memory self-reporting**: log process footprint (macOS
+    `phys_footprint` via `task_info`, RSS elsewhere) at startup and hourly at
+    debug level. Every future report then carries the growth curve in the log
+    file users already attach to the issue template.
+12. **Regression tests**: extend #240's throttle tests with a high-rate
+    synthetic wheel-report replay through the recognizer asserting bounded
+    Python-side object counts; document the macOS-only manual checklist
+    (`vmmap`/`heap`/`leaks` stress steps from #238) in `DEVELOPMENT.md` as a
+    release gate, since CI runners are Linux and cannot exercise
+    IOKit/Foundation paths.
+13. Track an upstream radar/feedback for the `GPProcessMonitor` framework leak
+    (it reproduces with a pooled caller on macOS 26.4.1/27 beta) so it can be
+    linked from the code comment.
+
+### Phase 4 — Baseline reduction (v3.8+, independent track)
+
+14. **Review draft #243** (daemon/UI process split, ~280 MB → ~48 MB resident).
+    This attacks the *baseline*, not the leaks, and is complementary. Requested
+    feedback for the author: IPC auth/packaging boundaries, signing
+    implications for the nested helper app, and a rebase once Phase 0–1 fixes
+    land. Substantial change from a first-time contributor — schedule a real
+    review rather than letting the draft go stale.
+
+### Sequencing summary
+
+| Order | Work | Vehicle | Closes |
+|---|---|---|---|
+| Now | Merge #240, #242; open residual-leak issue | existing PRs | #238 (core) |
+| Next | Read-loop + thread pools (§Phase 1) | new PR → v3.7.1 | #233, residual issue (HIDEvent part) |
+| Then | Event-driven app detection (§Phase 2) | new PR → v3.8 | residual issue (GPProcessMonitor part) |
+| Parallel | Footprint logging + regression tests (§Phase 3) | new PR → v3.8 | — |
+| Parallel | #243 review/iteration (§Phase 4) | draft PR → v3.8+ | — |
+
+---
+
+## 4. Verification protocol (shared by all phases)
+
+Reproducible measurement commands, standardized from #238 so all reporters
+produce comparable numbers:
+
+```bash
+PID="$(pgrep -x Mouser)"
+top -l 1 -pid "$PID" -stats pid,command,cpu,mem,ports,threads,time
+vmmap -summary "$PID"
+heap -s -H "$PID"
+leaks --nostacks --groupByType "$PID"
+```
+
+Acceptance criteria for calling the memory problem fixed:
+
+- `IOHIDManager` count constant (2) across reconnect storms — *already met by #240*.
+- Mach ports return near baseline after reconnect activity — *substantially met by #240*.
+- `HIDEvent`/`CGEvent` counts bounded during sustained scrolling — *Phase 1*.
+- `GPProcessMonitor` ROOT LEAK stops growing — *Phase 2*.
+- Physical footprint flat (±50 MB) over 24 h of active use on BLE — *overall*.

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -12,6 +12,7 @@ Falls back gracefully if the package or device are unavailable.
 """
 
 import atexit
+import functools
 import os
 import stat
 import sys
@@ -401,6 +402,51 @@ if sys.platform == "darwin":
         _K_IOHID_REPORT_TYPE_OUTPUT = 1
         _K_CF_RUN_LOOP_DEFAULT_MODE = c_void_p.in_dll(_cf, "kCFRunLoopDefaultMode")
 
+        # NSAutoreleasePool via libobjc: the IOHID paths below run on plain
+        # Python threads (HID listener, reconnect loop, battery/smart-shift
+        # pollers) that never drain an autorelease pool, so autoreleased
+        # Foundation/IOKit temporaries — most visibly the HIDEvent objects
+        # produced while CFRunLoopRunInMode delivers input reports — would
+        # otherwise accumulate for the process lifetime (#233, #238).
+        try:
+            _objc_rt = ctypes.CDLL("/usr/lib/libobjc.A.dylib")
+            _objc_rt.objc_getClass.argtypes = [c_char_p]
+            _objc_rt.objc_getClass.restype = c_void_p
+            _objc_rt.sel_registerName.argtypes = [c_char_p]
+            _objc_rt.sel_registerName.restype = c_void_p
+            _objc_rt.objc_msgSend.argtypes = [c_void_p, c_void_p]
+            _objc_rt.objc_msgSend.restype = c_void_p
+            _NS_POOL_CLASS = _objc_rt.objc_getClass(b"NSAutoreleasePool")
+            _SEL_NEW = _objc_rt.sel_registerName(b"new")
+            _SEL_DRAIN = _objc_rt.sel_registerName(b"drain")
+            _OBJC_POOL_OK = bool(_NS_POOL_CLASS and _SEL_NEW and _SEL_DRAIN)
+        except Exception as _pool_exc:
+            print(f"[HidGesture] NSAutoreleasePool unavailable: {_pool_exc}")
+            _OBJC_POOL_OK = False
+
+        class _AutoreleasePool:
+            __slots__ = ("_pool",)
+
+            def __enter__(self):
+                self._pool = (
+                    _objc_rt.objc_msgSend(_NS_POOL_CLASS, _SEL_NEW)
+                    if _OBJC_POOL_OK else None
+                )
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                pool, self._pool = self._pool, None
+                if pool:
+                    _objc_rt.objc_msgSend(pool, _SEL_DRAIN)
+                return False
+
+        def _pooled(fn):
+            @functools.wraps(fn)
+            def wrapper(*args, **kwargs):
+                with _AutoreleasePool():
+                    return fn(*args, **kwargs)
+            return wrapper
+
         _MAC_NATIVE_OK = True
     except Exception as exc:
         print(f"[HidGesture] macOS native HID unavailable: {exc}")
@@ -506,6 +552,7 @@ if _MAC_NATIVE_OK:
             _cf.CFRelease(manager)
 
         @classmethod
+        @_pooled
         def enumerate_infos(cls):
             infos = []
             manager = None
@@ -572,6 +619,7 @@ if _MAC_NATIVE_OK:
                     _cf.CFRelease(item)
             return infos
 
+        @_pooled
         def open(self):
             """Exception-safe open. On any partial failure, release every
             CoreFoundation object allocated so far so a failed open cannot
@@ -659,6 +707,7 @@ if _MAC_NATIVE_OK:
                 parts.append(f'transport "{self._transport}"')
             return "No IOHIDDevice for " + " ".join(parts)
 
+        @_pooled
         def close(self):
             if self._device and self._run_loop:
                 try:
@@ -694,6 +743,7 @@ if _MAC_NATIVE_OK:
         def set_nonblocking(self, _enabled):
             return None
 
+        @_pooled
         def write(self, buf):
             arr = (c_uint8 * len(buf))(*buf)
             res = _iokit.IOHIDDeviceSetReport(
@@ -737,11 +787,15 @@ if _MAC_NATIVE_OK:
                 else:
                     slice_seconds = 0.05
 
-                _cf.CFRunLoopRunInMode(
-                    _K_CF_RUN_LOOP_DEFAULT_MODE,
-                    slice_seconds,
-                    True,
-                )
+                # Pool per pump iteration: input-report callbacks fire inside
+                # this call, and their per-report temporaries must not outlive
+                # the slice.
+                with _AutoreleasePool():
+                    _cf.CFRunLoopRunInMode(
+                        _K_CF_RUN_LOOP_DEFAULT_MODE,
+                        slice_seconds,
+                        True,
+                    )
                 try:
                     return self._report_queue.get_nowait()
                 except queue.Empty:

--- a/tests/test_spec_coverage.py
+++ b/tests/test_spec_coverage.py
@@ -1,0 +1,374 @@
+"""Guard tests keeping the PyInstaller specs in sync with the codebase.
+
+The three spec files are easy to forget when a commit adds a module, a data
+file, or a QML import. These tests parse the specs (without executing
+PyInstaller) and fail when the app's actual imports or bundled assets drift
+from what the specs declare, so packaged builds cannot silently lose
+functionality that works from a source checkout.
+"""
+
+import ast
+import os
+import re
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+SPEC_FILES = {
+    "windows": "Mouser.spec",
+    "macos": "Mouser-mac.spec",
+    "linux": "Mouser-linux.spec",
+}
+
+# App code that ships inside the bundle. scripts/ and tools/ are build/dev-side.
+APP_CODE_DIRS = ("core", "ui")
+APP_ENTRY = "main_qml.py"
+
+# Conditional / lazy imports PyInstaller's static analysis can miss on the
+# platform they matter for. A new runtime dependency loaded behind a guard
+# must be added both here and to the relevant spec(s).
+REQUIRED_HIDDENIMPORTS = {
+    "windows": {"hid", "logging.handlers", "ctypes.wintypes", "ui.locale_manager"},
+    "macos": {"hid", "logging.handlers", "ui.locale_manager"},
+    "linux": {"hid", "hidraw", "evdev", "logging.handlers", "ui.locale_manager"},
+}
+
+# Qt libraries each QML import pulls in at runtime. An unmapped QML import
+# fails the test on purpose: whoever adds it must extend this mapping AND the
+# keep-lists in the specs/build_support so the packaged builds ship the
+# libraries the new QML page needs.
+QML_IMPORT_TO_QT_LIBS = {
+    "QtQml": {"Qt6Qml"},
+    "QtQuick": {"Qt6Quick"},
+    "QtQuick.Window": set(),
+    "QtQuick.Layouts": {"Qt6QuickLayouts"},
+    "QtQuick.Effects": {"Qt6QuickEffects"},
+    "QtQuick.Shapes": {"Qt6QuickShapes"},
+    "QtQuick.Controls": {"Qt6QuickControls2", "Qt6QuickTemplates2"},
+    "QtQuick.Controls.Material": {
+        "Qt6QuickControls2Material",
+        "Qt6QuickControls2MaterialStyleImpl",
+    },
+}
+
+# QML plugin directories (under PySide6/qml/) needed per import.
+QML_IMPORT_TO_QML_DIRS = {
+    "QtQml": ("QtQml", None),
+    "QtQuick": ("QtQuick", None),
+    "QtQuick.Window": ("QtQuick", "Window"),
+    "QtQuick.Layouts": ("QtQuick", "Layouts"),
+    "QtQuick.Effects": ("QtQuick", "Effects"),
+    "QtQuick.Shapes": ("QtQuick", "Shapes"),
+    "QtQuick.Controls": ("QtQuick", "Controls"),
+    "QtQuick.Controls.Material": ("QtQuick", "Controls"),
+}
+
+# Excludes that clash with an import that only executes on another platform.
+# Each entry must say why trimming is safe for that spec's target OS; anything
+# not listed here fails the excludes test and needs a conscious decision.
+PLATFORM_GUARDED_EXCLUDES = {
+    # ui/linux_screenshot.py imports QtDBus (behind try/except) for the Linux
+    # portal screenshot backend only; the Windows bundle trims it safely.
+    ("windows", "PySide6.QtDBus"),
+}
+
+# Assets referenced by path from Python code (not covered by a whole-dir
+# bundle on every platform, or load-bearing enough to pin explicitly).
+REQUIRED_ASSETS = (
+    os.path.join("images", "logo.ico"),          # Windows EXE icon
+    os.path.join("images", "AppIcon.icns"),      # macOS bundle icon
+    os.path.join("images", "logo_icon.png"),     # tray/autostart icon
+    os.path.join("images", "icons", "mouse-simple.svg"),
+    os.path.join("ui", "qml", "Theme.js"),
+)
+
+
+def _read(path):
+    with open(os.path.join(REPO_ROOT, path), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _spec_tree(platform_key):
+    return ast.parse(_read(SPEC_FILES[platform_key]))
+
+
+def _find_analysis_call(tree):
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "Analysis"
+        ):
+            return node
+    return None
+
+
+def _keyword(call, name):
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _string_list(node):
+    values = []
+    if node is None:
+        return values
+    for elt in getattr(node, "elts", []):
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            values.append(elt.value)
+    return values
+
+
+def _join_call_to_relpath(node):
+    """Turn os.path.join(ROOT, "a", "b") / os.path.join("a", "b") into a/b."""
+    if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+        return None
+    parts = []
+    for arg in node.args:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            parts.append(arg.value)
+        elif isinstance(arg, ast.Name):
+            continue  # ROOT-style prefix
+        else:
+            return None
+    return "/".join(parts) if parts else None
+
+
+def _datas_sources(call):
+    """Repo-relative source paths of every datas entry, plus bare names."""
+    sources = []
+    datas = _keyword(call, "datas")
+    for elt in getattr(datas, "elts", []):
+        if not isinstance(elt, ast.Tuple) or not elt.elts:
+            continue
+        src = elt.elts[0]
+        if isinstance(src, ast.Name):
+            sources.append(src.id)
+        elif isinstance(src, ast.Constant) and isinstance(src.value, str):
+            sources.append(src.value.replace(os.sep, "/"))
+        else:
+            rel = _join_call_to_relpath(src)
+            if rel:
+                sources.append(rel)
+    return sources
+
+
+def _module_level_set(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if name in targets:
+                return set(_string_list(node.value))
+    return set()
+
+
+def _app_imports():
+    """Every dotted module name imported anywhere in the bundled app code."""
+    imported = set()
+    files = [os.path.join(REPO_ROOT, APP_ENTRY)]
+    for dirname in APP_CODE_DIRS:
+        for root, _dirs, names in os.walk(os.path.join(REPO_ROOT, dirname)):
+            if "__pycache__" in root:
+                continue
+            files.extend(
+                os.path.join(root, n) for n in names if n.endswith(".py")
+            )
+    for path in files:
+        with open(path, encoding="utf-8") as fh:
+            try:
+                tree = ast.parse(fh.read())
+            except SyntaxError:  # pragma: no cover - would fail elsewhere
+                continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                imported.add(node.module)
+    return imported
+
+
+def _qml_imports():
+    imports = set()
+    qml_dir = os.path.join(REPO_ROOT, "ui", "qml")
+    pattern = re.compile(r"^import\s+(Qt[\w.]*)", re.MULTILINE)
+    for name in os.listdir(qml_dir):
+        if not name.endswith(".qml"):
+            continue
+        with open(os.path.join(qml_dir, name), encoding="utf-8") as fh:
+            imports.update(pattern.findall(fh.read()))
+    return imports
+
+
+class SpecStructureTests(unittest.TestCase):
+    """Every platform spec exists, analyzes the entry point, bundles the app data."""
+
+    def test_specs_exist_and_analyze_entry_point(self):
+        for platform_key, filename in SPEC_FILES.items():
+            with self.subTest(platform=platform_key):
+                self.assertTrue(
+                    os.path.exists(os.path.join(REPO_ROOT, filename)), filename
+                )
+                call = _find_analysis_call(_spec_tree(platform_key))
+                self.assertIsNotNone(call, f"{filename}: no Analysis(...) call")
+                entries = _string_list(call.args[0] if call.args else None)
+                self.assertIn(APP_ENTRY, entries, filename)
+
+    def test_all_specs_bundle_qml_images_and_build_info(self):
+        for platform_key, filename in SPEC_FILES.items():
+            with self.subTest(platform=platform_key):
+                call = _find_analysis_call(_spec_tree(platform_key))
+                sources = _datas_sources(call)
+                self.assertIn("ui/qml", sources, filename)
+                self.assertIn("images", sources, filename)
+                self.assertIn(
+                    "BUILD_INFO_DATA",
+                    sources,
+                    f"{filename}: mouser_build_info.json (core/version.py "
+                    f"reads it from the bundle root) is not in datas",
+                )
+
+    def test_linux_spec_bundles_every_packaging_file(self):
+        call = _find_analysis_call(_spec_tree("linux"))
+        sources = set(_datas_sources(call))
+        packaging_dir = os.path.join(REPO_ROOT, "packaging", "linux")
+        for name in sorted(os.listdir(packaging_dir)):
+            rel = f"packaging/linux/{name}"
+            covered = rel in sources or any(
+                rel.startswith(src + "/") for src in sources
+            )
+            with self.subTest(file=rel):
+                self.assertTrue(
+                    covered,
+                    f"{rel} exists but Mouser-linux.spec does not bundle it "
+                    f"(startup.py resolves packaging assets from the bundle)",
+                )
+
+
+class HiddenImportTests(unittest.TestCase):
+    """Conditional imports each platform needs are declared."""
+
+    def test_required_hiddenimports_present(self):
+        for platform_key, required in REQUIRED_HIDDENIMPORTS.items():
+            with self.subTest(platform=platform_key):
+                call = _find_analysis_call(_spec_tree(platform_key))
+                declared = set(_string_list(_keyword(call, "hiddenimports")))
+                missing = required - declared
+                self.assertFalse(
+                    missing,
+                    f"{SPEC_FILES[platform_key]} hiddenimports missing: "
+                    f"{sorted(missing)}",
+                )
+
+
+class ExcludesConsistencyTests(unittest.TestCase):
+    """No spec excludes a module the app code actually imports."""
+
+    def test_no_excluded_module_is_imported(self):
+        imported = _app_imports()
+        for platform_key, filename in SPEC_FILES.items():
+            call = _find_analysis_call(_spec_tree(platform_key))
+            excludes = _string_list(_keyword(call, "excludes"))
+            for excluded in excludes:
+                if (platform_key, excluded) in PLATFORM_GUARDED_EXCLUDES:
+                    continue
+                clashes = sorted(
+                    name
+                    for name in imported
+                    if name == excluded or name.startswith(excluded + ".")
+                )
+                with self.subTest(platform=platform_key, exclude=excluded):
+                    self.assertFalse(
+                        clashes,
+                        f"{filename} excludes {excluded!r} but the app "
+                        f"imports {clashes} — the packaged build would "
+                        f"crash at that import",
+                    )
+
+
+class QmlCoverageTests(unittest.TestCase):
+    """QML imports map to Qt libraries and qml dirs every spec keeps."""
+
+    def setUp(self):
+        self.qml_imports = _qml_imports()
+
+    def test_every_qml_import_is_mapped(self):
+        unmapped = sorted(self.qml_imports - set(QML_IMPORT_TO_QT_LIBS))
+        self.assertFalse(
+            unmapped,
+            f"New QML import(s) {unmapped} are not in the coverage mapping. "
+            f"Add them to QML_IMPORT_TO_QT_LIBS / QML_IMPORT_TO_QML_DIRS "
+            f"here AND to the keep-lists in Mouser.spec and "
+            f"build_support.py so packaged builds ship them.",
+        )
+
+    def _required_libs(self):
+        required = set()
+        for qml_import in self.qml_imports:
+            required.update(QML_IMPORT_TO_QT_LIBS.get(qml_import, set()))
+        return required
+
+    def test_windows_spec_keeps_required_qt_libs_and_qml_dirs(self):
+        tree = _spec_tree("windows")
+        qt_keep = _module_level_set(tree, "_qt_keep")
+        keep_qml = _module_level_set(tree, "_keep_qml")
+        keep_qtquick = _module_level_set(tree, "_keep_qtquick")
+
+        missing = self._required_libs() - qt_keep
+        self.assertFalse(
+            missing, f"Mouser.spec _qt_keep missing: {sorted(missing)}"
+        )
+        for qml_import in self.qml_imports:
+            top, sub = QML_IMPORT_TO_QML_DIRS.get(qml_import, (None, None))
+            if top:
+                self.assertIn(top, keep_qml, f"{qml_import}: qml/{top}")
+            if sub:
+                self.assertIn(
+                    sub, keep_qtquick, f"{qml_import}: qml/QtQuick/{sub}"
+                )
+
+    def test_linux_keep_lists_cover_required_qt_libs_and_qml_dirs(self):
+        import build_support
+
+        missing = self._required_libs() - set(build_support.LINUX_QT_KEEP)
+        self.assertFalse(
+            missing,
+            f"build_support.LINUX_QT_KEEP missing: {sorted(missing)}",
+        )
+        for qml_import in self.qml_imports:
+            top, sub = QML_IMPORT_TO_QML_DIRS.get(qml_import, (None, None))
+            if top:
+                self.assertIn(top, build_support.LINUX_KEEP_QML_TOP, qml_import)
+            if sub:
+                self.assertIn(sub, build_support.LINUX_KEEP_QTQUICK, qml_import)
+
+    def test_macos_spec_does_not_filter_required_qt_libs(self):
+        tree = _spec_tree("macos")
+        patterns = [
+            p.lower()
+            for name in ("UNWANTED_PATTERNS", "UNUSED_QUICK_CONTROLS_PATTERNS")
+            for p in _module_level_set(tree, name)
+        ]
+        for lib in sorted(self._required_libs()):
+            clashing = [p for p in patterns if p in lib.lower()]
+            with self.subTest(lib=lib):
+                self.assertFalse(
+                    clashing,
+                    f"Mouser-mac.spec filter pattern(s) {clashing} would "
+                    f"drop required library {lib}",
+                )
+
+
+class RequiredAssetTests(unittest.TestCase):
+    """Assets referenced from code/specs by exact path exist in the repo."""
+
+    def test_referenced_assets_exist(self):
+        for rel in REQUIRED_ASSETS:
+            with self.subTest(asset=rel):
+                self.assertTrue(
+                    os.path.exists(os.path.join(REPO_ROOT, rel)), rel
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #233 — the scroll-path leak that remained after #242, and the `HIDEvent` cluster measured in #238's follow-up validation.

## Problem

With #240 and #242 merged, on-device testing still showed linear growth during active use (~110 MB/h), isolated by A/B testing to **scrolling**: scroll-only leaked ~19 MB in 2.5 min while click-only bursts were flat. Long-run heap captures showed the dominant retained classes were `HIDEvent` (1.57M objects / 168 MB after 20 h), `CGSEventAppendix`, and `CGEvent`.

## Root cause

`_MacNativeHidDevice.read()` pumps `CFRunLoopRunInMode` in 0.05 s slices, and the IOHID input-report callbacks fire **inside that pump**, on whichever plain Python thread called `read()` (HID listener, reconnect loop, battery/smart-shift pollers). None of those threads ever drained an `NSAutoreleasePool`, so the per-report Foundation/IOKit temporaries delivered by the run loop accumulated for the process lifetime.

Previous fixes bracketed the problem but missed this spot: #125 pooled the CGEventTap callback (a different thread), and #242 pooled the injection entry points — coverage that begins only *after* the gesture recognizer decides to act. The raw report delivery itself was never pooled. Diverted wheels make this the hot path: a hi-res wheel (`0x2121`, mul=15) and thumb wheel (`0x2150`, divertedRes=120) generate an order of magnitude more reports than clicks, which is exactly why scrolling leaked and clicks didn't.

## Fix

- Bind `NSAutoreleasePool` through `libobjc` with ctypes — consistent with this module's no-PyObjC-dependency design, with a graceful no-op fallback if lookup fails.
- Drain a pool around **each `CFRunLoopRunInMode` iteration** in `read()`, so per-report temporaries cannot outlive a 0.05 s slice regardless of how long the caller's timeout is.
- Apply the same pool (via a `_pooled` decorator) to `enumerate_infos()`, `open()`, `write()`, and `close()` — every entry point that crosses into IOKit/Foundation — covering the reconnect loop and the background pollers at the choke point instead of per-caller.

Also includes `MEMORY_LEAK_PLAN.md`: the consolidated status of all memory issues/PRs (#125, #150/#151, #233/#242, #238/#240, #243), the evidence synthesis behind this fix, and the remaining roadmap (event-driven app detection to stop the `GPProcessMonitor` accumulation, footprint logging, regression gates).

Non-darwin platforms are unaffected.

## Testing

- `tests/test_hid_gesture.py`: 49 passed (including #240's throttle regression tests, re-run after rebasing onto current master).
- Full suite: 640 passed; the single failure (`test_default_ring_slots_have_short_labels`) is environment-dependent and fails identically on a clean master checkout.
- The IOKit/Foundation behavior itself is macOS-only and cannot be exercised on Linux CI. On-device validation requested from the #233/#238 reporters: scroll-only vs. click-only A/B plus `heap -s`/`leaks --groupByType` before/after — expected result is a bounded `HIDEvent` count and a scroll-only delta at noise level.
