### PR TITLE
fix: improve transport detection logic for direct HID mouse

### DIFF
--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -882,6 +882,7 @@ BT_DEV_IDX     = 0xFF        # device-index for direct Bluetooth
 # Known Logi Bolt receiver PID.
 # Source: https://github.com/pwr-Solaar/Solaar/blob/master/lib/logitech_receiver/base_usb.py
 BOLT_RECEIVER_PID = 0xC548
+UNIFYING_RECEIVER_PID = 0xC52B
 FEAT_IROOT     = 0x0000
 FEAT_REPROG_V4 = 0x1B04      # Reprogrammable Controls V4
 FEAT_ADJ_DPI   = 0x2201      # Adjustable DPI
@@ -3211,12 +3212,30 @@ class HidGestureListener:
                         # firmware does not advertise.
                         self._install_thumb_button_extra(device_spec, controls)
                         self._divert_extras()
-                        if idx == BT_DEV_IDX:
+                        is_receiver_pid = bool(
+                            pid is not None
+                            and (
+                                (int(pid) & 0xFF00) == 0xC500
+                                or int(pid) in (BOLT_RECEIVER_PID, UNIFYING_RECEIVER_PID)
+                            )
+                        )
+                        is_bluetooth = bool(
+                            idx == BT_DEV_IDX
+                            or "bluetooth" in (opened_transport or "").lower()
+                            or "bluetooth" in (candidate_transport or "").lower()
+                            or "ble" in (opened_transport or "").lower()
+                            or "ble" in (candidate_transport or "").lower()
+                            or not is_receiver_pid
+                        )
+
+                        if is_bluetooth:
                             actual_transport = "Bluetooth"
                         elif pid == BOLT_RECEIVER_PID:
                             actual_transport = "Logi Bolt"
-                        else:
+                        elif is_receiver_pid:
                             actual_transport = "USB Receiver"
