### PR TITLE
Release v3.7.3: fix shortcut recorder freezing the mouse pointer on Windows

### DIFF
--- a/.github/release-notes/v3.7.3.md
+++ b/.github/release-notes/v3.7.3.md
@@ -1,0 +1,24 @@
+# Mouser v3.7.3
+
+**A hotfix for v3.7.2.** Opening the custom shortcut recorder on Windows froze the mouse pointer for the rest of the session. If you are on v3.7.2, update.
+
+## 🖱️ The freeze
+
+Assigning a custom shortcut left the mouse completely unresponsive. The shortcut could be typed but not saved, because the Save button could no longer be clicked, and nothing short of a sign-out or a reboot brought the pointer back.
+
+Reported by **@327607501** (#259) on Windows 11 with an M590 over a Bolt receiver, though it was never device-specific: any mouse, any connection, on any Windows machine running v3.7.2.
+
+The cause was two hooks quietly sharing one object. `ctypes.windll.user32` is a single process-global handle, and ctypes stores function prototypes on the handle itself rather than per call site. Mouser's low-level mouse hook declares `CallNextHookEx` to take a mouse event; the shortcut recorder's keyboard hook declared the same function to take a keyboard event. Whichever ran second won. Opening the recorder rewrote the prototype the mouse hook depended on, so from that moment every mouse event failed on the way into the hook and no click, move or scroll reached Windows.
+
+The recorder now loads its own private handle, so the two hooks no longer share prototypes.
+
+> [!NOTE]
+> The recorder was reworked in v3.7.2 (record and type modes, Windows key support). This regression arrived with that rework, so v3.7.1 and earlier are unaffected.
+
+Two details from #259 are working as intended, now that the pointer moves again. `Enter` is recorded as part of the shortcut rather than confirming the dialog, because it is a bindable key, so use the Save button to confirm. Binding a button to launch an app is a separate feature request and is tracked on its own.
+
+## 🙏 Thanks
+
+To **@327607501**, again. The report in #253 found the crash fixed in v3.7.2, and #259 arrived within hours of that release with enough detail to pin this one down immediately.
+
+**Full changelog:** https://github.com/TomBadash/Mouser/compare/v3.7.2...v3.7.3

--- a/core/key_capture.py
+++ b/core/key_capture.py
@@ -276,7 +276,12 @@ class WindowsSuperKeyGuard(SuperKeyGuard):
 def _user32():
     import ctypes
 
-    return ctypes.windll.user32
+    # Private WinDLL instance, NOT the process-global ctypes.windll.user32.
+    # argtypes live on the DLL wrapper; the mouse hook (mouse_hook_windows.py)
+    # sets CallNextHookEx/SetWindowsHookExW prototypes for MSLLHOOKSTRUCT on the
+    # shared global handle. Reusing it here would overwrite lParam's type with
+    # KBDLLHOOKSTRUCT and make every mouse event raise, freezing the pointer.
+    return ctypes.WinDLL("user32")
 
 
 def create_super_key_guard(platform_name: str | None = None) -> SuperKeyGuard:

--- a/core/version.py
+++ b/core/version.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 
-_DEFAULT_APP_VERSION = "3.7.2"
+_DEFAULT_APP_VERSION = "3.7.3"
 _BUILD_INFO_FILENAME = "mouser_build_info.json"
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
Hotfix release for the v3.7.2 regression reported in #259.

## The bug

Opening the custom shortcut recorder on Windows froze the mouse pointer for the rest of the session. The shortcut could be typed but not saved, since the Save button could no longer be clicked, and only a sign-out or reboot restored the pointer.

`ctypes.windll.user32` is a single process-global handle and ctypes stores `argtypes` on the handle, not per call site. `core/mouse_hook_windows.py` declares `SetWindowsHookExW`/`CallNextHookEx` for `MSLLHOOKSTRUCT` at import time. `core/key_capture.py` then overwrote those same prototypes with `KBDLLHOOKSTRUCT` when the recorder opened, so every subsequent mouse event raised on conversion inside the low-level hook and no input reached Windows.

The recorder now loads a private `ctypes.WinDLL("user32")` instance, so the two hooks no longer share prototypes.

The recorder's keyboard hook first shipped in v3.7.2 (`v3.7.2~3`), so v3.7.1 and earlier are unaffected.

## Contents

- `fix(windows)` stop the shortcut recorder freezing the mouse pointer
- `docs(release)` add v3.7.3 release notes
- `chore(release)` bump version to 3.7.3

## Testing

Full suite run on this branch and on pristine `master` produces an identical set of 15 failures, all pre-existing Windows environment artifacts (POSIX path assumptions, symlink privilege errors, Linux `.desktop` discovery, one order-dependent engine test). No new failures. All 134 `key_capture` / hook / backend tests pass.

Closes #259
