### PR TITLE
fix(windows): recover the hook and HID++ handle after sleep

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -167,6 +167,8 @@ Mouser handles mouse power-off / on cycles automatically:
 
 - **HID++ layer** — `HidGestureListener` detects device disconnection (read errors) and enters a reconnect loop, retrying every 2–5 seconds until the device returns. Pending SmartShift / scroll-mode settings are replayed on reconnect.
 - **Hook layer** — `MouseHook` listens for `WM_DEVICECHANGE` (Windows) and platform equivalents elsewhere, reinstalling the low-level hook when devices are added or removed.
+- **Sleep / resume (Windows)** — `WM_POWERBROADCAST`, console display-state and session-unlock notifications all funnel into `_on_system_resume`, which rebuilds the hook and drops the HID++ handle on a 0.5 s / 3 s / 10 s ladder. The retries matter: the Bolt stack returns over several seconds, so reconnecting once on the first message can probe a receiver whose mouse has not re-paired yet.
+- **Liveness watchdog** — both halves of Mouser can die without raising anything. Windows silently removes a low-level hook whose procedure overruns `LowLevelHooksTimeout`, and a resume can leave the HID++ handle open against an orphaned device where reads never fail and never return. `BaseMouseHook` polls every 5 s and acts only on evidence: the hook is judged against raw input (same events, independent delivery path), and a HID++ handle that has been quiet for 90 s while the mouse is demonstrably in use is asked to answer a root request. Silence on its own is never treated as a fault — an idle mouse is silent on every channel.
 - **UI layer** — connection state and device identity flow from HID++ → MouseHook → Engine → Backend (cross-thread safe via Qt signals) → QML, updating the status badge, device name, and active layout in real time.
 
 ### Configuration

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -1120,6 +1120,11 @@ class HidGestureListener:
         self._connected_device_info = None
         self._last_controls = []   # REPROG_V4 controls from last connection
         self._consecutive_request_timeouts = 0
+        # Monotonic timestamp of the last report read off the live handle,
+        # and the flag the platform hook sets to have the listener prove the
+        # handle is still alive. See `_run_liveness_ping` (issue #263).
+        self._last_report_at = 0.0
+        self._pending_liveness_ping = False
         # 0x2121 Hi-Res Wheel + 0x2150 Thumbwheel native-invert state.
         # Lock ordering: outer `_wheel_divert_call_lock` serializes
         # cross-thread callers, inner `_wheel_divert_lock` protects the
@@ -2079,6 +2084,51 @@ class HidGestureListener:
         """
         self._reconnect_requested = True
 
+    def seconds_since_last_report(self):
+        """Seconds since the live handle last delivered a report, or None
+        when there is no connection to judge."""
+        if not self._connected or self._dev is None:
+            return None
+        if not self._last_report_at:
+            return None
+        return max(0.0, time.monotonic() - self._last_report_at)
+
+    def request_liveness_ping(self):
+        """Ask the listener thread to prove the handle is still alive.
+
+        Thread-safe: sets a flag serviced by the inner event loop. Callers
+        must only raise this when they have independent evidence that the
+        mouse is awake (see ``BaseMouseHook._check_hid_liveness``) -- pinging
+        a device that is merely idle wakes it for nothing.
+        """
+        self._pending_liveness_ping = True
+
+    def _run_liveness_ping(self):
+        """Probe the open handle with a cheap HID++ root request.
+
+        Listener-thread only. After a suspend/resume cycle Windows can hand
+        the device a new stack entry while our handle stays open against the
+        orphaned one: reads never fail, they simply never return anything
+        again, so the listener sits "connected" forever against a dead pipe
+        (issue #263, and the un-slept variants #257 / #246). A read timeout
+        alone cannot tell that apart from an idle mouse, so the caller
+        establishes that the mouse is in use and this asks the device to
+        answer. Raises IOError on failure, which drops the main loop into its
+        existing cleanup + reconnect path.
+        """
+        for attempt in (1, 2):
+            resp = self._request(
+                0x00, 0,
+                [(FEAT_IROOT >> 8) & 0xFF, FEAT_IROOT & 0xFF, 0x00],
+                timeout_ms=600,
+            )
+            if resp is not None:
+                self._last_report_at = time.monotonic()
+                self._consecutive_request_timeouts = 0
+                return
+            print(f"[HidGesture] Liveness ping unanswered ({attempt}/2)")
+        raise IOError("liveness ping unanswered — handle is stale")
+
     def read_smart_shift(self):
         """Queue a Smart Shift read.
         Returns dict {'mode': str, 'enabled': bool, 'threshold': int} or None."""
@@ -2728,6 +2778,10 @@ class HidGestureListener:
 
     def _on_report(self, raw):
         """Inspect an incoming HID++ report for diverted button / raw XY events."""
+        # Stamp before parsing: any report at all -- even one we ignore --
+        # proves the handle is still carrying traffic, which is what the
+        # liveness watchdog asks about.
+        self._last_report_at = time.monotonic()
         msg = _parse(raw)
         if msg is None:
             return
@@ -3325,6 +3379,8 @@ class HidGestureListener:
             connect_backoff_s = _CONNECT_BACKOFF_BASE_S
 
             self._connected = True
+            self._last_report_at = time.monotonic()
+            self._pending_liveness_ping = False
             if self._on_connect:
                 try:
                     self._on_connect()
@@ -3400,6 +3456,9 @@ class HidGestureListener:
                         self._apply_pending_haptic()
                     if self._pending_force_sensing is not None:
                         self._apply_pending_force_sensing()
+                    if self._pending_liveness_ping:
+                        self._pending_liveness_ping = False
+                        self._run_liveness_ping()
                     raw = self._rx(1000)
                     if raw:
                         _no_data_count = 0
@@ -3436,6 +3495,8 @@ class HidGestureListener:
             self._last_logged_battery = None
             self._last_battery_event = None
             self._consecutive_request_timeouts = 0
+            self._last_report_at = 0.0
+            self._pending_liveness_ping = False
             self._haptic_idx = None
             self._force_sensing_idx = None
             self._force_sensing_range = None

--- a/core/mouse_hook_base.py
+++ b/core/mouse_hook_base.py
@@ -3,6 +3,7 @@ Shared mouse hook behavior used by platform implementations.
 """
 
 import queue
+import threading
 import time
 
 try:
@@ -97,6 +98,110 @@ class BaseMouseHook:
         )
         self._connected_device = None
         self._dispatch_queue = None
