### PR TITLE
feat(haptic): Gesture Swipe Feedback for MX Master 4 gestures

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -295,6 +295,7 @@ DEFAULT_CONFIG = {
         "force_sensitivity": None,
         "actions_ring_hold_ms": 250,
         "actions_ring_hover_haptic": True,
+        "gesture_swipe_haptic": True,
         "actions_ring_use_global": True,
         "actions_ring_slots": _default_actions_ring_slots(),
     },
@@ -516,6 +517,12 @@ def set_button_haptic(cfg, button_key, enabled):
             lst.remove(button_key)
     save_config(cfg)
     return cfg
+
+
+def gesture_swipe_haptic_enabled(cfg):
+    """True if a haptic pulse fires the moment a gesture swipe direction is
+    recognized (independent of whether the direction is bound). Defaults on."""
+    return bool(cfg.get("settings", {}).get("gesture_swipe_haptic", True))
 
 
 def delete_profile(cfg, name):

--- a/core/engine.py
+++ b/core/engine.py
@@ -16,6 +16,7 @@ from core.config import (
     load_config, get_active_mappings, get_profile_for_app_identity,
     BUTTON_TO_EVENTS, BUTTON_HOLD_EVENTS, SWIPE_SET_FOR_TAP,
     save_config, action_haptic_enabled, button_haptic_enabled,
+    gesture_swipe_haptic_enabled,
     WHEEL_DIVERT_OFF, coerce_wheel_divert_setting,
     GESTURE_SWIPE_ACTION, BUTTON_GESTURE_OWNERS, BUTTON_GESTURE_DIRECTIONS,
     button_gesture_owners, button_gesture_bindings_for, button_gesture_tap_action,
@@ -228,6 +229,24 @@ class Engine:
         elif hasattr(self.hook, "configure_thumb_gestures"):
             # No secondary control on this device — keep it disabled.
             self.hook.configure_thumb_gestures(enabled=False)
+
+        # Gesture Swipe Feedback: a confirmation pulse the instant a swipe
+        # direction is recognized, for any direction (bound or not). Registered
+        # as an extra, non-consuming observer alongside any action handler; the
+        # toggle is read live in the handler so it applies without a rebind.
+        # Skipped when the control drives the Actions Ring instead of swipes.
+        swipe_haptic_events = set()
+        if _swipe_enabled(primary_tap_key) and not primary_ring:
+            prefix = "sense_swipe_" if via_sense else "gesture_swipe_"
+            swipe_haptic_events.update(
+                prefix + d for d in BUTTON_GESTURE_DIRECTIONS)
+        if (thumb_tap_key and _swipe_enabled(thumb_tap_key)
+                and mappings.get(thumb_tap_key) != "activate_actions_ring"):
+            # The thumb Gesture button always emits the gesture_swipe_* family.
+            swipe_haptic_events.update(
+                "gesture_swipe_" + d for d in BUTTON_GESTURE_DIRECTIONS)
+        for evt_type in swipe_haptic_events:
+            self.hook.register(evt_type, self._on_gesture_swipe_haptic)
 
         # Swipe-direction keys whose owning tap button is set to the Actions
         # Ring: their movement drives the ring, so the swipe events never fire
@@ -492,6 +511,15 @@ class Engine:
                 print(f"[Engine] _make_button_gesture_handler EXCEPTION: {exc}")
                 import traceback; traceback.print_exc()
         return handler
+
+    def _on_gesture_swipe_haptic(self, event):
+        """Non-consuming observer: play a confirmation pulse when a gesture
+        swipe direction is recognized, if Gesture Swipe Feedback is enabled.
+        Runs alongside any action handler bound to the same direction."""
+        if not self._enabled:
+            return
+        if gesture_swipe_haptic_enabled(self.cfg):
+            self._play_haptic_async(7)  # COMPLETED
 
     def _make_handler(self, action_id, btn_key=""):
         def handler(event):

--- a/tests/test_button_gestures.py
+++ b/tests/test_button_gestures.py
@@ -366,5 +366,79 @@ class EngineButtonGestureWiringTests(unittest.TestCase):
         self.assertNotIn("middle_down", engine.hook.registered)
 
 
+class EngineGestureSwipeHapticTests(unittest.TestCase):
+    """The dedicated 'Gesture Swipe Feedback' pulse fires the moment a swipe
+    direction is recognized, for any direction (bound or not), when the toggle
+    is on — independent of the per-action / per-button haptic allowlists."""
+
+    def _engine(self, mappings, *, via_sense=False,
+                supported_buttons=("gesture",)):
+        from core.engine import Engine
+        cfg = copy.deepcopy(DEFAULT_CONFIG)
+        cfg["profiles"]["default"]["mappings"].update(mappings)
+        with (
+            patch("core.engine.MouseHook", _RecordingHook),
+            patch("core.engine.AppDetector", _FakeAppDetector),
+            patch("core.engine.load_config", return_value=cfg),
+        ):
+            engine = Engine()
+        engine.hook.connected_device = SimpleNamespace(
+            supported_buttons=supported_buttons,
+            gesture_via_sense_panel=via_sense,
+        )
+        engine.hook.reset_bindings()
+        engine._setup_hooks()
+        return engine, cfg
+
+    def test_observer_registered_on_all_directions_in_swipe_mode(self):
+        engine, _ = self._engine({"gesture": "gesture_swipe"})
+        for d in ("left", "right", "up", "down"):
+            self.assertIn(f"gesture_swipe_{d}", engine.hook.registered)
+
+    def test_thumb_swipe_observer_on_sense_panel_device(self):
+        # MX Master 4: primary control is the Sense Panel; the thumb Gesture
+        # button emits the gesture_swipe_* family.
+        engine, _ = self._engine(
+            {"gesture": "gesture_swipe"}, via_sense=True,
+            supported_buttons=("gesture", "actions_ring"),
+        )
+        for d in ("left", "right", "up", "down"):
+            self.assertIn(f"gesture_swipe_{d}", engine.hook.registered)
+
+    def test_recognition_fires_pulse_when_enabled_even_if_unbound(self):
+        engine, _ = self._engine({"gesture": "gesture_swipe"})  # up is unbound
+        engine._enabled = True
+        handler = engine.hook.registered["gesture_swipe_up"]
+        with patch.object(engine, "_play_haptic_async") as ph:
+            handler(SimpleNamespace(
+                event_type="gesture_swipe_up", raw_data={}, timestamp=1.0))
+        ph.assert_called_once_with(7)
+
+    def test_no_pulse_when_toggle_off(self):
+        engine, cfg = self._engine({"gesture": "gesture_swipe"})
+        cfg["settings"]["gesture_swipe_haptic"] = False
+        engine.cfg = cfg
+        engine._enabled = True
+        handler = engine.hook.registered["gesture_swipe_up"]
+        with patch.object(engine, "_play_haptic_async") as ph:
+            handler(SimpleNamespace(
+                event_type="gesture_swipe_up", raw_data={}, timestamp=1.0))
+        ph.assert_not_called()
+
+    def test_no_pulse_when_engine_disabled(self):
+        engine, _ = self._engine({"gesture": "gesture_swipe"})
+        engine._enabled = False
+        handler = engine.hook.registered["gesture_swipe_up"]
+        with patch.object(engine, "_play_haptic_async") as ph:
+            handler(SimpleNamespace(
+                event_type="gesture_swipe_up", raw_data={}, timestamp=1.0))
+        ph.assert_not_called()
+
+    def test_no_observer_when_gesture_not_in_swipe_mode(self):
+        engine, _ = self._engine({"gesture": "middle_click"})
+        for d in ("left", "right", "up", "down"):
+            self.assertNotIn(f"gesture_swipe_{d}", engine.hook.registered)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -354,6 +354,18 @@ class ConfigMigrationTests(unittest.TestCase):
         self.assertTrue(config.action_haptic_enabled(cfg, "cycle_dpi"))
         self.assertFalse(config.action_haptic_enabled(cfg, "alt_tab"))
 
+    def test_gesture_swipe_haptic_defaults_on(self):
+        # Absent from config → on by default (matches Logi Options+ behaviour).
+        self.assertTrue(config.gesture_swipe_haptic_enabled({}))
+        self.assertTrue(
+            config.gesture_swipe_haptic_enabled(config.DEFAULT_CONFIG))
+
+    def test_gesture_swipe_haptic_reflects_setting(self):
+        self.assertFalse(config.gesture_swipe_haptic_enabled(
+            {"settings": {"gesture_swipe_haptic": False}}))
+        self.assertTrue(config.gesture_swipe_haptic_enabled(
+            {"settings": {"gesture_swipe_haptic": True}}))
+
     def test_set_action_haptic_adds_and_removes(self):
         cfg = {"settings": {"action_haptic": []}}
 

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -786,6 +786,11 @@ class Backend(QObject):
         return bool(self._cfg.get("settings", {}).get(
             "actions_ring_hover_haptic", True))
 
+    @Property(bool, notify=hapticChanged)
+    def gestureSwipeHaptic(self):
+        return bool(self._cfg.get("settings", {}).get(
+            "gesture_swipe_haptic", True))
+
     @Property(bool, notify=hidFeaturesReadyChanged)
     def forceSensingSupported(self):
         return self._engine.force_sensing_supported if self._engine else False
@@ -1780,6 +1785,15 @@ class Backend(QObject):
     def setActionsRingHoverHaptic(self, enabled):
         """Set whether landing on a ring slot fires haptic feedback."""
         self._cfg.setdefault("settings", {})["actions_ring_hover_haptic"] = bool(enabled)
+        save_config(self._cfg)
+        if self._engine:
+            self._engine.cfg = self._cfg
+        self.hapticChanged.emit()
+
+    @Slot(bool)
+    def setGestureSwipeHaptic(self, enabled):
+        """Set whether recognizing a gesture swipe direction fires haptic feedback."""
+        self._cfg.setdefault("settings", {})["gesture_swipe_haptic"] = bool(enabled)
         save_config(self._cfg)
         if self._engine:
             self._engine.cfg = self._cfg

--- a/ui/locale_manager.py
+++ b/ui/locale_manager.py
@@ -39,6 +39,8 @@ _TRANSLATIONS = {
         "haptic.buttons_empty": "No buttons selected. Pick from Available.",
         "haptic.dedup_title": "Prevent Duplicate Haptics",
         "haptic.dedup_desc": "When two haptic events fire close together, play only one pulse. Disable to allow both.",
+        "haptic.gesture_swipe_title": "Gesture Swipe Feedback",
+        "haptic.gesture_swipe_desc": "Fire a haptic pulse the moment a Gesture button swipe direction is recognized.",
         "haptic.experimental_note": "Haptic feedback support is experimental. Some settings may not take effect until the protocol is fully documented.",
 
         # Actions Ring page
@@ -315,6 +317,8 @@ _TRANSLATIONS = {
         "haptic.buttons_empty": "\u672a\u9009\u62e9\u4efb\u4f55\u6309\u952e\u3002\u8bf7\u4ece\u201c\u53ef\u9009\u201d\u4e2d\u6dfb\u52a0\u3002",
         "haptic.dedup_title": "\u9632\u6b62\u91cd\u590d\u89e6\u89c9",
         "haptic.dedup_desc": "\u5f53\u4e24\u4e2a\u89e6\u89c9\u4e8b\u4ef6\u77ed\u65f6\u95f4\u5185\u540c\u65f6\u89e6\u53d1\u65f6\uff0c\u4ec5\u64ad\u653e\u4e00\u6b21\u3002\u7981\u7528\u5219\u5141\u8bb8\u4e24\u6b21\u90fd\u89e6\u53d1\u3002",
+        "haptic.gesture_swipe_title": "\u624b\u52bf\u6ed1\u52a8\u53cd\u9988",
+        "haptic.gesture_swipe_desc": "\u8bc6\u522b\u5230\u624b\u52bf\u6309\u952e\u7684\u6ed1\u52a8\u65b9\u5411\u65f6\u7acb\u5373\u64ad\u653e\u4e00\u6b21\u89e6\u89c9\u8109\u51b2\u3002",
         "haptic.experimental_note": "\u89e6\u89c9\u53cd\u9988\u652f\u6301\u4e3a\u5b9e\u9a8c\u6027\u529f\u80fd\u3002\u90e8\u5206\u8bbe\u7f6e\u53ef\u80fd\u5728\u534f\u8bae\u5b8c\u5168\u6587\u6863\u5316\u540e\u624d\u751f\u6548\u3002",
 
         # Actions Ring page
@@ -577,6 +581,8 @@ _TRANSLATIONS = {
         "haptic.buttons_empty": "\u672a\u9078\u64c7\u4efb\u4f55\u6309\u9375\u3002\u8acb\u5f9e\u300c\u53ef\u9078\u300d\u4e2d\u52a0\u5165\u3002",
         "haptic.dedup_title": "\u9632\u6b62\u91cd\u8907\u89f8\u89ba",
         "haptic.dedup_desc": "\u7576\u5169\u500b\u89f8\u89ba\u4e8b\u4ef6\u77ed\u6642\u9593\u5167\u540c\u6642\u89f8\u767c\u6642\uff0c\u50c5\u64ad\u653e\u4e00\u6b21\u3002\u505c\u7528\u5247\u5141\u8a31\u5169\u6b21\u90fd\u89f8\u767c\u3002",
+        "haptic.gesture_swipe_title": "\u624b\u52e2\u6ed1\u52d5\u56de\u994b",
+        "haptic.gesture_swipe_desc": "\u8fa8\u8b58\u5230\u624b\u52e2\u6309\u9375\u7684\u6ed1\u52d5\u65b9\u5411\u6642\u7acb\u5373\u64ad\u653e\u4e00\u6b21\u89f8\u89ba\u8108\u885d\u3002",
         "haptic.experimental_note": "\u89f8\u89ba\u56de\u994b\u652f\u63f4\u70ba\u5be6\u9a57\u6027\u529f\u80fd\u3002\u90e8\u5206\u8a2d\u5b9a\u53ef\u80fd\u5728\u5354\u5b9a\u5b8c\u5168\u6587\u4ef6\u5316\u5f8c\u624d\u751f\u6548\u3002",
 
         # Actions Ring page

--- a/ui/qml/HapticPage.qml
+++ b/ui/qml/HapticPage.qml
@@ -842,6 +842,62 @@ Item {
 
             Item { width: 1; height: 16 }
 
+            // Gesture Swipe Feedback Toggle Card
+            Rectangle {
+                id: gestureSwipeCard
+                opacity: backend.hapticEnabled ? 1.0 : 0.4
+                Behavior on opacity { NumberAnimation { duration: 150 } }
+                width: parent.width - 72
+                anchors.horizontalCenter: parent.horizontalCenter
+                height: gestureSwipeRow.implicitHeight + 32
+                radius: Theme.radius
+                color: hapticPage.theme.bgCard
+                border.width: 1
+                border.color: hapticPage.theme.border
+
+                Column {
+                    id: gestureSwipeRow
+                    anchors {
+                        left: parent.left
+                        right: parent.right
+                        top: parent.top
+                        margins: 20
+                    }
+                    spacing: 6
+
+                    Row {
+                        width: parent.width
+
+                        Text {
+                            text: s["haptic.gesture_swipe_title"] || "Gesture Swipe Feedback"
+                            font { family: uiState.fontFamily; pixelSize: 14; bold: true }
+                            color: hapticPage.theme.textPrimary
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: parent.width - gestureSwipeSwitch.width
+                        }
+
+                        Switch {
+                            id: gestureSwipeSwitch
+                            checked: backend.gestureSwipeHaptic
+                            anchors.verticalCenter: parent.verticalCenter
+                            enabled: backend.hapticEnabled
+                            onToggled: backend.setGestureSwipeHaptic(checked)
+                        }
+                    }
+
+                    Text {
+                        text: s["haptic.gesture_swipe_desc"]
+                              || "Fire a haptic pulse the moment a Gesture button swipe direction is recognized."
+                        font { family: uiState.fontFamily; pixelSize: 12 }
+                        color: hapticPage.theme.textSecondary
+                        wrapMode: Text.WordWrap
+                        width: parent.width
+                    }
+                }
+            }
+
+            Item { width: 1; height: 16 }
+
             // ── Experimental Note ────────────────────────────────────
             Rectangle {
                 width: parent.width - 72


### PR DESCRIPTION
## Summary

Closes #283.

Adds haptic feedback when a **gesture-button swipe direction is recognized** on the MX Master 4 — matching Logi Options+. Previously, swiping executed the mapped action but gave no physical confirmation.

A new **"Gesture Swipe Feedback"** toggle on the Haptic page (default **on**) gates it and reuses the existing haptic level/pattern settings. It sits alongside the existing "Actions Ring Slot Feedback" toggle.

## How it works

The engine registers a non-consuming observer on the active swipe event families (`gesture_swipe_*` / `sense_swipe_*`). The pulse fires on **recognition** for any direction — bound or not — so it behaves like Options+, and the toggle is read live so it applies without a rebind. Fires waveform 7 (COMPLETED), the same pulse used on gesture resolution and ring execute.

## Changes

- `core/config.py` — `gesture_swipe_haptic` setting (default `True`) + `gesture_swipe_haptic_enabled()` helper.
- `core/engine.py` — recognition observer on the swipe event families.
- `ui/backend.py` — `gestureSwipeHaptic` property + `setGestureSwipeHaptic` slot.
- `ui/qml/HapticPage.qml` — the toggle card (mirrors the Actions Ring Slot Feedback card).
- `ui/locale_manager.py` — strings localized for `en`, `zh_CN`, `zh_TW`.
- Tests: 6 engine tests + 2 config tests.

## Testing

- Full suite (`unittest discover`) green except 4 pre-existing macOS `test_wheel_divert` failures unrelated to this change (confirmed identical on `master`).
- `qmllint` clean; `py_compile` clean.
- Built the native macOS bundle and manually verified: the toggle appears (default on), persists, localizes, and the pulse fires on swipe recognition on an MX Master 4.