### PR TITLE
fix(macOS): rearm mouse hook after lock wake

### DIFF
--- a/core/mouse_hook_macos.py
+++ b/core/mouse_hook_macos.py
@@ -71,6 +71,8 @@ class MouseHook(BaseMouseHook):
         self._wake_observer = None
         self._session_resign_observer = None
         self._session_activate_observer = None
+        self._session_rearm_timers = set()
+        self._session_rearm_lock = threading.Lock()
         self._init_dispatch_queue(maxsize=512)
         self._dispatch_thread = None
         self._first_event_logged = False
@@ -473,14 +475,39 @@ class MouseHook(BaseMouseHook):
             if hg:
                 hg.force_reconnect()
 
+        def _retry_after_session_transition(reason, delay):
+            """Retry after macOS finishes rebuilding the login session.
+
+            On lock/unlock, NSWorkspace's active notification can arrive
+            before the HID receiver and CGEventTap are usable again. A single
+            immediate re-enable races that transition and leaves the hook
+            alive but ineffective. Keep the retry bounded and cancel it in
+            ``stop`` so this cannot create a permanent background worker.
+            """
+            def _retry():
+                with self._session_rearm_lock:
+                    self._session_rearm_timers.discard(timer)
+                if self._running:
+                    _re_enable_tap_and_reconnect(reason)
+
+            timer = threading.Timer(delay, _retry)
+            timer.daemon = True
+            with self._session_rearm_lock:
+                self._session_rearm_timers.add(timer)
+            timer.start()
+
         def _on_wake(notification):
             _re_enable_tap_and_reconnect("wake")
+            _retry_after_session_transition("wake-retry-1", 1.0)
+            _retry_after_session_transition("wake-retry-2", 3.0)
 
         def _on_session_resign(notification):
             print("[MouseHook] Session deactivated", flush=True)
 
         def _on_session_activate(notification):
             _re_enable_tap_and_reconnect("user-switch")
+            _retry_after_session_transition("session-retry-1", 1.0)
+            _retry_after_session_transition("session-retry-2", 3.0)
 
         self._wake_observer = notification_center.addObserverForName_object_queue_usingBlock_(
             "NSWorkspaceDidWakeNotification",
@@ -579,6 +606,11 @@ class MouseHook(BaseMouseHook):
 
     def stop(self):
         self._unregister_wake_observer()
+        with self._session_rearm_lock:
+            timers = tuple(self._session_rearm_timers)
+            self._session_rearm_timers.clear()
+        for timer in timers:
+            timer.cancel()
         self._running = False
         self.abort_button_gesture("stop")
         self._stop_hid_listener()

--- a/core/version.py
+++ b/core/version.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 
-_DEFAULT_APP_VERSION = "3.7.1"
+_DEFAULT_APP_VERSION = "3.7.2"
 _BUILD_INFO_FILENAME = "mouser_build_info.json"
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
## Problem
On macOS, locking and unlocking the session can leave Mouser's CGEventTap or Logitech HID++ connection ineffective even though the process remains running.

## Root cause
`NSWorkspace` wake/session activation notifications were handled with only one immediate event-tap enable and HID reconnect. macOS can deliver those notifications before the HID receiver and event tap are ready again.

## Fix
- Re-enable the event tap immediately on wake/session activation.
- Schedule bounded retries at 1 and 3 seconds to cover the session restoration race.
- Cancel pending retry timers during shutdown.

## Validation
- macOS event-tap tests pass.
- Accessibility tests pass.
- `git diff --check` passes.
- Built and launched an Apple Silicon macOS app bundle locally.
