### PR TITLE
fix(macOS): reconnect stale HID++ handle after mouse idle

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -37,6 +37,7 @@ BACKGROUND_BATTERY_POLL_INTERVAL_S = 1800
 BACKGROUND_SMART_SHIFT_POLL_INTERVAL_S = 300
 BACKGROUND_HID_POLL_IDLE_GRACE_S = 60.0
 BACKGROUND_HID_POLL_EVENT_FUZZ_S = 2.0
+BACKGROUND_HID_RESUME_PROBE_WINDOW_S = 10.0
 
 
 def _system_idle_seconds():
@@ -77,6 +78,37 @@ def _system_idle_seconds():
     return None
 
 
+def _mouse_idle_seconds():
+    """Return seconds since the last mouse input on macOS.
+
+    Unlike ``_system_idle_seconds()``, this ignores keyboard activity so a
+    background health probe does not wake a mouse that the user has not
+    actually resumed using.
+    """
+    if sys.platform != "darwin":
+        return None
+    try:
+        import Quartz
+        state = getattr(Quartz, "kCGEventSourceStateCombinedSessionState", 0)
+        event_names = (
+            "kCGEventMouseMoved",
+            "kCGEventLeftMouseDown",
+            "kCGEventRightMouseDown",
+            "kCGEventOtherMouseDown",
+            "kCGEventScrollWheel",
+        )
+        idle_values = [
+            float(Quartz.CGEventSourceSecondsSinceLastEventType(
+                state, getattr(Quartz, event_name)
+            ))
+            for event_name in event_names
+            if hasattr(Quartz, event_name)
+        ]
+        return min(idle_values) if idle_values else None
+    except Exception:
+        return None
+
+
 class Engine:
     """
     Core logic: reads config, installs the mouse hook,
@@ -110,6 +142,7 @@ class Engine:
         self._battery_poll_thread = None          # track the poller thread
         self._last_background_hid_poll_at = None
         self._frontend_visible = False
+        self._hidden_hid_resume_probe_armed = False
         self._last_connection_state = bool(self._hid_runtime_state().input_ready)
         self._wheel_divert_change_cb = None
         self._wheel_divert_active_local = False
@@ -1368,6 +1401,31 @@ class Engine:
     def set_frontend_visible(self, visible):
         self._frontend_visible = bool(visible)
 
+    def _hidden_hid_resume_probe_due(self):
+        """Arm while the mouse is idle; fire once when mouse input resumes.
+
+        This keeps hidden-window polling dormant while the mouse is asleep,
+        but gives the HID++ listener one chance to discover a stale macOS
+        IOKit handle as soon as the user starts using the mouse again.
+        """
+        if self._frontend_visible:
+            self._hidden_hid_resume_probe_armed = False
+            return False
+
+        idle_seconds = _mouse_idle_seconds()
+        if idle_seconds is None:
+            return False
+        if idle_seconds >= BACKGROUND_HID_POLL_IDLE_GRACE_S:
+            self._hidden_hid_resume_probe_armed = True
+            return False
+        if (
+            self._hidden_hid_resume_probe_armed
+            and idle_seconds <= BACKGROUND_HID_RESUME_PROBE_WINDOW_S
+        ):
+            self._hidden_hid_resume_probe_armed = False
+            return True
+        return False
+
     def _battery_poll_loop(self, stop_event):
         """Read battery and smart shift mode periodically until disconnected."""
         _battery_poll_interval = BACKGROUND_BATTERY_POLL_INTERVAL_S
@@ -1380,6 +1438,12 @@ class Engine:
             now = time.time()
             hg = self.hook._hid_gesture
             if hg and hg.connected_device is not None:
+                if self._hidden_hid_resume_probe_due():
+                    print("[Engine] Mouse resumed after idle; checking HID++ connection")
+                    hg.check_connection()
+                    if stop_event.is_set():
+                        return
+
                 if (
                     now - _last_battery >= _battery_poll_interval
                     and self._background_hid_poll_allowed(now)

--- a/core/hid_gesture.py
+++ b/core/hid_gesture.py
@@ -1115,6 +1115,9 @@ class HidGestureListener:
         self._pending_battery = None
         self._battery_result = None
         self._battery_event = threading.Event()
+        self._pending_connection_check = False
+        self._connection_check_result = False
+        self._connection_check_event = threading.Event()
         self._last_logged_battery = None
         self._last_battery_event = None
         self._connected_device_info = None
@@ -2610,6 +2613,37 @@ class HidGestureListener:
             return None
         return self._battery_result
 
+    def check_connection(self):
+        """Probe the active HID++ session on the listener thread.
+
+        Returns True on a valid IRoot response. A transport error or timeout
+        raises inside the listener loop so its normal cleanup/reconnect path
+        runs; this caller receives False once pending requests are drained.
+        """
+        self._connection_check_result = False
+        self._connection_check_event.clear()
+        self._pending_connection_check = True
+        if not self._connection_check_event.wait(3.0):
+            print("[HidGesture] Connection check timed out waiting for listener")
+            self._pending_connection_check = False
+            return False
+        return self._connection_check_result
+
+    def _apply_pending_connection_check(self):
+        """Validate the live handle with an idempotent HID++ IRoot query."""
+        if self._dev is None:
+            self._connection_check_result = False
+            self._pending_connection_check = False
+            self._connection_check_event.set()
+            return
+
+        feature_idx = self._find_feature(FEAT_REPROG_V4, timeout_ms=1000)
+        self._connection_check_result = feature_idx is not None
+        self._pending_connection_check = False
+        self._connection_check_event.set()
+        if feature_idx is None:
+            raise IOError("HID++ connection health check failed")
+
     @staticmethod
     def _parse_battery_params(params):
         """Extract ``(level, charging)`` from a 0x1004/0x1000 battery payload.
