### PR TITLE
ci(release): support publishing a tagged release from workflow_dispatch

### DIFF
--- a/.github/release-notes/v3.7.1.md
+++ b/.github/release-notes/v3.7.1.md
@@ -1,0 +1,41 @@
+# Mouser v3.7.1
+
+**The macOS memory leak is fixed.** If Mouser's memory usage grew into the hundreds of MB (or GB) over long sessions on your Mac, this release is for you: a long-running instance now stays flat instead of climbing until restart.
+
+## 🧠 Memory fixes (macOS)
+
+Three complementary fixes, each validated on real hardware by the community:
+
+- **HID reconnect leak** (#240) — the IOKit backend never called `IOHIDManagerClose`, so every BLE discovery/reconnect cycle leaked a manager plus Mach ports; a 24-hour session could reach 3.3 GB with 33,000 leaked managers and 67,000 ports. Managers are now closed and reconnect probing is throttled with exponential backoff. *Validated: manager count pinned at 2 across thousands of cycles.*
+- **Click-path leak** (#242) — the threads that execute your remapped actions had no `NSAutoreleasePool`, so every injected click/keystroke left native `CGEvent` temporaries behind forever. All action-execution paths now drain pools. *Validated: click bursts no longer accumulate.*
+- **Scroll-path leak** (#247) — the native HID read loop delivered input reports (15 per hi-res wheel detent!) on threads that never drained a pool, leaking `HIDEvent` objects by the million during scrolling. The read-loop pump and every IOKit entry point are now pooled. *Validated: memory flat at ~393 MB across an 11-hour monitored window that previously forced a restart at 700 MB every ~2 hours.*
+
+Also: background HID polls no longer wake a sleeping Mac.
+
+Huge thanks to **@maxhis** for the exceptional `vmmap`/`heap`/`leaks` forensics, **@bdhwrsh** for the scroll-vs-click A/B isolation, **@skinnyshy** for days of threshold monitoring, and **@Spoon94**, **@XXC385**, and **@mizi** for reports and long-run testing.
+
+*Known residual:* a very slow creep (~1 MB/h) from foreground-app polling remains and is next on the roadmap (`MEMORY_LEAK_PLAN.md`). Fast growth tied to clicking/scrolling/reconnects is gone.
+
+## 🖱️ New device support
+
+- **Logitech M585 / M590** with wheel-tilt configuration and interactive layout — thanks **@unijiang**.
+
+## ✨ New features
+
+- **Gesture Swipe** — turn any button into a hold-and-slide gesture pad (all platforms).
+- **Scroll force** support for enhanced SmartShift devices — thanks **@mizi** (#232).
+- **Zoom In / Zoom Out** actions on Windows and Linux.
+- Battery badge now shows a **charging indicator** — thanks **@davidnoyes** (#239).
+
+## 🔧 Fixes
+
+- Hi-res smooth scrolling survives device reconnects (0x2121 resolution bit preserved, #244).
+- UWP apps now receive side-button copy/paste correctly — thanks **@zeward-lee** (#226).
+- Idle-timer improvements — thanks **@ArtisticZhao** (#225).
+
+## 📦 For contributors
+
+- `MEMORY_LEAK_PLAN.md` documents the full memory investigation, evidence, and remaining roadmap.
+- A new spec-coverage guard (`tests/test_spec_coverage.py`) fails CI if a change adds modules, assets, or QML imports the PyInstaller specs don't bundle — packaged builds can no longer silently drift from the source tree.
+
+**Full changelog:** https://github.com/TomBadash/Mouser/compare/v3.7.0...v3.7.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,21 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Tag to create and publish a release for (e.g. v3.7.1). The tag is
+          created at the built commit by the release job. Leave empty for a
+          build-only dry run.
+        required: false
+        default: ""
 
 permissions:
   contents: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  MOUSER_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+  MOUSER_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.tag || '' }}
   MOUSER_GIT_COMMIT: ${{ github.sha }}
   MOUSER_GIT_DIRTY: "false"
 
@@ -220,9 +228,11 @@ jobs:
           path: Mouser-Linux.zip
 
   release:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.tag != ''
     needs: [build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.tag }}
     steps:
       - uses: actions/checkout@v6
 
@@ -241,38 +251,48 @@ jobs:
           cp Mouser-Linux/Mouser-Linux.zip update-assets/
           python tools/generate_update_manifest.py \
             --repo "${{ github.repository }}" \
-            --tag "${{ github.ref_name }}" \
+            --tag "${{ env.RELEASE_TAG }}" \
             --commit "${{ github.sha }}" \
             --asset-dir update-assets \
-            --output "mouser-${{ github.ref_name }}-update.json"
+            --output "mouser-${{ env.RELEASE_TAG }}-update.json"
 
       - uses: actions/upload-artifact@v7
         with:
           name: Mouser-Update-Metadata
-          path: mouser-${{ github.ref_name }}-update.json
+          path: mouser-${{ env.RELEASE_TAG }}-update.json
 
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+          if gh release view "${{ env.RELEASE_TAG }}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
             # Release already exists — just upload the assets
-            gh release upload "${{ github.ref_name }}" \
+            gh release upload "${{ env.RELEASE_TAG }}" \
               --repo "${{ github.repository }}" \
               --clobber \
               Mouser-Windows/Mouser-Windows.zip \
               Mouser-macOS/Mouser-macOS.zip \
               Mouser-macOS-intel/Mouser-macOS-intel.zip \
               Mouser-Linux/Mouser-Linux.zip \
-              mouser-${{ github.ref_name }}-update.json
+              mouser-${{ env.RELEASE_TAG }}-update.json
           else
-            gh release create "${{ github.ref_name }}" \
+            # Checked-in notes win over auto-generated ones; a workflow_dispatch
+            # run also creates the tag here (--target), since tag pushes are
+            # not possible from every contributor environment.
+            notes_file=".github/release-notes/${{ env.RELEASE_TAG }}.md"
+            if [ -f "$notes_file" ]; then
+              notes_args=(--notes-file "$notes_file")
+            else
+              notes_args=(--generate-notes)
+            fi
+            gh release create "${{ env.RELEASE_TAG }}" \
               --repo "${{ github.repository }}" \
-              --title "Mouser ${{ github.ref_name }}" \
-              --generate-notes \
+              --target "${{ github.sha }}" \
+              --title "Mouser ${{ env.RELEASE_TAG }}" \
+              "${notes_args[@]}" \
               Mouser-Windows/Mouser-Windows.zip \
               Mouser-macOS/Mouser-macOS.zip \
               Mouser-macOS-intel/Mouser-macOS-intel.zip \
               Mouser-Linux/Mouser-Linux.zip \
-              mouser-${{ github.ref_name }}-update.json
+              mouser-${{ env.RELEASE_TAG }}-update.json
           fi


### PR DESCRIPTION
Adds an optional `tag` input to the release workflow so a release can be published without pushing a tag ref directly:

- `workflow_dispatch` with `tag: v3.7.1` → all four platform builds run as usual, then the release job creates the tag at the built commit (`gh release create --target`) and publishes.
- Release notes come from a checked-in `.github/release-notes/<tag>.md` when present (v3.7.1's notes are included in this PR), falling back to `--generate-notes`.
- Tag-push releases behave exactly as before; a dispatch without the input remains a build-only dry run (as validated earlier today — all four builds green on `f96a867`).

Unblocks publishing v3.7.1 with the prepared notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uB8aXzbsRT1jAAwAP9roA

---
_Generated by [Claude Code](https://claude.ai/code/session_011uB8aXzbsRT1jAAwAP9roA)_