### PR TITLE
chore(release): bump version to 3.7.1

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 
-_DEFAULT_APP_VERSION = "3.7.0"
+_DEFAULT_APP_VERSION = "3.7.1"
 _BUILD_INFO_FILENAME = "mouser_build_info.json"
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
Version bump for the v3.7.1 release (packaged builds take the version from the release tag via `MOUSER_VERSION`; this keeps source checkouts consistent).

Release scope since v3.7.0: the three validated macOS memory-leak fixes (#240, #242, #247), M585/M590 device support (#241), Gesture Swipe, scroll force (#232), Zoom actions, charging badge (#239), UWP paste fix (#226), and the hi-res scroll reconnect fix (#244).

Verified before tagging: spec-coverage guard green (all three PyInstaller specs bundle everything in this release) and full suite green (650 passed; the single `test_default_ring_slots_have_short_labels` failure is environment-dependent and identical on clean master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uB8aXzbsRT1jAAwAP9roA

---
_Generated by [Claude Code](https://claude.ai/code/session_011uB8aXzbsRT1jAAwAP9roA)_