@@ -2688,6 +2722,9 @@ class HidGestureListener:
 
     def _drain_pending_requests(self):
         """Abort all pending HID++ requests, unblocking waiting threads."""
+        self._pending_connection_check = False
+        self._connection_check_result = False
+        self._connection_check_event.set()
         self._pending_battery = None
         self._battery_event.set()
         self._pending_dpi = None
@@ -3396,6 +3433,8 @@ class HidGestureListener:
                         self._apply_pending_native_wheel_invert()
                     if self._pending_battery is not None:
                         self._apply_pending_read_battery()
+                    if self._pending_connection_check:
+                        self._apply_pending_connection_check()
                     if self._pending_haptic is not None:
                         self._apply_pending_haptic()
                     if self._pending_force_sensing is not None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -318,6 +318,8 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
         return SimpleNamespace(
             connected_device=connected_device,
             read_battery=Mock(return_value=None),
+            read_smart_shift=Mock(return_value=None),
+            check_connection=Mock(return_value=True),
             set_dpi=Mock(return_value=dpi_result),
             set_smart_shift=Mock(return_value=smart_shift_result),
             smart_shift_supported=True,
@@ -537,7 +539,8 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
             read_smart_shift=Mock(return_value={"mode": "ratchet", "enabled": False, "threshold": 25}),
         )
 
-        engine._battery_poll_loop(stop_event)
+        with patch("core.engine._system_idle_seconds", return_value=0.0):
+            engine._battery_poll_loop(stop_event)
 
         engine.hook._hid_gesture.read_battery.assert_called_once_with()
         engine.hook._hid_gesture.read_smart_shift.assert_not_called()
@@ -611,6 +614,36 @@ class EngineReplayPhaseOneTests(unittest.TestCase):
 
         engine.hook._hid_gesture.read_battery.assert_called_once_with()
         engine.hook._hid_gesture.read_smart_shift.assert_called_once_with()