+        # ── Liveness watchdog state (see _liveness_watchdog_loop) ─────────
+        self._last_os_mouse_activity_at = 0.0
+        self._last_liveness_ping_at = 0.0
+        self._liveness_thread = None
+        self._liveness_stop = None
+
+    # ── Liveness watchdog ─────────────────────────────────────────────
+    # Both halves of Mouser can die without saying so: the OS-level hook
+    # (Windows silently drops a low-level hook whose proc overruns
+    # LowLevelHooksTimeout) and the HID++ handle (a suspend/resume cycle can
+    # leave it open against an orphaned device, where reads never fail and
+    # never return). Neither failure raises anything, so without an active
+    # check the app sits there looking connected until the user restarts it
+    # -- issue #263 after sleep, #257 / #246 at random.
+    #
+    # The check has to be cheap and false-positive-free. Silence alone proves
+    # nothing: an idle mouse is silent on every channel. So we only act when
+    # the OS event stream shows the mouse is *being used right now* while the
+    # channel under test has gone quiet -- and even then the HID side asks the
+    # device to answer rather than assuming the worst.
+    _LIVENESS_POLL_INTERVAL_S = 5.0
+    # How recently OS mouse events must have arrived for the mouse to count
+    # as "in use" -- i.e. provably awake, so silence is a real symptom.
+    _LIVENESS_OS_ACTIVITY_WINDOW_S = 10.0
+    # HID++ silence tolerated from a mouse in active use. Generous: a healthy
+    # connection is legitimately quiet while the user only moves and scrolls,
+    # since only diverted controls and battery events report.
+    _LIVENESS_HID_SILENCE_S = 90.0
+
+    def _note_os_mouse_activity(self, now=None):
+        """Record that the OS event stream just carried a mouse event.
+
+        Called from platform hot paths (raw input / event tap / evdev), so it
+        stays a single timestamp write with no lock: a torn read costs the
+        watchdog one cycle, and locking here would be on every mouse move.
+        """
+        self._last_os_mouse_activity_at = time.monotonic() if now is None else now
+
+    def _start_liveness_watchdog(self):
+        if self._liveness_thread and self._liveness_thread.is_alive():
+            return
+        self._liveness_stop = threading.Event()
+        self._liveness_thread = threading.Thread(
+            target=self._liveness_watchdog_loop,
+            args=(self._liveness_stop,),
+            daemon=True,
+            name="MouseHook-liveness",
+        )
+        self._liveness_thread.start()
+
+    def _stop_liveness_watchdog(self):
+        if self._liveness_stop:
+            self._liveness_stop.set()
+        if self._liveness_thread:
+            self._liveness_thread.join(timeout=1)
+            self._liveness_thread = None
+        self._liveness_stop = None
+
+    def _liveness_watchdog_loop(self, stop_event):
+        while not stop_event.wait(self._LIVENESS_POLL_INTERVAL_S):
+            try:
+                self._platform_liveness_check()
+            except Exception as exc:
+                print(f"[MouseHook] platform liveness check error: {exc}")
+            try:
+                self._check_hid_liveness()
+            except Exception as exc:
+                print(f"[MouseHook] HID liveness check error: {exc}")
+
+    def _platform_liveness_check(self):
+        """Hook for platforms that can verify their own OS-level event path.
+        Default is a no-op; Windows overrides it to catch a dropped hook."""
+        return None
+
+    def _check_hid_liveness(self, now=None):
+        """Ask the HID++ listener to prove itself when it has gone quiet while
+        the mouse is demonstrably in use. Returns True if a probe was asked
+        for (test seam)."""
+        hg = self._hid_gesture
+        if hg is None or not self._device_connected:
+            return False
+        ping = getattr(hg, "request_liveness_ping", None)
+        silence_of = getattr(hg, "seconds_since_last_report", None)
+        if ping is None or silence_of is None:
+            return False
+        now = time.monotonic() if now is None else now
+        if now - self._last_os_mouse_activity_at > self._LIVENESS_OS_ACTIVITY_WINDOW_S:
+            # Mouse idle. Its silence is expected, and probing a device that
+            # may have gone to sleep just costs battery to learn nothing.
+            return False
+        silence = silence_of()
+        if silence is None or silence < self._LIVENESS_HID_SILENCE_S:
+            return False
+        # One probe per silence window, so a genuinely dead handle is not
+        # hammered every poll while the reconnect is still in flight.
+        if now - self._last_liveness_ping_at < self._LIVENESS_HID_SILENCE_S:
+            return False
+        self._last_liveness_ping_at = now
+        print(
+            f"[MouseHook] HID++ silent for {silence:.0f}s while the mouse is "
+            "in use — probing the connection"
+        )
+        ping()
+        return True
 
     def _init_dispatch_queue(self, maxsize=0):
         """Initialize dispatch queue storage for subclasses with event threads."""

--- a/core/mouse_hook_linux.py
+++ b/core/mouse_hook_linux.py
@@ -709,6 +709,10 @@ class MouseHook(BaseMouseHook):
             readable, _, _ = _select_mod.select([fd], [], [], 0.5)
             if not readable:
                 continue
+            # Proof the mouse is in use, for the HID liveness watchdog. The
+            # evdev device we read from is the Logitech itself, so this is a
+            # direct statement that the device is awake.
+            self._note_os_mouse_activity()
             for event in self._evdev_device.read():
                 if not self._running:
                     return
@@ -872,10 +876,12 @@ class MouseHook(BaseMouseHook):
         else:
             print("[MouseHook] evdev not available — button remapping disabled")
 
+        self._start_liveness_watchdog()
         return True
 
     def stop(self):
         self._running = False
+        self._stop_liveness_watchdog()
         self.abort_button_gesture("stop")
         self._stop_hid_listener()
         self._hid_ready = False

--- a/core/mouse_hook_macos.py
+++ b/core/mouse_hook_macos.py
@@ -249,6 +249,9 @@ class MouseHook(BaseMouseHook):
                 Quartz.CGEventTapEnable(self._tap, True)
                 return cg_event
 
+            # Proof the mouse is in use, for the HID liveness watchdog.
+            self._note_os_mouse_activity()
+
             if not self._first_event_logged:
                 self._first_event_logged = True
                 print("[MouseHook] CGEventTap: first event received", flush=True)
@@ -575,10 +578,12 @@ class MouseHook(BaseMouseHook):
 
         self._start_hid_listener()
         self._register_wake_observer()
+        self._start_liveness_watchdog()
         return True
 
     def stop(self):
         self._unregister_wake_observer()
+        self._stop_liveness_watchdog()
         self._running = False
         self.abort_button_gesture("stop")
         self._stop_hid_listener()

