### PR TITLE
fix(macos): recover the hook and HID++ handle after sleep

### DIFF
--- a/core/mouse_hook_macos.py
+++ b/core/mouse_hook_macos.py
@@ -69,8 +69,10 @@ class MouseHook(BaseMouseHook):
         self._tap_source = None
         self.ignore_trackpad = True
         self._wake_observer = None
+        self._screens_wake_observer = None
         self._session_resign_observer = None
         self._session_activate_observer = None
+        self._last_resume_at = 0.0
         self._init_dispatch_queue(maxsize=512)
         self._dispatch_thread = None
         self._first_event_logged = False
@@ -453,6 +455,40 @@ class MouseHook(BaseMouseHook):
         self._emit_debug("HID DPI switch button up")
         self._dispatch(MouseEvent(MouseEvent.DPI_SWITCH_UP))
 
+    # Give the macOS HID stack a moment to return, then replace the stale
+    # pre-sleep handle once. HidGestureListener owns all subsequent retries;
+    # queueing more force requests while it reconnects would tear down each
+    # fresh connection as soon as it opens.
+    _RESUME_RECONNECT_DELAY_S = 0.5
+    _RESUME_DEDUPE_S = 5.0
+
+    def _start_resume_recovery(self, reason):
+        # A full wake commonly raises both system-wake and screens-wake.
+        # Collapse that burst into one recovery pass.
+        now = time.monotonic()
+        if now - self._last_resume_at < self._RESUME_DEDUPE_S:
+            return False
+        self._last_resume_at = now
+        print(f"[MouseHook] Resume detected ({reason}) — recovering")
+        threading.Thread(
+            target=self._resume_recovery_worker,
+            daemon=True,
+            name="MouseHook-resume",
+        ).start()
+        return True
+
+    def _resume_recovery_worker(self):
+        time.sleep(self._RESUME_RECONNECT_DELAY_S)
+        if not self._running or not self._device_connected:
+            return
+        hg = self._hid_gesture
+        if hg is None:
+            return
+        try:
+            hg.force_reconnect()
+        except Exception as exc:
+            print(f"[MouseHook] resume reconnect request failed: {exc}")
+
     def _register_wake_observer(self):
         try:
             from AppKit import NSWorkspace
@@ -461,7 +497,7 @@ class MouseHook(BaseMouseHook):
         notification_center = NSWorkspace.sharedWorkspace().notificationCenter()
         hg = self._hid_gesture
 
-        def _re_enable_tap_and_reconnect(reason):
+        def _re_enable_tap_and_reconnect(reason, reconnect=True):
             if self._tap and self._running:
                 Quartz.CGEventTapEnable(self._tap, True)
                 ok = Quartz.CGEventTapIsEnabled(self._tap)
@@ -470,11 +506,16 @@ class MouseHook(BaseMouseHook):
                     f"{'OK' if ok else 'FAILED — may need restart'}",
                     flush=True,
                 )
-            if hg:
+            if hg and reconnect:
                 hg.force_reconnect()
 
         def _on_wake(notification):
-            _re_enable_tap_and_reconnect("wake")
+            _re_enable_tap_and_reconnect("wake", reconnect=False)
+            self._start_resume_recovery("system wake")
+
+        def _on_screens_wake(notification):
+            _re_enable_tap_and_reconnect("screens wake", reconnect=False)
+            self._start_resume_recovery("screens wake")
 
         def _on_session_resign(notification):
             print("[MouseHook] Session deactivated", flush=True)
@@ -487,6 +528,12 @@ class MouseHook(BaseMouseHook):
             None,
             None,
             _on_wake,