+
+    def test_hidden_mouse_resume_runs_one_connection_check(self):
+        engine = self._make_engine()
+        stop_event = Mock()
+        stop_event.is_set.return_value = False
+        stop_event.wait.side_effect = [False, True]
+        engine.hook._hid_gesture = self._make_hid(
+            connected_device=SimpleNamespace(name="MX Master 3S")
+        )
+
+        with patch("core.engine._mouse_idle_seconds", side_effect=[120.0, 1.0]):
+            engine._battery_poll_loop(stop_event)
+
+        engine.hook._hid_gesture.check_connection.assert_called_once_with()
+        engine.hook._hid_gesture.read_battery.assert_not_called()
+        engine.hook._hid_gesture.read_smart_shift.assert_not_called()
+
+    def test_hidden_mouse_activity_without_prior_idle_does_not_probe(self):
+        engine = self._make_engine()
+        stop_event = Mock()
+        stop_event.is_set.return_value = False
+        stop_event.wait.return_value = True
+        engine.hook._hid_gesture = self._make_hid(
+            connected_device=SimpleNamespace(name="MX Master 3S")
+        )
+
+        with patch("core.engine._mouse_idle_seconds", return_value=1.0):
+            engine._battery_poll_loop(stop_event)
+
+        engine.hook._hid_gesture.check_connection.assert_not_called()
 
 
 class WheelInvertConnectThreadingTests(unittest.TestCase):

--- a/tests/test_hid_gesture.py
+++ b/tests/test_hid_gesture.py
@@ -128,6 +128,32 @@ class GestureCandidateSelectionTests(unittest.TestCase):
         )
 
 
+class HidConnectionCheckTests(unittest.TestCase):
+    def test_connection_check_uses_reprog_feature_as_health_probe(self):
+        listener = hid_gesture.HidGestureListener()
+        listener._dev = object()
+
+        with patch.object(listener, "_find_feature", return_value=0x09) as find:
+            listener._apply_pending_connection_check()
+
+        find.assert_called_once_with(hid_gesture.FEAT_REPROG_V4, timeout_ms=1000)
+        self.assertTrue(listener._connection_check_result)
+        self.assertTrue(listener._connection_check_event.is_set())
+
+    def test_failed_connection_check_drives_reconnect_exception(self):
+        listener = hid_gesture.HidGestureListener()
+        listener._dev = object()
+
+        with (
+            patch.object(listener, "_find_feature", return_value=None),
+            self.assertRaisesRegex(IOError, "health check failed"),
+        ):
+            listener._apply_pending_connection_check()
+
+        self.assertFalse(listener._connection_check_result)
+        self.assertTrue(listener._connection_check_event.is_set())
+
+
 class DeviceInfoDumpTests(unittest.TestCase):
     def test_dump_device_info_includes_runtime_capability_inventory(self):
         listener = hid_gesture.HidGestureListener()


### PR DESCRIPTION
## Summary

- detect a stale macOS HID++ handle when mouse activity resumes after idle
- run a one-shot IRoot health check on the HID listener thread
- reuse the existing cleanup, reconnect, and saved-settings replay path on failure
- preserve the existing policy of avoiding continuous HID polling while the settings window is hidden

## Root cause

Mouser intentionally suppresses battery and Smart Shift polling while its settings window is hidden so background HID requests do not wake an idle mouse. On macOS, that also means a stale IOKit handle can remain marked connected indefinitely: the listener receives no reports, but no request exercises the dead handle.

Opening the settings window makes background polling eligible again. The first request then fails with `IOHIDDeviceSetReport`, which finally enters the existing disconnect/reconnect path. This is why opening Mouser appears to repair the connection.

## Fix

While Mouser is hidden, track mouse-class activity through `CGEventSourceSecondsSinceLastEventType`. After at least 60 seconds without pointer, button, or scroll input, arm a one-shot probe. If mouse activity resumes within the polling window, queue an idempotent HID++ IRoot lookup for `REPROG_V4` on the listener thread.

A transport error or missing response raises through the listener's existing cleanup path, which reconnects and reapplies saved device settings. Keyboard-only activity does not trigger the probe, and no periodic HID request is made while the mouse remains idle.

## Validation

- `.venv/bin/python -m unittest tests.test_engine tests.test_hid_gesture` — 76 tests passed
- PyInstaller macOS application build completed successfully
- deep, strict code-signature verification passed for the Developer ID-signed arm64 bundle
- manually validated for several days with an MX Master 3S over Bluetooth on macOS; advanced button mappings continued recovering without opening the Mouser window

Fixes #258