--- a/core/mouse_hook_windows.py
+++ b/core/mouse_hook_windows.py
@@ -221,13 +221,78 @@ WM_APP = 0x8000
 WM_APP_INJECT_VSCROLL = WM_APP + 1
 WM_APP_INJECT_HSCROLL = WM_APP + 2
 WM_APP_INJECT_SHIFT_HSCROLL = WM_APP + 3
+# Re-arm the OS-level capture (reinstall the low-level hook, re-register raw
+# input). Always posted rather than called: SetWindowsHookExW binds the hook
+# to the calling thread, and only the hook thread pumps messages, so a rehook
+# from any other thread would install a hook nothing ever delivers to.
+WM_APP_REARM = WM_APP + 4
 
 WM_DEVICECHANGE = 0x0219
 DBT_DEVNODES_CHANGED = 0x0007
 
+# ── Power / session notifications ────────────────────────────────────
+# Windows never reports that it dropped a low-level hook, and a resumed
+# machine can hand the mouse a fresh device stack while our HID handle stays
+# open against the old one. Both are silent, so the resume itself is the only
+# reliable cue to rebuild them (issue #263).
+WM_POWERBROADCAST = 0x0218
+PBT_APMSUSPEND = 0x0004
+PBT_APMRESUMESUSPEND = 0x0007
+PBT_APMRESUMEAUTOMATIC = 0x0012
+PBT_POWERSETTINGCHANGE = 0x8013
+DEVICE_NOTIFY_WINDOW_HANDLE = 0x00000000
+# Modern Standby (S0 low-power idle) does not reliably raise the APM resume
+# messages, so we also watch the console display state — display-on is the
+# moment the user is back and the device stack has been rebuilt.
+GUID_CONSOLE_DISPLAY_STATE = (
+    0x6FE69556, 0x704A, 0x47A0, (0x8F, 0x24, 0xC2, 0x8D, 0x93, 0x6F, 0xDA, 0x47)
+)
+DISPLAY_STATE_ON = 0x1
+
+WM_WTSSESSION_CHANGE = 0x02B1
+NOTIFY_FOR_THIS_SESSION = 0x0000
+WTS_SESSION_LOGON = 0x5
+WTS_SESSION_UNLOCK = 0x8
+
+
+class GUID(Structure):
+    _fields_ = [
+        ("Data1", c_ulong),
+        ("Data2", c_ushort),
+        ("Data3", c_ushort),
+        ("Data4", ctypes.c_ubyte * 8),
+    ]
+
+    @classmethod
+    def from_parts(cls, d1, d2, d3, d4):
+        return cls(d1, d2, d3, (ctypes.c_ubyte * 8)(*d4))
+
+
+class POWERBROADCAST_SETTING(Structure):
+    _fields_ = [
+        ("PowerSetting", GUID),
+        ("DataLength", wintypes.DWORD),
+        ("Data", ctypes.c_ubyte * 1),
+    ]
+
+
 PostMessageW = windll.user32.PostMessageW
 PostMessageW.argtypes = [wintypes.HWND, c_uint, wintypes.WPARAM, wintypes.LPARAM]
 PostMessageW.restype = wintypes.BOOL
+
+RegisterPowerSettingNotification = windll.user32.RegisterPowerSettingNotification
+RegisterPowerSettingNotification.restype = wintypes.HANDLE
+RegisterPowerSettingNotification.argtypes = [
+    wintypes.HANDLE,
+    POINTER(GUID),
+    wintypes.DWORD,
+]
+
+UnregisterPowerSettingNotification = windll.user32.UnregisterPowerSettingNotification
+UnregisterPowerSettingNotification.restype = wintypes.BOOL
+UnregisterPowerSettingNotification.argtypes = [wintypes.HANDLE]
+
+_CONSOLE_DISPLAY_STATE_BYTES = bytes(GUID.from_parts(*GUID_CONSOLE_DISPLAY_STATE))
 
 
 class MouseHook(BaseMouseHook):
@@ -256,6 +321,12 @@ class MouseHook(BaseMouseHook):
         self._startup_ok = False
         self._prev_raw_buttons = {}
         self._last_rehook_time = 0
+        # Watchdog / resume-recovery state (see _platform_liveness_check).
+        self._last_hook_event_at = 0.0
+        self._last_raw_input_at = 0.0
+        self._last_resume_at = 0.0
+        self._power_notify_handle = None
+        self._session_notify_registered = False
         # Per-button slide gesture: last cursor position while an owner button
         # is held, to derive per-move deltas from the LL hook's absolute point.
         self._btn_gesture_last_x = 0
@@ -313,6 +384,10 @@ class MouseHook(BaseMouseHook):
 
     def _low_level_handler_inner(self, nCode, wParam, lParam):
         if nCode == HC_ACTION:
+            # Proof-of-life for the hook watchdog. Stamped before every early
+            # return below (injected events, the KVM guard) so a hook that is
+            # merely passing traffic through still counts as alive.
+            self._last_hook_event_at = time.monotonic()
             data = lParam.contents
             mouse_data = data.mouseData
             flags = data.flags
@@ -533,12 +608,43 @@ class MouseHook(BaseMouseHook):
                 _inject_scroll_impl(MOUSEEVENTF_HWHEEL, delta)
             return 0
 
+        if msg == WM_APP_REARM:
+            self._rearm_os_capture()
+            return 0
+
         if msg == WM_DEVICECHANGE:
             if wParam == DBT_DEVNODES_CHANGED:
                 self._on_device_change()
             return 0
 
+        if msg == WM_POWERBROADCAST:
+            if wParam in (PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND):
+                self._on_system_resume("power resume")
+            elif wParam == PBT_APMSUSPEND:
+                print("[MouseHook] System suspending")
+            elif wParam == PBT_POWERSETTINGCHANGE:
+                if self._is_display_on_notification(lParam):
+                    self._on_system_resume("display on")
+            return 1
+
+        if msg == WM_WTSSESSION_CHANGE:
+            if wParam in (WTS_SESSION_UNLOCK, WTS_SESSION_LOGON):
+                self._on_system_resume("session unlock")
+            return 0
+
         return DefWindowProcW(hwnd, msg, wParam, lParam)
+
+    @staticmethod
+    def _is_display_on_notification(lParam):
+        """True when a PBT_POWERSETTINGCHANGE payload says the console
+        display just turned on."""
+        try:
+            setting = POWERBROADCAST_SETTING.from_address(lParam)
+            if bytes(setting.PowerSetting) != _CONSOLE_DISPLAY_STATE_BYTES:
+                return False
+            return setting.DataLength >= 1 and setting.Data[0] == DISPLAY_STATE_ON
+        except Exception:
+            return False
 
     def _process_raw_input(self, lParam):
         size = c_uint(0)
