### PR TITLE
Fix reversed horizontal wheel-tilt direction on Windows

### DIFF
--- a/core/mouse_hook_windows.py
+++ b/core/mouse_hook_windows.py
@@ -376,12 +376,15 @@ class MouseHook(BaseMouseHook):
 
             elif wParam == WM_MOUSEHWHEEL:
                 delta = hiword(mouse_data)
+                # WM_MOUSEHWHEEL: a positive delta means the wheel was tilted
+                # to the right, negative to the left (per Win32 docs). Match the
+                # macOS/Linux hooks, which also map positive -> HSCROLL_RIGHT.
                 if delta > 0:
-                    event = MouseEvent(MouseEvent.HSCROLL_LEFT, abs(delta))
-                    should_block = MouseEvent.HSCROLL_LEFT in self._blocked_events
-                elif delta < 0:
                     event = MouseEvent(MouseEvent.HSCROLL_RIGHT, abs(delta))
                     should_block = MouseEvent.HSCROLL_RIGHT in self._blocked_events
+                elif delta < 0:
+                    event = MouseEvent(MouseEvent.HSCROLL_LEFT, abs(delta))
+                    should_block = MouseEvent.HSCROLL_LEFT in self._blocked_events
 
                 if self.invert_hscroll and not self.wheel_native_invert_active:
                     if delta != 0 and self._ri_hwnd and not should_block:


### PR DESCRIPTION
The WM_MOUSEHWHEEL handler mapped a positive delta to HSCROLL_LEFT, but a positive WM_MOUSEHWHEEL delta means the wheel was tilted to the right (per the Win32 docs). This made hscroll_left/hscroll_right actions fire in the opposite direction on Windows compared to macOS and Linux, whose hooks both map positive -> HSCROLL_RIGHT.

Swap the Windows mapping so positive delta -> HSCROLL_RIGHT and negative -> HSCROLL_LEFT, matching the other platforms. The invert/injection path (which negates delta) is unaffected.

Verified in Windows and macOS.