+        )
+        self._screens_wake_observer = notification_center.addObserverForName_object_queue_usingBlock_(
+            "NSWorkspaceScreensDidWakeNotification",
+            None,
+            None,
+            _on_screens_wake,
         )
         self._session_resign_observer = (
             notification_center.addObserverForName_object_queue_usingBlock_(
@@ -512,6 +559,7 @@ class MouseHook(BaseMouseHook):
             notification_center = NSWorkspace.sharedWorkspace().notificationCenter()
             for attr in (
                 "_wake_observer",
+                "_screens_wake_observer",
                 "_session_resign_observer",
                 "_session_activate_observer",
             ):

--- a/tests/test_mouse_hook.py
+++ b/tests/test_mouse_hook.py
@@ -156,6 +156,202 @@ class BaseMouseHookRuntimeStateTests(unittest.TestCase):
         self.assertFalse(hook._should_intercept_events())
 
 
+class _MacOSNotificationCenter:
+    """Minimal NSWorkspace notification-center stand-in for wake tests."""
+
+    def __init__(self):
+        self.callbacks = {}
+        self.removed = []
+
+    def addObserverForName_object_queue_usingBlock_(
+        self, name, _object, _queue, callback
+    ):
+        token = object()
+        self.callbacks[name] = (token, callback)
+        return token
+
+    def removeObserver_(self, token):
+        self.removed.append(token)
+
+
+class MacOSWakeRecoveryTests(unittest.TestCase):
+    """Unit-test the macOS wake recovery without requiring PyObjC or hardware."""
+
+    _WAKE = "NSWorkspaceDidWakeNotification"
+    _SCREENS_WAKE = "NSWorkspaceScreensDidWakeNotification"
+    _SESSION_ACTIVE = "NSWorkspaceSessionDidBecomeActiveNotification"
+
+    def setUp(self):
+        # CI is Linux-only. Import the macOS hook against lightweight PyObjC
+        # stand-ins so these recovery semantics stay covered there too.
+        self._module_name = "core.mouse_hook_macos"
+        self._loaded_test_module = False
+        self.module = sys.modules.get(self._module_name)
+        if self.module is None:
+            fake_objc = SimpleNamespace(autorelease_pool=MagicMock())
+            fake_quartz = MagicMock(name="Quartz")
+            with patch.dict(sys.modules, {"objc": fake_objc, "Quartz": fake_quartz}):
+                self.module = importlib.import_module(self._module_name)
+            self._loaded_test_module = True
+            self.addCleanup(self._unload_module)
+
+        self.hook = self.module.MouseHook()
+        self.hook._running = True
+        self.hook._device_connected = True
+        self.listener = Mock()
+        self.hook._hid_gesture = self.listener
+
+    def _unload_module(self):
+        if self._loaded_test_module and sys.modules.get(self._module_name) is self.module:
+            sys.modules.pop(self._module_name, None)
+        if self._loaded_test_module and getattr(core, "mouse_hook_macos", None) is self.module:
+            delattr(core, "mouse_hook_macos")
+
+    def _register_observers(self):
+        center = _MacOSNotificationCenter()
+        workspace = SimpleNamespace(notificationCenter=lambda: center)
+        fake_appkit = SimpleNamespace(
+            NSWorkspace=SimpleNamespace(sharedWorkspace=lambda: workspace)
+        )
+        with patch.dict(sys.modules, {"AppKit": fake_appkit}):
+            self.hook._register_wake_observer()
+        return center, fake_appkit
+
+    @staticmethod
+    def _capturing_thread_class(created):
+        class CapturingThread:
+            def __init__(self, *, target, daemon, name):
+                self.target = target
+                self.daemon = daemon
+                self.name = name
+                created.append(self)
+
+            def start(self):
+                pass
+
+        return CapturingThread
+
+    def test_system_and_screens_wake_coalesce_to_one_recovery_worker(self):
+        center, _ = self._register_observers()
+        workers = []
+
+        with (
+            patch.object(
+                self.module.threading,
+                "Thread",
+                self._capturing_thread_class(workers),
+            ),
+            patch.object(self.module.time, "monotonic", return_value=100.0),
+        ):
+            center.callbacks[self._SCREENS_WAKE][1](None)
+            center.callbacks[self._WAKE][1](None)
+
+        self.assertEqual(len(workers), 1)
+        self.assertEqual(workers[0].name, "MouseHook-resume")
+        self.assertTrue(workers[0].daemon)
+
+    def test_later_wake_outside_dedupe_window_schedules_another_worker(self):
+        center, _ = self._register_observers()
+        workers = []
+
+        with (
+            patch.object(
+                self.module.threading,
+                "Thread",
+                self._capturing_thread_class(workers),
+            ),
+            patch.object(self.module.time, "monotonic", side_effect=(100.0, 106.0)),
+        ):
+            center.callbacks[self._WAKE][1](None)
+            center.callbacks[self._SCREENS_WAKE][1](None)
+
+        self.assertEqual(len(workers), 2)
+
+    def test_resume_worker_does_not_reconnect_after_stop(self):
+        self.hook._running = False
+
+        with patch.object(self.module.time, "sleep") as sleep:
+            self.hook._resume_recovery_worker()
+
+        sleep.assert_called_once_with(self.hook._RESUME_RECONNECT_DELAY_S)
+        self.listener.force_reconnect.assert_not_called()
+
+    def test_resume_worker_skips_disconnected_or_missing_listener(self):
+        for connected, listener in ((False, self.listener), (True, None)):
+            with self.subTest(connected=connected, listener=listener is not None):
+                self.hook._running = True
+                self.hook._device_connected = connected
+                self.hook._hid_gesture = listener
+                with patch.object(self.module.time, "sleep"):
+                    self.hook._resume_recovery_worker()
+                if listener is not None:
+                    listener.force_reconnect.assert_not_called()
+
+    def test_resume_worker_contains_and_logs_reconnect_failure(self):
+        self.listener.force_reconnect.side_effect = RuntimeError("boom")
+
+        with (
+            patch.object(self.module.time, "sleep"),
+            patch("builtins.print") as print_mock,
+        ):
+            self.hook._resume_recovery_worker()
+
+        self.assertTrue(
+            any(
+                "resume reconnect request failed: boom" in str(call.args)
+                for call in print_mock.call_args_list
+            )
+        )
+
+    def test_registration_stores_every_observer_including_screens_wake(self):
+        center, _ = self._register_observers()
+
+        self.assertEqual(
+            set(center.callbacks),
+            {
+                self._WAKE,
+                self._SCREENS_WAKE,
+                "NSWorkspaceSessionDidResignActiveNotification",
+                self._SESSION_ACTIVE,
+            },
+        )
+        for attr in (
+            "_wake_observer",
+            "_screens_wake_observer",
+            "_session_resign_observer",
+            "_session_activate_observer",
+        ):
+            self.assertIsNotNone(getattr(self.hook, attr))
+
+    def test_unregistration_removes_and_clears_every_observer(self):
+        center, fake_appkit = self._register_observers()
+        tokens = {
+            self.hook._wake_observer,
+            self.hook._screens_wake_observer,
+            self.hook._session_resign_observer,
+            self.hook._session_activate_observer,
+        }
+
+        with patch.dict(sys.modules, {"AppKit": fake_appkit}):
+            self.hook._unregister_wake_observer()
+
+        self.assertCountEqual(center.removed, tokens)
+        for attr in (
+            "_wake_observer",
+            "_screens_wake_observer",
+            "_session_resign_observer",
+            "_session_activate_observer",
+        ):
+            self.assertIsNone(getattr(self.hook, attr))
+
+    def test_session_activation_keeps_its_separate_direct_reconnect_path(self):
+        center, _ = self._register_observers()
+
+        center.callbacks[self._SESSION_ACTIVE][1](None)
+
+        self.listener.force_reconnect.assert_called_once_with()
+
+
 class BaseMouseHookDispatchQueueTests(unittest.TestCase):
     def test_enqueue_keeps_queue_bounded_and_drops_oldest(self):
         hook = BaseMouseHook()


### PR DESCRIPTION

This complements [#264](https://github.com/TomBadash/Mouser/pull/264) and addresses the macOS counterpart of [#263](https://github.com/TomBadash/Mouser/issues/263) by completing the equivalent sleep/resume recovery behavior on macOS.

## Summary

- Listen for both system-wake and screens-wake notifications on macOS.
- Coalesce the two notifications into one recovery pass within a 5-second window.
- Give the HID stack 0.5 seconds to return, then replace the stale pre-sleep handle once.
- Avoid queuing another forced reconnect while `HidGestureListener` is already reconnecting.
- Re-enable the `CGEventTap` on either wake notification.

## Why

The existing macOS handler force-reconnects immediately on `NSWorkspaceDidWakeNotification`. In testing, `NSWorkspaceScreensDidWakeNotification` can arrive first, while the old HID handle still appears connected.

Waiting briefly before requesting one reconnect reliably replaces the stale handle. Deduplicating the system-wake and screens-wake notifications prevents the second notification from tearing down a newly established connection.

This branch is based directly on `master` and can be merged independently of #264. The two changes complement each other:

- #264 provides Windows resume recovery and a cross-platform liveness watchdog for disconnects without a wake event.
- This PR completes the deterministic macOS sleep/resume recovery path.

## Validation

Built and ran the macOS app on Apple Silicon, then tested a real system sleep/wake cycle with an MX Master 3.

Key log entries:

```text
2026-08-09 23:49:52 [MouseHook] Event tap re-enabled (screens wake): OK
2026-08-09 23:49:52 [MouseHook] Resume detected (screens wake) — recovering
2026-08-09 23:49:53 [MouseHook] Event tap re-enabled (wake): OK
2026-08-09 23:49:54 [HidGesture] read error: reconnect requested
2026-08-09 23:49:54 [MouseHook] Device Disconnected
2026-08-09 23:49:56 [HidGesture] Opened PID=0xB023 via iokit-exact
2026-08-09 23:49:58 [MouseHook] Device Connected
2026-08-09 23:49:58 [HidGesture] Listening for gesture events…
2026-08-09 23:49:58 [HidGesture] Smart Shift set to fixed ratchet
2026-08-09 23:49:58 [HidGesture] Wheel native invert v=True h=True vertical=OK thumb=OK
2026-08-09 23:50:03 [HidGesture] DPI set to 1000
```

The system-wake notification at `23:49:53` re-enabled the event tap but did not start a second recovery pass, confirming that deduplication worked. There was one disconnect/reconnect cycle, with core controls restored approximately 6 seconds after wake.

Existing mouse hook suite: 59 tests passed.