@@ -556,9 +662,20 @@ class MouseHook(BaseMouseHook):
         if ret == 0xFFFFFFFF:
             return
         header = RAWINPUTHEADER.from_buffer_copy(buffer)
+        if header.dwType == RIM_TYPEMOUSE:
+            # Raw input and the low-level hook are independent deliveries of
+            # the same events, which is what makes them a usable cross-check:
+            # raw input keeps arriving after Windows drops the hook. Only
+            # mouse-type reports count -- the vendor (0xFF43) and consumer
+            # collections we also register for never reach a WH_MOUSE_LL hook,
+            # so counting them would read a healthy hook as dead.
+            self._last_raw_input_at = time.monotonic()
         if not self._is_logitech(header.hDevice):
             return
         if header.dwType == RIM_TYPEMOUSE:
+            # Proof the Logitech itself is awake and in use, for the HID
+            # liveness watchdog.
+            self._note_os_mouse_activity()
             self._check_raw_mouse_gesture(header.hDevice, buffer)
 
     def _check_raw_mouse_gesture(self, hDevice, buffer):
@@ -618,6 +735,12 @@ class MouseHook(BaseMouseHook):
             return False
 
         ShowWindow(self._ri_hwnd, SW_HIDE)
+        self._register_power_notifications()
+        return self._register_raw_input_devices()
+
+    def _register_raw_input_devices(self, log=True):
+        if not self._ri_hwnd:
+            return False
 
         devices = (RAWINPUTDEVICE * 4)()
         devices[0].usUsagePage = 0x01
@@ -637,17 +760,60 @@ class MouseHook(BaseMouseHook):
         devices[3].dwFlags = RIDEV_INPUTSINK
         devices[3].hwndTarget = self._ri_hwnd
 
-        if RegisterRawInputDevices(devices, 4, sizeof(RAWINPUTDEVICE)):
-            print("[MouseHook] Raw Input: mice + Logitech HID + consumer")
-            return True
-        if RegisterRawInputDevices(devices, 2, sizeof(RAWINPUTDEVICE)):
-            print("[MouseHook] Raw Input: mice + Logitech HID short")
-            return True
-        if RegisterRawInputDevices(devices, 1, sizeof(RAWINPUTDEVICE)):
-            print("[MouseHook] Raw Input: mice only")
-            return True
+        for count, label in (
+            (4, "mice + Logitech HID + consumer"),
+            (2, "mice + Logitech HID short"),
+            (1, "mice only"),
+        ):
+            if RegisterRawInputDevices(devices, count, sizeof(RAWINPUTDEVICE)):
+                if log:
+                    print(f"[MouseHook] Raw Input: {label}")
+                return True
         print("[MouseHook] Raw Input registration failed")
         return False
+
+    def _register_power_notifications(self):
+        """Subscribe the message window to resume and unlock notifications.
+
+        Best-effort: every one of these is a recovery *cue*, not a
+        requirement, and the watchdog still covers us if a subscription
+        fails, so a failure here must never take the hook down with it.
+        """
+        try:
+            guid = GUID.from_parts(*GUID_CONSOLE_DISPLAY_STATE)
+            self._power_notify_handle = RegisterPowerSettingNotification(
+                self._ri_hwnd, byref(guid), DEVICE_NOTIFY_WINDOW_HANDLE
+            )
+            if not self._power_notify_handle:
+                self._power_notify_handle = None
+                print("[MouseHook] Display-state notifications unavailable")
+        except Exception as exc:
+            self._power_notify_handle = None
+            print(f"[MouseHook] Display-state notifications unavailable: {exc}")
+
+        try:
+            if windll.wtsapi32.WTSRegisterSessionNotification(
+                self._ri_hwnd, NOTIFY_FOR_THIS_SESSION
+            ):
+                self._session_notify_registered = True
+            else:
+                print("[MouseHook] Session notifications unavailable")
+        except Exception as exc:
+            print(f"[MouseHook] Session notifications unavailable: {exc}")
+
+    def _unregister_power_notifications(self):
+        if self._power_notify_handle:
+            try:
+                UnregisterPowerSettingNotification(self._power_notify_handle)
+            except Exception:
+                pass
+            self._power_notify_handle = None
+        if self._session_notify_registered:
+            try:
+                windll.wtsapi32.WTSUnRegisterSessionNotification(self._ri_hwnd)
+            except Exception:
+                pass
+            self._session_notify_registered = False
 
     def _dispatch_worker(self):
         while self._running:
@@ -689,6 +855,7 @@ class MouseHook(BaseMouseHook):
             DispatchMessageW(ctypes.byref(message))
 
         if self._ri_hwnd:
+            self._unregister_power_notifications()
             DestroyWindow(self._ri_hwnd)
             self._ri_hwnd = None
         if self._hook:
@@ -701,11 +868,26 @@ class MouseHook(BaseMouseHook):
         now = time.time()
         if now - self._last_rehook_time < 2.0:
             return
-        self._last_rehook_time = now
         print("[MouseHook] Device change detected — refreshing hook")
+        self._rearm_os_capture()
+
+    def _request_rearm(self, reason):
+        """Ask the hook thread to rebuild the OS-level capture. Safe to call
+        from any thread — the work itself must happen on the hook thread."""
+        hwnd = self._ri_hwnd
+        if not hwnd or not self._running:
+            return False
+        print(f"[MouseHook] Re-arm requested ({reason})")
+        return bool(PostMessageW(hwnd, WM_APP_REARM, 0, 0))
+
+    def _rearm_os_capture(self):
+        """Rebuild everything the OS can silently take away from us.
+        Hook-thread only (see WM_APP_REARM)."""
+        self._last_rehook_time = time.time()
         self._device_name_cache.clear()
         self._prev_raw_buttons.clear()
         self._reinstall_hook()
+        self._register_raw_input_devices(log=False)
 
     def _reinstall_hook(self):
         if self._hook:
@@ -719,9 +901,96 @@ class MouseHook(BaseMouseHook):
             0,
         )
         if self._hook:
+            # Treat the fresh hook as alive, so the watchdog gives it a full
+            # silence window to prove itself instead of firing again at once.
+            self._last_hook_event_at = time.monotonic()
             print("[MouseHook] Hook reinstalled successfully")
         else:
             print("[MouseHook] Failed to reinstall hook!")
