### PR TITLE
fix: macOS start-at-login self-termination and settings reverting to defaults

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -1589,7 +1589,12 @@ class Engine:
         Re-wire callbacks without tearing down the hook or HID++.
         """
         with self._lock:
-            self.cfg = load_config()
+            fresh_cfg = load_config()
+            # Update in place instead of rebinding self.cfg: Backend shares
+            # this exact dict object, and rebinding it would silently fork
+            # the two config holders again (stale-copy overwrite bug).
+            self.cfg.clear()
+            self.cfg.update(fresh_cfg)
             self._current_profile = self.cfg.get("active_profile", "default")
             self.hook.reset_bindings()
             self._setup_hooks()

--- a/core/startup.py
+++ b/core/startup.py
@@ -355,6 +355,25 @@ def _macos_plist_path() -> str:
     )
 
 
+def running_as_macos_launch_agent() -> bool:
+    """True when THIS process was spawned by the Mouser LaunchAgent.
+
+    launchd sets ``XPC_SERVICE_NAME`` to the job label for the processes it
+    spawns. Booting that job out would terminate this very process, so the
+    caller must avoid ``launchctl bootout`` (and a re-``bootstrap``, whose
+    RunAtLoad would spawn a duplicate instance) while running as the agent.
+    """
+    return os.environ.get("XPC_SERVICE_NAME", "").strip() == MACOS_LAUNCH_AGENT_LABEL
+
+
+def _launchctl_job_loaded(domain: str) -> bool:
+    """True when the Mouser LaunchAgent is loaded in the given launchd domain."""
+    result = _launchctl_run(
+        ["launchctl", "print", f"{domain}/{MACOS_LAUNCH_AGENT_LABEL}"]
+    )
+    return result.returncode == 0
+
+
 def _launchctl_run(args: list) -> subprocess.CompletedProcess:
     return subprocess.run(
         args,
@@ -434,12 +453,18 @@ def _apply_macos(enabled: bool) -> None:
     launch_agents_dir = os.path.dirname(plist_path)
     uid = os.getuid()
     domain = f"gui/{uid}"
+    running_as_agent = running_as_macos_launch_agent()
 
     if enabled:
         os.makedirs(launch_agents_dir, exist_ok=True)
-        plist_existed = os.path.isfile(plist_path)
+        payload = {
+            "Label": MACOS_LAUNCH_AGENT_LABEL,
+            "ProgramArguments": _program_arguments(),
+            "RunAtLoad": True,
+        }
+        new_plist = plistlib.dumps(payload, fmt=plistlib.FMT_XML)
         previous_plist = None
-        if plist_existed:
+        if os.path.isfile(plist_path):
             try:
                 with open(plist_path, "rb") as f:
                     previous_plist = f.read()
@@ -447,28 +472,46 @@ def _apply_macos(enabled: bool) -> None:
                 raise RuntimeError(
                     f"failed to preserve existing launch agent: {exc}"
                 ) from exc
-            _launchctl_run(["launchctl", "bootout", domain, plist_path])
-        payload = {
-            "Label": MACOS_LAUNCH_AGENT_LABEL,
-            "ProgramArguments": _program_arguments(),
-            "RunAtLoad": True,
-        }
-        new_plist = plistlib.dumps(payload, fmt=plistlib.FMT_XML)
-        try:
-            _atomic_write_file(plist_path, new_plist)
+
+        if previous_plist == new_plist:
+            # The on-disk agent already matches the desired state. Re-loading
+            # the job here is not just wasteful -- it is harmful:
+            #   * bootout would kill this process when launchd spawned it
+            #     (login start), silently breaking start-at-login;
+            #   * bootstrap re-runs RunAtLoad, spawning a duplicate instance
+            #     that immediately exits via the single-instance lock (and
+            #     pops the settings window while doing so).
+            if running_as_agent or _launchctl_job_loaded(domain):
+                return
+            # The plist exists but the job is not loaded in this session;
+            # load it so the state matches the config right away.
             result = _launchctl_run(["launchctl", "bootstrap", domain, plist_path])
             if result.returncode != 0:
                 raise RuntimeError(_launchctl_failure_message("bootstrap", result))
+            return
+
+        # Desired agent differs from what is on disk (or none exists yet).
+        if previous_plist is not None and not running_as_agent:
+            _launchctl_run(["launchctl", "bootout", domain, plist_path])
+        try:
+            _atomic_write_file(plist_path, new_plist)
+            if not running_as_agent:
+                result = _launchctl_run(["launchctl", "bootstrap", domain, plist_path])
+                if result.returncode != 0:
+                    raise RuntimeError(_launchctl_failure_message("bootstrap", result))
         except Exception as exc:
             _restore_macos_plist_then_raise(plist_path, previous_plist, domain, exc)
+        # When running as the agent itself, the rewritten plist is picked up
+        # at the next login; re-loading the job now would terminate us.
     else:
         if os.path.isfile(plist_path):
-            _launchctl_run(["launchctl", "bootout", domain, plist_path])
+            if not running_as_agent:
+                _launchctl_run(["launchctl", "bootout", domain, plist_path])
             try:
                 os.remove(plist_path)
             except OSError:
                 pass
-        else:
+        elif not running_as_agent:
             _launchctl_run(
                 ["launchctl", "bootout", domain, MACOS_LAUNCH_AGENT_LABEL]
             )

--- a/main_qml.py
+++ b/main_qml.py
@@ -66,7 +66,11 @@ from core.config import load_config, save_config
 from core.engine import Engine
 from core.hid_gesture import set_backend_preference as set_hid_backend_preference
 from core.accessibility import is_process_trusted
-from core.startup import linux_runtime_icon_path, sync_linux_icon_theme
+from core.startup import (
+    linux_runtime_icon_path,
+    running_as_macos_launch_agent,
+    sync_linux_icon_theme,
+)
 from core.version import APP_BUILD_MODE, APP_COMMIT_DISPLAY, APP_VERSION
 from ui.backend import Backend
 from ui.locale_manager import LocaleManager
@@ -123,13 +127,18 @@ def _single_instance_server_name() -> str:
     return f"mouser_instance_{digest}"
 
 
-def _try_activate_existing_instance(server_name: str, timeout_ms: int = 500) -> bool:
+def _try_activate_existing_instance(
+    server_name: str,
+    timeout_ms: int = 500,
+    send_activate: bool = True,
+) -> bool:
     sock = QLocalSocket()
     sock.connectToServer(server_name)
     if not sock.waitForConnected(timeout_ms):
         return False
-    sock.write(_SINGLE_INSTANCE_ACTIVATE_MSG)
-    sock.waitForBytesWritten(timeout_ms)
+    if send_activate:
+        sock.write(_SINGLE_INSTANCE_ACTIVATE_MSG)
+        sock.waitForBytesWritten(timeout_ms)
     sock.disconnectFromServer()
     return True
 
@@ -144,7 +153,14 @@ def _drain_local_activate_socket(sock: QLocalSocket | None) -> None:
 
 def _single_instance_acquire(app: QApplication, server_name: str):
     """Return (QLocalServer, None) if this process owns the instance, or (None, exit_code)."""
-    if _try_activate_existing_instance(server_name):
+    # When our own LaunchAgent spawned us (login start or a re-bootstrap)
+    # while another instance already runs, exit quietly: raising the running
+    # instance's window would pop the settings window on every login start
+    # even when configured to start minimized.
+    send_activate = not (
+        sys.platform == "darwin" and running_as_macos_launch_agent()
+    )
+    if _try_activate_existing_instance(server_name, send_activate=send_activate):
         return None, 0
     server = QLocalServer(app)
     QLocalServer.removeServer(server_name)
@@ -155,7 +171,7 @@ def _single_instance_acquire(app: QApplication, server_name: str):
         return None, 1
     for _ in range(3):
         time.sleep(0.05)
-        if _try_activate_existing_instance(server_name):
+        if _try_activate_existing_instance(server_name, send_activate=send_activate):
             return None, 0
         QLocalServer.removeServer(server_name)
         server.close()

--- a/main_qml.py
+++ b/main_qml.py
@@ -1410,7 +1410,10 @@ def main():
     def _save_language():
         """Persist the selected language to config.json."""
         try:
-            saved_cfg = load_config()
+            # Write through the Backend's live config dict -- the same object
+            # the Engine holds -- so this save cannot be clobbered by a stale
+            # in-memory copy the next time another component saves config.
+            saved_cfg = backend._cfg if backend is not None else load_config()
             saved_cfg.setdefault("settings", {})["language"] = locale_mgr.language
             save_config(saved_cfg)
         except Exception as exc:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -86,6 +86,64 @@ class _FakeEngine:
 
 
 @unittest.skipIf(Backend is None, "PySide6 not installed in test environment")
+class BackendConfigSharingTests(unittest.TestCase):
+    """The Backend must share the Engine's live config dict.
+
+    Separate per-component copies caused a stale holder to clobber newer
+    settings on its next whole-config save: switching the UI language to
+    Chinese was reverted to "en" by the next Backend/Engine save, and
+    start_at_login was reverted the same way by Engine-side saves (which
+    then removed the login agent at the next startup sync).
+    """
+
+    @staticmethod
+    def _make_engine_with_cfg(cfg):
+        engine = _FakeEngine()
+        engine.cfg = cfg
+        return engine
+
+    def _make_backend(self, engine, loaded_config):
+        with (
+            patch("ui.backend.load_config", return_value=loaded_config),
+            patch("ui.backend.save_config"),
+            patch("ui.backend.supports_login_startup", return_value=False),
+        ):
+            return Backend(engine=engine)
+
+    def test_backend_shares_engine_live_config_dict(self):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        engine = self._make_engine_with_cfg(cfg)
+        backend = self._make_backend(engine, copy.deepcopy(DEFAULT_CONFIG))
+        self.assertIs(backend._cfg, cfg)
+
+    def test_backend_falls_back_to_own_load_without_engine_cfg(self):
+        engine = _FakeEngine()  # no .cfg attribute
+        loaded = copy.deepcopy(DEFAULT_CONFIG)
+        backend = self._make_backend(engine, loaded)
+        self.assertIs(backend._cfg, loaded)
+
+    def test_language_change_survives_subsequent_backend_save(self):
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        engine = self._make_engine_with_cfg(cfg)
+
+        with (
+            patch("ui.backend.load_config", return_value=copy.deepcopy(DEFAULT_CONFIG)),
+            patch("ui.backend.save_config") as save_mock,
+            patch("ui.backend.supports_login_startup", return_value=False),
+        ):
+            backend = Backend(engine=engine)
+            # What main_qml._save_language now does: write "zh" through the
+            # shared live config and persist it.
+            backend._cfg.setdefault("settings", {})["language"] = "zh"
+            save_mock.reset_mock()
+            backend.setStartMinimized(False)  # default is True; forces a save
+
+        saved_cfg = save_mock.call_args.args[0]
+        self.assertIs(saved_cfg, cfg)
+        self.assertEqual(saved_cfg["settings"]["language"], "zh")
+
+
+@unittest.skipIf(Backend is None, "PySide6 not installed in test environment")
 class BackendDeviceLayoutTests(unittest.TestCase):
     def _make_backend(self, engine=None, root_dir=None, cfg=None):
         loaded_config = copy.deepcopy(cfg or DEFAULT_CONFIG)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -288,6 +288,35 @@ class EngineHorizontalScrollTests(unittest.TestCase):
         self.assertTrue(engine._app_detector.start_called)
 
 
+class EngineReloadMappingsConfigIdentityTests(unittest.TestCase):
+    def _make_engine(self):
+        from core.engine import Engine
+
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        with (
+            patch("core.engine.MouseHook", _FakeMouseHook),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=cfg),
+        ):
+            return Engine()
+
+    def test_reload_mappings_updates_config_in_place(self):
+        # Backend shares the Engine's live config dict; reload_mappings must
+        # refresh that dict in place instead of rebinding self.cfg, which
+        # would fork the two holders and resurrect the stale-copy overwrite
+        # bug (language/start_at_login silently reverted on later saves).
+        engine = self._make_engine()
+        original_cfg = engine.cfg
+
+        fresh_cfg = copy.deepcopy(DEFAULT_CONFIG)
+        fresh_cfg["settings"]["language"] = "zh"
+        with patch("core.engine.load_config", return_value=fresh_cfg):
+            engine.reload_mappings()
+
+        self.assertIs(engine.cfg, original_cfg)
+        self.assertEqual(engine.cfg["settings"]["language"], "zh")
+
+
 class EngineDesktopCycleTests(unittest.TestCase):
     def _make_engine(self):
         from core.engine import Engine

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -52,6 +52,18 @@ class TryActivateExistingTests(unittest.TestCase):
         sock.write.assert_called_once_with(main_qml._SINGLE_INSTANCE_ACTIVATE_MSG)
         sock.disconnectFromServer.assert_called_once()
 
+    @patch("main_qml.QLocalSocket")
+    def test_does_not_send_payload_when_send_activate_disabled(self, mock_sock_cls):
+        sock = MagicMock()
+        sock.waitForConnected.return_value = True
+        sock.waitForBytesWritten.return_value = True
+        mock_sock_cls.return_value = sock
+        self.assertTrue(
+            main_qml._try_activate_existing_instance("pipe_name", send_activate=False)
+        )
+        sock.write.assert_not_called()
+        sock.disconnectFromServer.assert_called_once()
+
 
 @unittest.skipIf(main_qml is None, "main_qml / PySide6 not available")
 class SingleInstanceAcquireTests(unittest.TestCase):
@@ -61,6 +73,21 @@ class SingleInstanceAcquireTests(unittest.TestCase):
         server, code = main_qml._single_instance_acquire(app, "any_name")
         self.assertIsNone(server)
         self.assertEqual(code, 0)
+
+    @patch("main_qml.running_as_macos_launch_agent", return_value=True)
+    @patch("main_qml._try_activate_existing_instance", return_value=True)
+    def test_launch_agent_spawned_duplicate_does_not_raise_window(
+        self, try_activate, _running_as_agent
+    ):
+        """A LaunchAgent-spawned duplicate exits without sending "show" --
+        sending it popped the settings window on every login start, even
+        when start_minimized was configured."""
+        app = _ensure_qapp()
+        with patch.object(main_qml.sys, "platform", "darwin"):
+            server, code = main_qml._single_instance_acquire(app, "any_name")
+        self.assertIsNone(server)
+        self.assertEqual(code, 0)
+        try_activate.assert_called_once_with("any_name", send_activate=False)
 
     @patch("main_qml._try_activate_existing_instance", return_value=False)
     @patch("main_qml.QLocalServer.removeServer")

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -387,6 +387,171 @@ class ApplyLoginStartupMacTests(unittest.TestCase):
             ]
         )
 
+    def test_macos_enable_noop_when_plist_matches_and_job_loaded(self):
+        domain = "gui/501"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "io.github.tombadash.mouser.plist")
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+            ):
+                m_lc.return_value = MagicMock(returncode=0)
+                st.apply_login_startup(True)
+                with open(plist, "rb") as f:
+                    written = f.read()
+
+                # Startup sync with identical on-disk agent and the job
+                # already loaded: must not bootout (kills a login-started
+                # instance) and must not bootstrap (RunAtLoad ghost run).
+                m_lc.reset_mock()
+                m_lc.return_value = MagicMock(returncode=0)
+                st.apply_login_startup(True)
+
+                self.assertEqual(
+                    [call.args[0] for call in m_lc.call_args_list],
+                    [
+                        [
+                            "launchctl",
+                            "print",
+                            f"{domain}/{st.MACOS_LAUNCH_AGENT_LABEL}",
+                        ]
+                    ],
+                )
+                with open(plist, "rb") as f:
+                    self.assertEqual(f.read(), written)
+
+    def test_macos_enable_noop_when_running_as_launch_agent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "io.github.tombadash.mouser.plist")
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+                patch.dict(
+                    os.environ, {"XPC_SERVICE_NAME": st.MACOS_LAUNCH_AGENT_LABEL}
+                ),
+            ):
+                m_lc.return_value = MagicMock(returncode=0)
+                st.apply_login_startup(True)
+                with open(plist, "rb") as f:
+                    written = f.read()
+
+                m_lc.reset_mock()
+                st.apply_login_startup(True)
+
+            # The agent-spawned process must not reload its own job: bootout
+            # would terminate it, bootstrap would spawn a duplicate.
+            m_lc.assert_not_called()
+            with open(plist, "rb") as f:
+                self.assertEqual(f.read(), written)
+
+    def test_macos_enable_bootstraps_matching_plist_when_job_not_loaded(self):
+        domain = "gui/501"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "io.github.tombadash.mouser.plist")
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+            ):
+                m_lc.return_value = MagicMock(returncode=0)
+                st.apply_login_startup(True)
+                with open(plist, "rb") as f:
+                    written = f.read()
+
+                m_lc.reset_mock()
+                m_lc.side_effect = [
+                    MagicMock(returncode=1),  # print: job not loaded
+                    MagicMock(returncode=0),  # bootstrap
+                ]
+                st.apply_login_startup(True)
+
+                self.assertEqual(
+                    [call.args[0] for call in m_lc.call_args_list],
+                    [
+                        [
+                            "launchctl",
+                            "print",
+                            f"{domain}/{st.MACOS_LAUNCH_AGENT_LABEL}",
+                        ],
+                        ["launchctl", "bootstrap", domain, plist],
+                    ],
+                )
+                with open(plist, "rb") as f:
+                    self.assertEqual(f.read(), written)
+
+    def test_macos_enable_rewrites_changed_plist_without_reloading_when_agent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "io.github.tombadash.mouser.plist")
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/X/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+            ):
+                m_lc.return_value = MagicMock(returncode=0)
+                st.apply_login_startup(True)
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_program_arguments", return_value=["/Y/Mouser"]),
+                patch.object(st, "_launchctl_run") as m_lc,
+                patch.dict(
+                    os.environ, {"XPC_SERVICE_NAME": st.MACOS_LAUNCH_AGENT_LABEL}
+                ),
+            ):
+                st.apply_login_startup(True)
+
+            m_lc.assert_not_called()
+            with open(plist, "rb") as f:
+                payload = plistlib.load(f)
+            self.assertEqual(payload["ProgramArguments"], ["/Y/Mouser"])
+
+    def test_macos_disable_skips_bootout_when_running_as_launch_agent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plist = os.path.join(tmp, "io.github.tombadash.mouser.plist")
+            with open(plist, "wb") as f:
+                f.write(b"agent plist")
+
+            with (
+                patch.object(sys, "platform", "darwin"),
+                patch("core.startup.os.getuid", return_value=501, create=True),
+                patch.object(st, "supports_login_startup", return_value=True),
+                patch.object(st, "_macos_plist_path", return_value=plist),
+                patch.object(st, "_launchctl_run") as m_lc,
+                patch.dict(
+                    os.environ, {"XPC_SERVICE_NAME": st.MACOS_LAUNCH_AGENT_LABEL}
+                ),
+            ):
+                st.apply_login_startup(False)
+
+            # Disabling from the agent-spawned process itself: booting the
+            # job out would quit the app; removing the plist is enough to
+            # stop the agent at the next login.
+            m_lc.assert_not_called()
+            self.assertFalse(os.path.exists(plist))
+
 
 class SyncFromConfigTests(unittest.TestCase):
     def test_delegates_to_apply(self):

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -272,7 +272,14 @@ class Backend(QObject):
         super().__init__(parent)
         self._engine = engine
         self._root_dir = root_dir or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        self._cfg = load_config()
+        # Share the engine's live config dict when one exists. Separate
+        # per-component copies previously let a stale holder clobber newer
+        # settings on its next whole-config save: changing the UI language
+        # (persisted by main_qml through a fresh load) was silently reverted
+        # to "en" the next time the Backend or Engine saved anything, and
+        # start_at_login was reverted the same way by Engine-side saves.
+        engine_cfg = getattr(engine, "cfg", None) if engine is not None else None
+        self._cfg = engine_cfg if isinstance(engine_cfg, dict) else load_config()
         self._mouse_connected = False
         self._device_display_name = "Logitech mouse"
         self._connected_device_key = ""


### PR DESCRIPTION
## Summary

Two fixes for bugs that are visible as "start-at-login never works on macOS" and "settings (e.g. UI language) revert to defaults after restart" (#157, #209). Both root causes are in code paths introduced by #39/#36 and not addressed by #174 (which surfaced registration errors but kept the unconditional reload and the stale-copy saves).

### 1. The login-started process killed itself (`core/startup.py`, `main_qml.py`)

On every launch the Backend startup sync calls `_apply_macos(True)`, which unconditionally reloaded the LaunchAgent (`bootout` + `bootstrap`) even when the on-disk plist already matched the desired state. When launchd itself had spawned Mouser (login start), the `bootout` SIGTERM'd the very process performing the sync: start-at-login appeared broken while `config.json` and the plist looked perfectly healthy (`start_at_login: true`, valid plist, job loaded, last exit code 0). The re-`bootstrap` also re-ran `RunAtLoad`, spawning a duplicate instance that popped the settings window before exiting through the single-instance lock.

Fix:

- Add `running_as_macos_launch_agent()`: detects the launchd-spawned case via `XPC_SERVICE_NAME` (launchd sets it to the job label for its children).
- The agent-spawned process never `bootout`s/`bootstrap`s its own job; a rewritten plist is picked up at the next login.
- An unchanged plist is a no-op when the job is already loaded (checked via `launchctl print`); `bootstrap` runs only when the job is missing from the session.
- A duplicate spawned by our own LaunchAgent exits quietly (no "show" message to the running instance), so a login start respects start-minimized instead of raising the settings window.

### 2. Stale config copies clobbered newer settings (`ui/backend.py`, `core/engine.py`, `main_qml.py`)

`Backend.__init__` loaded its own copy of `config.json` (`self._cfg = load_config()`) while the Engine held a separate dict. Every whole-config save from either holder wrote its stale snapshot over newer disk state. Changing the UI language (persisted by `main_qml` through yet another fresh load) was reverted to `"en"` by the next Backend/Engine save (e.g. the update-check state write, or a mouse-button-triggered save); `start_at_login` was reverted the same way by Engine-side saves, and the next startup sync then removed the login agent entirely. This half is platform-independent — #209 reports the identical language revert on Windows.

Fix:

- Backend adopts the Engine's live config dict when one exists (falls back to `load_config()` for engine-less construction).
- `Engine.reload_mappings` updates `self.cfg` in place (`clear()` + `update()`) instead of rebinding it, so shared references stay valid.
- `_save_language` writes through the Backend's live dict instead of a fresh load that the next stale save would clobber.

Fixes #157
Fixes #209

## Validation

- `python -m unittest discover -s tests` — 961 tests, no new failures (the 6 failures on my machine are pre-existing sandbox artifacts: 2x `~/Pictures/Screenshots` PermissionError, 4x MacOSSuppressionTests — identical on unmodified master).
- New tests:
  - `tests/test_startup.py` (6): no-op when the plist is unchanged and the job is loaded; no-op when running as the agent; bootstrap-only when the job is missing; plist rewrite without reload when running as the agent; disable skips `bootout` when running as the agent.
  - `tests/test_single_instance.py` (2): `send_activate=False` skips the write; a LaunchAgent duplicate exits 0 without "show".
  - `tests/test_backend.py`: `BackendConfigSharingTests` — Backend shares the Engine's dict (`assertIs`), engine-less fallback, a `zh` language setting survives a later Backend save.
  - `tests/test_engine.py`: `reload_mappings` updates `self.cfg` in place (`assertIs`).
- Manual end-to-end on macOS 15 (arm64), rebuilt with PyInstaller and installed into `/Applications`:
  - `launchctl kickstart` simulating a login start: the process survives (previously it died within ~1 s), `XPC_SERVICE_NAME` is set, PPID is 1, the job stays loaded, and no window is popped.
  - Switch language to Chinese → trigger mouse-button saves → quit and relaunch: the language persists.