+                        else:
+                            actual_transport = "Bluetooth"
                         self._connected_device_info = build_connected_device_info(
                             product_id=pid,
                             product_name=hidpp_name or product,

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -879,10 +879,16 @@ SHORT_LEN      = 7
 LONG_LEN       = 20
 
 BT_DEV_IDX     = 0xFF        # device-index for direct Bluetooth
-# Known Logi Bolt receiver PID.
+# Known Logi Bolt / Unifying receiver PIDs.
 # Source: https://github.com/pwr-Solaar/Solaar/blob/master/lib/logitech_receiver/base_usb.py
+# Both fall inside the 0xC500-0xC5FF receiver range (see RECEIVER_PID_MASK
+# below); they are kept as named constants only to pick the right label
+# ("Logi Bolt" vs. the generic "USB Receiver") once a receiver is confirmed.
 BOLT_RECEIVER_PID = 0xC548
 UNIFYING_RECEIVER_PID = 0xC52B
+# All Logitech USB receiver PIDs (Unifying, Bolt, ...) live in this block.
+RECEIVER_PID_MASK = 0xFF00
+RECEIVER_PID_PREFIX = 0xC500
 FEAT_IROOT     = 0x0000
 FEAT_REPROG_V4 = 0x1B04      # Reprogrammable Controls V4
 FEAT_ADJ_DPI   = 0x2201      # Adjustable DPI
@@ -3212,30 +3218,42 @@ class HidGestureListener:
                         # firmware does not advertise.
                         self._install_thumb_button_extra(device_spec, controls)
                         self._divert_extras()
+                        # A PID inside the 0xC500-0xC5FF block is always a
+                        # Logitech USB receiver (Unifying, Bolt, ...); the
+                        # mask alone already covers BOLT_RECEIVER_PID and
+                        # UNIFYING_RECEIVER_PID, so there is no need to test
+                        # them individually here.
                         is_receiver_pid = bool(
                             pid is not None
-                            and (
-                                (int(pid) & 0xFF00) == 0xC500
-                                or int(pid) in (BOLT_RECEIVER_PID, UNIFYING_RECEIVER_PID)
-                            )
+                            and (int(pid) & RECEIVER_PID_MASK) == RECEIVER_PID_PREFIX
                         )
-                        is_bluetooth = bool(
+                        # Explicit BT signals (dev-index or a reported
+                        # transport string) always win. They matter for the
+                        # rare case where a direct/BT device answered on a
+                        # receiver-slot dev-index (see idx_order fallback
+                        # above) -- without this override it would otherwise
+                        # be misread as a receiver connection.
+                        has_bt_signal = bool(
                             idx == BT_DEV_IDX
                             or "bluetooth" in (opened_transport or "").lower()
                             or "bluetooth" in (candidate_transport or "").lower()
                             or "ble" in (opened_transport or "").lower()
                             or "ble" in (candidate_transport or "").lower()
-                            or not is_receiver_pid
                         )
 
-                        if is_bluetooth:
+                        if not is_receiver_pid:
+                            # Every PID outside the receiver block is a
+                            # direct connection. Mouser only ships Bluetooth
+                            # and USB-receiver support (see README), so a
+                            # non-receiver PID is reported as "Bluetooth"
+                            # regardless of has_bt_signal.
+                            actual_transport = "Bluetooth"
+                        elif has_bt_signal:
                             actual_transport = "Bluetooth"
                         elif pid == BOLT_RECEIVER_PID:
                             actual_transport = "Logi Bolt"
-                        elif is_receiver_pid:
-                            actual_transport = "USB Receiver"
                         else:
-                            actual_transport = "Bluetooth"
+                            actual_transport = "USB Receiver"
                         self._connected_device_info = build_connected_device_info(
                             product_id=pid,
                             product_name=hidpp_name or product,

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -1174,6 +1174,49 @@ class HidBoltReceiverTests(unittest.TestCase):
 
         self.assertEqual(listener.connected_device.transport, "USB Receiver")
 
+    def test_transport_label_bluetooth_for_direct_mouse_pid(self):
+        """Direct mouse PID (e.g. MX Master 3S 0xB034) should produce
+        'Bluetooth', even if devIdx is 1."""
+        listener = hid_gesture.HidGestureListener()
+        info = {
+            "product_id": 0xB034,
+            "usage_page": 0xFF00,
+            "usage": 0x0001,
+            "source": "hidapi-enumerate",
+            "product_string": "MX Master 3S",
+            "path": b"/dev/hidraw-test-bt",
+        }
+        fake_dev = _FakeHidDevice()
+        call_count = [0]
+
+        def fake_find_feature(feature_id, *, timeout_ms=None):
+            if feature_id != hid_gesture.FEAT_REPROG_V4:
+                return None
+            call_count[0] += 1
+            return 0x09 if call_count[0] >= 2 else None
+
+        with (
+            patch.object(listener, "_vendor_hid_infos", return_value=[info]),
+            patch.object(listener, "_find_feature", side_effect=fake_find_feature),
+            patch.object(listener, "_discover_reprog_controls", return_value=[]),
+            patch.object(listener, "_divert", return_value=True),
+            patch.object(listener, "_divert_extras"),
+            patch.object(hid_gesture, "HIDAPI_OK", True),
+            patch.object(hid_gesture, "_BACKEND_PREFERENCE", "hidapi"),
+            patch.object(hid_gesture, "_HID_API_STYLE", "hidapi"),
+            patch.object(
+                hid_gesture,
+                "_hid",
+                SimpleNamespace(device=lambda: fake_dev),
+                create=True,
+            ),
+            patch("builtins.print"),
+        ):
+            self.assertTrue(listener._try_connect())
+
+        self.assertEqual(listener.connected_device.transport, "Bluetooth")
+
+
 
 class HidReconnectInvariantTests(unittest.TestCase):
     def test_force_release_stale_holds_clears_gesture_and_extra_buttons(self):


### PR DESCRIPTION
fix https://github.com/TomBadash/Mouser/issues/267

If a Bluetooth mouse enumerated on `dev_idx = 1` (or another non-`0xFF` slot), it failed `idx == BT_DEV_IDX` and fell back to `USB Receiver`, even though its Product ID belonged to a standalone Bluetooth mouse rather than a USB dongle.

### Solution

1. Added `UNIFYING_RECEIVER_PID` (`0xC52B`) and a receiver PID check (`0xC5xx` range).
2. Updated transport determination so standalone mouse PIDs (such as `0xB034` / `0xB043`) or Bluetooth candidate interfaces are correctly identified as `"Bluetooth"`.
3. Kept `"Logi Bolt"` for `PID 0xC548` and `"USB Receiver"` for other receiver PIDs (such as `0xC52B`).

### Testing

- Added `test_transport_label_bluetooth_for_direct_mouse_pid` in `tests/test_hid_gesture.py`.
- Ran full test suite: `PYTHONPATH=. pytest tests/test_hid_gesture.py` (50 passed).