+
+    # ── Resume recovery ───────────────────────────────────────────────
+    # Rebuilding once on the resume message is not enough: the USB/Bolt stack
+    # comes back over several seconds, so an immediate reconnect can probe a
+    # receiver whose mouse has not re-paired yet and fail for reasons that
+    # have nothing to do with us (issue #81). Retry on a widening ladder and
+    # stop as soon as the device is back.
+    _RESUME_REARM_DELAYS_S = (0.5, 3.0, 10.0)
+    _RESUME_DEDUPE_S = 5.0
+
+    def _on_system_resume(self, reason):
+        """Entry point for every resume-ish cue. Windows commonly raises
+        several for one wake (APM resume, then display-on, then unlock), so
+        collapse a burst into a single recovery pass."""
+        now = time.monotonic()
+        if now - self._last_resume_at < self._RESUME_DEDUPE_S:
+            return False
+        self._last_resume_at = now
+        print(f"[MouseHook] System resume detected ({reason}) — recovering")
+        threading.Thread(
+            target=self._resume_recovery_worker,
+            args=(reason,),
+            daemon=True,
+            name="MouseHook-resume",
+        ).start()
+        return True
+
+    def _resume_recovery_worker(self, reason):
+        elapsed = 0.0
+        for index, deadline in enumerate(self._RESUME_REARM_DELAYS_S):
+            time.sleep(max(0.0, deadline - elapsed))
+            elapsed = deadline
+            if not self._running:
+                return
+            self._request_rearm(f"resume: {reason}")
+            hg = self._hid_gesture
+            if hg is None:
+                continue
+            # The first pass always drops the HID handle: after a resume it
+            # can stay open against a device stack Windows has already
+            # replaced, and from the outside that is indistinguishable from a
+            # healthy connection. Later passes only step in if the device has
+            # not come back on its own.
+            if index == 0 or not self._device_connected:
+                try:
+                    hg.force_reconnect()
+                except Exception as exc:
+                    print(f"[MouseHook] resume reconnect request failed: {exc}")
+
+    # ── Hook watchdog ─────────────────────────────────────────────────
+    # Windows removes a low-level hook whose procedure overruns
+    # LowLevelHooksTimeout (300 ms by default) and tells nobody: the HHOOK
+    # stays non-NULL and simply never fires again. Resume is the classic
+    # trigger — the process is still being scheduled back in while a burst of
+    # input arrives — but it also happens under load, which is what leaves
+    # users with a dead Mouser and no explanation (#257 / #246).
+    #
+    # There is no API to ask whether a hook is still installed, so we compare
+    # it against raw input: same events, independent delivery path, already
+    # registered. Raw input live + hook silent is the signature of a dropped
+    # hook. Both silent just means nobody is touching the mouse.
+    _HOOK_ACTIVITY_WINDOW_S = 3.0
+    _HOOK_SILENCE_LIMIT_S = 3.0
+
+    def _platform_liveness_check(self, now=None):
+        if not self._running or not self._ri_hwnd:
+            return False
+        now = time.monotonic() if now is None else now
+        if not self._last_raw_input_at or not self._last_hook_event_at:
+            return False
+        if now - self._last_raw_input_at > self._HOOK_ACTIVITY_WINDOW_S:
+            return False
+        hook_silence = now - self._last_hook_event_at
+        if hook_silence < self._HOOK_SILENCE_LIMIT_S:
+            return False
+        print(
+            f"[MouseHook] Low-level hook silent for {hook_silence:.0f}s while "
+            "raw input is live — Windows dropped it; reinstalling"
+        )
+        self._request_rearm("hook watchdog")
+        # Assume recovery until the reinstall lands, so a slow rehook does not
+        # queue a second one behind the first.
+        self._last_hook_event_at = now
+        return True
 
     def _emit_gesture_swipe(self, mouse_event):
         """Route gesture swipes through the dispatch queue so they run on
@@ -748,10 +1017,12 @@ class MouseHook(BaseMouseHook):
             name="HookDispatch",
         )
         self._dispatch_worker_thread.start()
+        self._start_liveness_watchdog()
         return True
 
     def stop(self):
         self._running = False
+        self._stop_liveness_watchdog()
         self.abort_button_gesture("stop")
         self._stop_hid_listener()
         self._connected_device = None

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -496,6 +496,100 @@ class HidRequestTransportFailureTests(unittest.TestCase):
         self.assertEqual(listener._consecutive_request_timeouts, 1)
 
 
+class HidLivenessPingTests(unittest.TestCase):
+    """A resumed Windows box can leave our HID handle open against a device
+    stack it has already replaced: reads never fail, they just never return
+    anything again, so the listener sits "connected" against a dead pipe until
+    the user restarts Mouser (issue #263). The ping is what turns that silence
+    into a verdict."""
+
+    def _connected_listener(self):
+        listener = hid_gesture.HidGestureListener()
+        listener._connected = True
+        listener._dev = object()
+        return listener
+
+    def test_silence_is_unknown_until_a_connection_exists(self):
+        listener = hid_gesture.HidGestureListener()
+
+        self.assertIsNone(listener.seconds_since_last_report())
+
+    def test_silence_is_measured_from_the_last_report(self):
+        listener = self._connected_listener()
+        listener._last_report_at = time.monotonic() - 42.0
+
+        silence = listener.seconds_since_last_report()
+
+        self.assertIsNotNone(silence)
+        self.assertAlmostEqual(silence, 42.0, delta=1.0)
+
+    def test_any_report_counts_as_proof_of_life(self):
+        """Even a report we go on to ignore proves the pipe still carries
+        traffic, so the stamp lands before parsing."""
+        listener = self._connected_listener()
+        listener._last_report_at = 0.0
+
+        listener._on_report([0x11, 0x01, 0x00, 0x00])
+
+        self.assertGreater(listener._last_report_at, 0.0)
+
+    def test_request_liveness_ping_only_arms_a_flag(self):
+        """Callers are other threads; the probe itself must run on the
+        listener thread alongside every other HID++ exchange."""
+        listener = self._connected_listener()
+
+        listener.request_liveness_ping()
+
+        self.assertTrue(listener._pending_liveness_ping)
+
+    def test_answered_ping_clears_the_silence(self):
+        listener = self._connected_listener()
+        listener._last_report_at = 0.0
+        listener._consecutive_request_timeouts = 2
+
+        with patch.object(listener, "_request", return_value=("msg",)) as request:
+            listener._run_liveness_ping()
+
+        request.assert_called_once()
+        self.assertGreater(listener._last_report_at, 0.0)
+        self.assertEqual(listener._consecutive_request_timeouts, 0)
+
+    def test_unanswered_ping_raises_to_force_a_reconnect(self):
+        """IOError is the main loop's existing signal to tear the handle down
+        and rebuild it, diverts and all."""
+        listener = self._connected_listener()
+
+        with patch.object(listener, "_request", return_value=None) as request:
+            with self.assertRaises(IOError):
+                listener._run_liveness_ping()
+
+        # Retried once before giving up, so a single dropped reply does not
+        # cost a reconnect.
+        self.assertEqual(request.call_count, 2)
+
+    def test_single_dropped_reply_is_survivable(self):
+        listener = self._connected_listener()
+
+        with patch.object(listener, "_request", side_effect=[None, ("msg",)]):
+            listener._run_liveness_ping()
+
+    def test_connect_resets_liveness_state(self):
+        listener = hid_gesture.HidGestureListener()
+        listener._pending_liveness_ping = True
+        listener._last_report_at = 0.0
+
+        # Mirrors the main loop's post-connect bookkeeping: a fresh handle
+        # starts its silence window now, with no probe left over from the
+        # connection that just died.
+        listener._connected = True
+        listener._dev = object()
+        listener._last_report_at = time.monotonic()
+        listener._pending_liveness_ping = False
+
+        self.assertLess(listener.seconds_since_last_report(), 1.0)
+        self.assertFalse(listener._pending_liveness_ping)
+
+
 class HidBoltReceiverTests(unittest.TestCase):
     """Tests for Logi Bolt receiver support."""
 

--- a/tests/test_mouse_hook.py
+++ b/tests/test_mouse_hook.py
@@ -1,3 +1,4 @@
+import ctypes
 import importlib
 import queue
 import sys
@@ -154,6 +155,314 @@ class BaseMouseHookRuntimeStateTests(unittest.TestCase):
         hook._on_hid_disconnect()
 
         self.assertFalse(hook._should_intercept_events())
+
+
+class _FakeHidListener:
+    """Stand-in exposing just the liveness surface the watchdog uses."""
+
+    def __init__(self, silence):
+        self._silence = silence
+        self.pings = 0
+        self.connected_device = SimpleNamespace(name="MX Master 4")
+
+    def seconds_since_last_report(self):
+        return self._silence
+
+    def request_liveness_ping(self):
+        self.pings += 1
+
+
+class BaseMouseHookLivenessTests(unittest.TestCase):
+    """The watchdog that stops a silently-dead HID++ handle from surviving
+    until the user restarts Mouser (issue #263, and #257 / #246 without the
+    sleep). It must probe when the mouse is provably in use and the handle
+    has gone quiet -- and must stay silent in every other case, because a
+    needless probe wakes an idle mouse to learn nothing."""
+
+    def _connected_hook(self, silence):
+        hook = BaseMouseHook()
+        listener = _FakeHidListener(silence)
+        hook._hid_gesture = listener
+        hook._on_hid_connect()
+        return hook, listener
+
+    def test_probes_when_mouse_in_use_and_hid_has_gone_quiet(self):
+        hook, listener = self._connected_hook(silence=120.0)
+        now = 1000.0
+        hook._note_os_mouse_activity(now - 1.0)
+
+        self.assertTrue(hook._check_hid_liveness(now=now))
+        self.assertEqual(listener.pings, 1)
+
+    def test_no_probe_while_the_mouse_is_idle(self):
+        """An idle mouse is silent on every channel -- that is not a symptom,
+        and probing it would only cost battery."""
+        hook, listener = self._connected_hook(silence=600.0)
+        now = 1000.0
+        hook._note_os_mouse_activity(now - 300.0)
+
+        self.assertFalse(hook._check_hid_liveness(now=now))
+        self.assertEqual(listener.pings, 0)
+
+    def test_no_probe_while_hid_is_reporting(self):
+        hook, listener = self._connected_hook(silence=5.0)
+        now = 1000.0
+        hook._note_os_mouse_activity(now)
+
+        self.assertFalse(hook._check_hid_liveness(now=now))
+        self.assertEqual(listener.pings, 0)
+
+    def test_no_probe_when_no_device_is_connected(self):
+        """The reconnect loop already owns this case; probing would race it."""
+        hook = BaseMouseHook()
+        listener = _FakeHidListener(silence=600.0)
+        hook._hid_gesture = listener
+        hook._note_os_mouse_activity(1000.0)
+
+        self.assertFalse(hook._check_hid_liveness(now=1000.0))
+        self.assertEqual(listener.pings, 0)
+
+    def test_one_probe_per_silence_window(self):
+        """A dead handle must not be hammered every poll while its reconnect
+        is still in flight."""
+        hook, listener = self._connected_hook(silence=120.0)
+        now = 1000.0
+        hook._note_os_mouse_activity(now)
+
+        self.assertTrue(hook._check_hid_liveness(now=now))
+        self.assertFalse(hook._check_hid_liveness(now=now + 5.0))
+        self.assertFalse(hook._check_hid_liveness(now=now + 30.0))
+        self.assertEqual(listener.pings, 1)
+
+    def test_probes_again_after_the_window_elapses(self):
+        hook, listener = self._connected_hook(silence=120.0)
+        now = 1000.0
+        hook._note_os_mouse_activity(now)
+        hook._check_hid_liveness(now=now)
+
+        later = now + hook._LIVENESS_HID_SILENCE_S + 1.0
+        hook._note_os_mouse_activity(later)
+
+        self.assertTrue(hook._check_hid_liveness(now=later))
+        self.assertEqual(listener.pings, 2)
+
+    def test_listener_without_liveness_surface_is_tolerated(self):
+        """Older/stub listeners must not take the watchdog thread down."""
+        hook = BaseMouseHook()
+        hook._hid_gesture = SimpleNamespace(connected_device=object())
+        hook._on_hid_connect()
+        hook._note_os_mouse_activity(1000.0)
+
+        self.assertFalse(hook._check_hid_liveness(now=1000.0))
+
+    def test_platform_liveness_check_defaults_to_noop(self):
+        self.assertIsNone(BaseMouseHook()._platform_liveness_check())
+
+
+def _load_windows_hook_module():
+    """Import the Windows hook regardless of host OS.
+
+    Its recovery logic -- when a dropped hook is worth reinstalling, when a
+    burst of resume messages is one wake -- is pure decision-making that needs
+    no real Win32 to exercise, and CI runs Linux-only, so without this the
+    code that fixes issue #263 would ship with no test behind it at all.
+    """
+    if "core.mouse_hook_windows" in sys.modules:
+        return sys.modules["core.mouse_hook_windows"]
+    if sys.platform == "win32":
+        return importlib.import_module("core.mouse_hook_windows")
+    with patch.object(ctypes, "windll", MagicMock(), create=True):
+        return importlib.import_module("core.mouse_hook_windows")
+
+
+class WindowsHookWatchdogTests(unittest.TestCase):
+    """Windows removes a low-level hook whose proc overruns
+    LowLevelHooksTimeout and never says so -- the HHOOK stays valid and simply
+    stops firing, which is how users end up with a live-looking Mouser that
+    remaps nothing (#263 after sleep, #257 / #246 at random). Raw input is the
+    independent witness that tells a dropped hook from an untouched mouse."""
+
+    def setUp(self):
+        self.module = _load_windows_hook_module()
+        self.hook = self.module.MouseHook()
+        self.hook._running = True
+        self.hook._ri_hwnd = 4242
+
+    def _active_mouse(self, now):
+        self.hook._last_raw_input_at = now - 0.1
+
+    def test_reinstalls_when_raw_input_is_live_but_the_hook_is_silent(self):
+        now = 500.0
+        self._active_mouse(now)
+        self.hook._last_hook_event_at = now - 30.0
+
+        with patch.object(self.module, "PostMessageW") as post:
+            self.assertTrue(self.hook._platform_liveness_check(now=now))
+
+        post.assert_called_once()
+        self.assertEqual(post.call_args[0][1], self.module.WM_APP_REARM)
+
+    def test_idle_mouse_is_not_a_dropped_hook(self):
+        """Both channels silent just means nobody is touching the mouse."""
+        now = 500.0
+        self.hook._last_raw_input_at = now - 600.0
+        self.hook._last_hook_event_at = now - 600.0
+
+        with patch.object(self.module, "PostMessageW") as post:
+            self.assertFalse(self.hook._platform_liveness_check(now=now))
+
+        post.assert_not_called()
+
+    def test_live_hook_is_left_alone(self):
+        now = 500.0
+        self._active_mouse(now)
+        self.hook._last_hook_event_at = now - 0.1
+
+        self.assertFalse(self.hook._platform_liveness_check(now=now))
+
+    def test_second_verdict_waits_for_the_reinstall_to_land(self):
+        """Re-arm is posted to the hook thread, so it completes after this
+        returns; a second verdict meanwhile would queue a redundant rehook."""
+        now = 500.0
+        self._active_mouse(now)
+        self.hook._last_hook_event_at = now - 30.0
+
+        with patch.object(self.module, "PostMessageW"):
+            self.assertTrue(self.hook._platform_liveness_check(now=now))
+            self._active_mouse(now + 1.0)
+            self.assertFalse(self.hook._platform_liveness_check(now=now + 1.0))
+
+    def test_stopped_hook_is_not_rearmed(self):
+        self.hook._running = False
+        now = 500.0
+        self._active_mouse(now)
+        self.hook._last_hook_event_at = now - 30.0
+
+        self.assertFalse(self.hook._platform_liveness_check(now=now))
+
+    def test_never_fires_before_either_channel_has_reported(self):
+        """At startup both clocks are zero -- that is "no data yet", not a
+        30-year-old hook event."""
+        self.assertFalse(self.hook._platform_liveness_check(now=500.0))
+
+
+class WindowsResumeRecoveryTests(unittest.TestCase):
+    """One wake raises several cues (APM resume, then display-on, then
+    unlock). They must collapse into a single recovery pass, and that pass has
+    to retry: the Bolt stack comes back over seconds, so reconnecting once on
+    the first message can probe a receiver whose mouse has not re-paired
+    (issue #81)."""
+
+    def setUp(self):
+        self.module = _load_windows_hook_module()
+        self.hook = self.module.MouseHook()
+        self.hook._running = True
+        self.hook._ri_hwnd = 4242
+
+    def test_a_burst_of_resume_cues_is_one_recovery(self):
+        with patch.object(self.module.threading, "Thread") as thread:
+            self.assertTrue(self.hook._on_system_resume("power resume"))
+            self.assertFalse(self.hook._on_system_resume("display on"))
+            self.assertFalse(self.hook._on_system_resume("session unlock"))
+
+        self.assertEqual(thread.call_count, 1)
+
+    def test_a_later_wake_recovers_again(self):
+        with patch.object(self.module.threading, "Thread") as thread:
+            self.assertTrue(self.hook._on_system_resume("power resume"))
+            self.hook._last_resume_at -= self.hook._RESUME_DEDUPE_S + 1.0
+            self.assertTrue(self.hook._on_system_resume("power resume"))
+
+        self.assertEqual(thread.call_count, 2)
+
+    def test_recovery_rearms_and_drops_the_hid_handle_on_the_first_pass(self):
+        """After a resume the handle can stay open against a device stack
+        Windows already replaced, and from outside that looks healthy -- so
+        the first pass reconnects unconditionally."""
+        listener = Mock()
+        self.hook._hid_gesture = listener
+        self.hook._device_connected = True
+
+        with (
+            patch.object(self.module.time, "sleep"),
+            patch.object(self.module, "PostMessageW") as post,
+        ):
+            self.hook._resume_recovery_worker("power resume")
+
+        self.assertEqual(listener.force_reconnect.call_count, 1)
+        self.assertEqual(post.call_count, len(self.hook._RESUME_REARM_DELAYS_S))
+
+    def test_recovery_keeps_retrying_while_the_device_stays_away(self):
+        listener = Mock()
+        self.hook._hid_gesture = listener
+        self.hook._device_connected = False
+
+        with (
+            patch.object(self.module.time, "sleep"),
+            patch.object(self.module, "PostMessageW"),
+        ):
+            self.hook._resume_recovery_worker("power resume")
+
+        self.assertEqual(
+            listener.force_reconnect.call_count,
+            len(self.hook._RESUME_REARM_DELAYS_S),
+        )
+
+    def test_recovery_stops_if_the_hook_is_torn_down_mid_ladder(self):
+        listener = Mock()
+        self.hook._hid_gesture = listener
+        self.hook._running = False
+
+        with (
+            patch.object(self.module.time, "sleep"),
+            patch.object(self.module, "PostMessageW") as post,
+        ):
+            self.hook._resume_recovery_worker("power resume")
+
+        post.assert_not_called()
+        listener.force_reconnect.assert_not_called()
+
+    def test_display_on_payload_is_recognised(self):
+        setting = self.module.POWERBROADCAST_SETTING()
+        setting.PowerSetting = self.module.GUID.from_parts(
+            *self.module.GUID_CONSOLE_DISPLAY_STATE
+        )
+        setting.DataLength = 1
+        setting.Data[0] = self.module.DISPLAY_STATE_ON
+
+        self.assertTrue(
+            self.module.MouseHook._is_display_on_notification(
+                ctypes.addressof(setting)
+            )
+        )
+
+    def test_display_off_payload_is_ignored(self):
+        setting = self.module.POWERBROADCAST_SETTING()
+        setting.PowerSetting = self.module.GUID.from_parts(
+            *self.module.GUID_CONSOLE_DISPLAY_STATE
+        )
+        setting.DataLength = 1
+        setting.Data[0] = 0
+
+        self.assertFalse(
+            self.module.MouseHook._is_display_on_notification(
+                ctypes.addressof(setting)
+            )
+        )
+
+    def test_unrelated_power_setting_is_ignored(self):
+        setting = self.module.POWERBROADCAST_SETTING()
+        setting.PowerSetting = self.module.GUID.from_parts(
+            0xDEADBEEF, 0x1234, 0x5678, (0,) * 8
+        )
+        setting.DataLength = 1
+        setting.Data[0] = self.module.DISPLAY_STATE_ON
+
+        self.assertFalse(
+            self.module.MouseHook._is_display_on_notification(
+                ctypes.addressof(setting)
+            )
+        )
 
 
 class BaseMouseHookDispatchQueueTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #263. Also covers #257, #246 and #258, which are the same failure without the sleep.

## The problem

Mouser stops working entirely after a Windows resume and stays that way until it is restarted. Two independent failures can put it there, and **neither one raises anything**:

**The low-level hook.** Windows removes a `WH_MOUSE_LL` hook whose procedure overruns `LowLevelHooksTimeout` (300 ms by default) and tells nobody — the `HHOOK` stays non-NULL and simply never fires again. Resume is the classic trigger (the process is still being scheduled back in while a burst of input arrives), but it also happens under load, which is the un-slept variant in #257 / #246. The only thing that reinstalled it was `WM_DEVICECHANGE`, which does not necessarily fire on Modern Standby where USB stays enumerated.

**The HID++ handle.** A resume can leave it open against a device stack Windows has already replaced. `_rx()` returns `None` on timeout and raises only on a real error, so reads never fail — they just never return anything again, and the listener sits `_connected` against a dead pipe.

**Why nothing caught it.** The listener already has a full escalation for this (`_consecutive_request_timeouts` → device-asleep → 300 s → reconnect), but it only advances off *failed HID++ requests*, and `engine._background_hid_poll_allowed` gates all background traffic on `_frontend_visible`, which is `False` whenever the window is hidden or minimised — i.e. exactly the state Mouser is left in over a sleep. So no requests, no timeouts, no detection. This is also why #258 reports that *opening the UI* fixes it: that re-enables polling, the first request fails, and the existing recovery chain finally runs.

And the two failures compound: when HID++ does notice a disconnect, `_connected_device` goes `None` and `_should_intercept_events()` deliberately turns the hook into a pass-through, so one dead channel silences the other.

macOS already rebuilds on `NSWorkspaceDidWakeNotification` (`mouse_hook_macos.py`). Windows had no equivalent at all — this is a platform gap more than a deep bug. The reporter's workaround (a Task Scheduler job on resume event 107) works because it does by hand exactly what the code never did.

## The fix

**1. Windows learns that the machine woke.** The existing hidden message window now subscribes to `WM_POWERBROADCAST`, console display-state (`GUID_CONSOLE_DISPLAY_STATE` — required, since Modern Standby does not reliably raise the APM resume messages) and session unlock. All of them funnel into one recovery pass; a burst of cues for a single wake collapses via a 5 s dedupe.

Recovery runs on a **0.5 s / 3 s / 10 s ladder** rather than once: the Bolt stack returns over several seconds, so reconnecting on the first message can probe a receiver whose mouse has not re-paired yet (#81). The first pass always drops the HID handle — a handle orphaned by the resume is indistinguishable from a healthy one from the outside — and later passes only step in if the device has not come back on its own.

Re-arms are **posted** to the hook thread, never called directly: `SetWindowsHookExW` binds the hook to its caller and only the hook thread pumps messages, so rehooking from a worker would install a hook nothing ever delivers to.

**2. A liveness watchdog** (`BaseMouseHook`, polling every 5 s) for the cases with no resume to hang off. It acts on evidence rather than silence, because an idle mouse is silent on every channel:

- **The hook** is judged against raw input — the same events over an independent delivery path, already registered. Raw input live + hook silent is the signature of a dropped hook; both silent just means nobody is touching the mouse. Only `RIM_TYPEMOUSE` reports count here, since the vendor (`0xFF43`) and consumer collections we also register for never reach a `WH_MOUSE_LL` hook and would read a healthy hook as dead.
- **The HID++ handle**, quiet for 90 s while the mouse is *demonstrably in use*, is asked to answer a root request before anything is torn down. The ping is the test, not an assumption, and a single dropped reply is retried before it costs a reconnect.

**3. Recovery itself is unchanged** — `force_reconnect()` already tears down and rebuilds, and `engine._on_connection_change` already replays diverts, DPI, Smart Shift and wheel invert. Only the detection was missing.

The watchdog lives in the base class and is wired on all three platforms, so the macOS report (#258) is covered too.

## Tests

30 new tests; 898 pass, no regressions. (Six pre-existing errors remain, all missing `PIL` / `PySide6` in this environment — verified identical on `master`.)

CI runs Linux-only, so the Windows module would normally ship with no coverage at all. The new tests import it with `ctypes.windll` stubbed — the added logic (when a dropped hook is worth reinstalling, when a burst of cues is one wake, parsing a display-state payload) is pure decision-making that needs no real Win32 to exercise.

Coverage includes the negative cases that matter most: an idle mouse must not be probed, a live hook must not be reinstalled, a resume burst must not trigger three recoveries, and a listener lacking the new methods must not take the watchdog thread down.

## Not verified

I could not run a real suspend/resume — no Windows host and no mouse in this environment. The logic is tested; what is untested is that reinstalling the hook actually revives it on real hardware. Worth having someone with an MX Master on Windows 11 build this branch, sleep the machine, and confirm the log shows `System resume detected` followed by `Hook reinstalled successfully`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMSq4YDpgj55L267K5bx7j

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMSq4YDpgj55L267K5bx7j)_