### PR TITLE
feat(ui): add 4 vs 8 sector layout selector and dynamic Actions Ring slots

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1614,6 +1614,14 @@ class BackendListPropertyMemoizationTests(unittest.TestCase):
         backend.mappingsChanged.emit()
         self.assertIs(backend.profiles, first)
 
+    def test_known_apps_cache_not_invalidated_by_unrelated_signals(self):
+        backend = self._build()
+        first = backend.knownApps
+        backend.profilesChanged.emit()
+        backend.mappingsChanged.emit()
+        backend.deviceLayoutChanged.emit()
+        self.assertIs(backend.knownApps, first)
+
     def test_actions_ring_slot_count_and_resize(self):
         backend = self._build()
         # Default slots count

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1614,14 +1614,27 @@ class BackendListPropertyMemoizationTests(unittest.TestCase):
         backend.mappingsChanged.emit()
         self.assertIs(backend.profiles, first)
 
-    def test_known_apps_cache_not_invalidated_by_unrelated_signals(self):
+    def test_actions_ring_slot_count_and_resize(self):
         backend = self._build()
-        first = backend.knownApps
-        backend.profilesChanged.emit()
-        backend.mappingsChanged.emit()
-        backend.deviceLayoutChanged.emit()
-        self.assertIs(backend.knownApps, first)
+        # Default slots count
+        self.assertGreaterEqual(backend.actionsRingSlotCount, 4)
+        initial_slots = list(backend.actionsRingSlots)
+
+        # Expand to 8 slots
+        backend.setActionsRingSlotCount(8)
+        self.assertEqual(backend.actionsRingSlotCount, 8)
+        self.assertEqual(len(backend.actionsRingSlots), 8)
+        # Ensure previous slots were preserved
+        for i, s in enumerate(initial_slots):
+            self.assertEqual(backend.actionsRingSlots[i], s)
+
+        # Shrink to 4 slots
+        backend.setActionsRingSlotCount(4)
+        self.assertEqual(backend.actionsRingSlotCount, 4)
+        self.assertEqual(len(backend.actionsRingSlots), 4)
+        self.assertEqual(backend.actionsRingSlots[:4], initial_slots[:4])
 
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/ui/backend.py
+++ b/ui/backend.py
@@ -23,6 +23,7 @@ from core.config import (
     get_icon_for_exe, HAPTIC_ELIGIBLE_ACTIONS, set_action_haptic,
     set_button_haptic,
     GESTURE_SWIPE_ACTION, SWIPE_CAPABLE_BUTTONS, GESTURE_SWIPE_DIRECTIONS,
+    _default_actions_ring_slots,
 )
 from core import app_catalog
 from core.device_layouts import get_device_layout, get_manual_layout_choices
@@ -700,8 +701,12 @@ class Backend(QObject):
     @Property(list, notify=mappingsChanged)
     def actionsRingSlots(self):
         if self.actionsRingUseGlobal:
-            return list(self._cfg.get("settings", {}).get("actions_ring_slots", []))
-        return list(self._ring_slots_target_mappings().get("actions_ring_slots", []))
+            slots = self._cfg.get("settings", {}).get("actions_ring_slots")
+        else:
+            slots = self._ring_slots_target_mappings().get("actions_ring_slots")
+        if slots is None:
+            return list(_default_actions_ring_slots())
+        return list(slots)
 
     @Slot(list)
     def setActionsRingSlots(self, slots):
@@ -713,6 +718,29 @@ class Backend(QObject):
         self.mappingsChanged.emit()
         if self._engine:
             self._engine.reload_mappings()
+
+    @Property(int, notify=mappingsChanged)
+    def actionsRingSlotCount(self):
+        slots = self.actionsRingSlots
+        return len(slots) if slots else 4
+
+    @Slot(int)
+    def setActionsRingSlotCount(self, count):
+        count = max(2, min(16, int(count)))
+        current = list(self.actionsRingSlots)
+        if len(current) == count:
+            return
+        if len(current) < count:
+            default_slots = _default_actions_ring_slots()
+            while len(current) < count:
+                idx = len(current)
+                if idx < len(default_slots):
+                    current.append(default_slots[idx])
+                else:
+                    current.append("none")
+        else:
+            current = current[:count]
+        self.setActionsRingSlots(current)
 
     @Property(bool, notify=hidFeaturesReadyChanged)
     def hapticSupported(self):

--- a/ui/locale_manager.py
+++ b/ui/locale_manager.py
@@ -49,6 +49,10 @@ _TRANSLATIONS = {
         "ring.slots_title": "Ring Actions",
         "ring.slots_desc": "Choose the actions available in each sector of the radial menu",
         "ring.slot_prefix": "Slot ",
+        "ring.layout": "Ring Layout",
+        "ring.layout_desc": "Select the number of action sectors in the radial menu",
+        "ring.sectors_4": "4 Sectors",
+        "ring.sectors_8": "8 Sectors",
 
         # Mouse page — profile list
         "mouse.profiles": "Profiles",
@@ -325,6 +329,10 @@ _TRANSLATIONS = {
         "ring.slots_title": "\u73af\u5f62\u52a8\u4f5c",
         "ring.slots_desc": "\u9009\u62e9\u5f84\u5411\u83dc\u5355\u6bcf\u4e2a\u6247\u533a\u4e2d\u53ef\u7528\u7684\u52a8\u4f5c",
         "ring.slot_prefix": "\u4f4d\u7f6e ",
+        "ring.layout": "\u52a8\u4f5c\u73af\u5e03\u5c40",
+        "ring.layout_desc": "\u9009\u62e9\u5f84\u5411\u83dc\u5355\u4e2d\u7684\u6247\u533a\u6570\u91cf",
+        "ring.sectors_4": "4 \u4e2a\u6247\u533a",
+        "ring.sectors_8": "8 \u4e2a\u6247\u533a",
 
         "nav.actions_ring": "\u52a8\u4f5c\u73af",
         "nav.about": "\u5173\u4e8e",
@@ -587,6 +595,10 @@ _TRANSLATIONS = {
         "ring.slots_title": "\u74b0\u5f62\u52d5\u4f5c",
         "ring.slots_desc": "\u9078\u64c7\u5f91\u5411\u9078\u55ae\u6bcf\u500b\u6247\u5340\u4e2d\u53ef\u7528\u7684\u52d5\u4f5c",
         "ring.slot_prefix": "\u4f4d\u7f6e ",
+        "ring.layout": "\u52d5\u4f5c\u74b0\u7248\u9762\u914d\u7f6e",
+        "ring.layout_desc": "\u9078\u53d6\u5f91\u5411\u529f\u80fd\u8868\u4e2d\u7684\u6247\u5340\u6578\u91cf",
+        "ring.sectors_4": "4 \u500b\u6247\u5340",
+        "ring.sectors_8": "8 \u500b\u6247\u5340",
 
         "nav.actions_ring": "\u52d5\u4f5c\u74b0",
         "nav.about": "\u95dc\u65bc",

--- a/ui/qml/ActionsRingConfig.qml
+++ b/ui/qml/ActionsRingConfig.qml
@@ -368,14 +368,14 @@ Item {
 
                             Button {
                                 text: s["ring.sectors_4"] || "4 Sectors"
-                                highlighted: backend.actionsRingSlots.length === 4
+                                highlighted: backend.actionsRingSlotCount === 4
                                 Material.accent: actionsRingConfig.theme.accent
                                 onClicked: backend.setActionsRingSlotCount(4)
                             }
 
                             Button {
                                 text: s["ring.sectors_8"] || "8 Sectors"
-                                highlighted: backend.actionsRingSlots.length === 8
+                                highlighted: backend.actionsRingSlotCount === 8
                                 Material.accent: actionsRingConfig.theme.accent
                                 onClicked: backend.setActionsRingSlotCount(8)
                             }
@@ -438,7 +438,7 @@ Item {
                     }
 
                     Repeater {
-                        model: backend.actionsRingSlots.length || 4
+                        model: backend.actionsRingSlotCount
 
                         delegate: RowLayout {
                             width: slotsContent.width
@@ -446,7 +446,7 @@ Item {
 
                             Text {
                                 text: {
-                                    var dir = actionsRingConfig.getSectorDirectionName(index, backend.actionsRingSlots.length || 4)
+                                    var dir = actionsRingConfig.getSectorDirectionName(index, backend.actionsRingSlotCount)
                                     var prefix = (s["ring.slot_prefix"] || "Slot ") + (index + 1)
                                     return dir ? prefix + " (" + dir + ")" : prefix
                                 }

--- a/ui/qml/ActionsRingConfig.qml
+++ b/ui/qml/ActionsRingConfig.qml
@@ -37,12 +37,23 @@ Item {
         return 0
     }
 
+    function getSectorDirectionName(slotIndex, totalSlots) {
+        if (totalSlots === 4) {
+            var dir4 = ["Top", "Right", "Bottom", "Left"]
+            return slotIndex < dir4.length ? dir4[slotIndex] : ""
+        } else if (totalSlots === 8) {
+            var dir8 = ["Top", "Top-Right", "Right", "Bottom-Right", "Bottom", "Bottom-Left", "Left", "Top-Left"]
+            return slotIndex < dir8.length ? dir8[slotIndex] : ""
+        }
+        return ""
+    }
+
     function rebuildSlots(slotIndex, newActionId) {
         var current = backend.actionsRingSlots
         var slots = []
         for (var i = 0; i < current.length; i++)
             slots.push(current[i])
-        while (slots.length < 4)
+        while (slots.length <= slotIndex)
             slots.push("none")
         slots[slotIndex] = newActionId
         backend.setActionsRingSlots(slots)
@@ -319,6 +330,71 @@ Item {
 
             Item { width: 1; height: 16 }
 
+            // ── Ring Layout Card (4 vs 8 Sectors) ────────────────────
+            Rectangle {
+                width: parent.width - 72
+                anchors.horizontalCenter: parent.horizontalCenter
+                height: ringLayoutContent.implicitHeight + 40
+                radius: Theme.radius
+                color: actionsRingConfig.theme.bgCard
+                border.width: 1
+                border.color: actionsRingConfig.theme.border
+
+                Column {
+                    id: ringLayoutContent
+                    anchors {
+                        left: parent.left
+                        right: parent.right
+                        top: parent.top
+                        margins: 20
+                    }
+                    spacing: 12
+
+                    Row {
+                        width: parent.width
+
+                        Text {
+                            text: s["ring.layout"] || "Ring Layout"
+                            font { family: uiState.fontFamily; pixelSize: 16; bold: true }
+                            color: actionsRingConfig.theme.textPrimary
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: parent.width - layoutButtonsRow.width
+                        }
+
+                        Row {
+                            id: layoutButtonsRow
+                            spacing: 8
+                            anchors.verticalCenter: parent.verticalCenter
+
+                            Button {
+                                text: s["ring.sectors_4"] || "4 Sectors"
+                                highlighted: backend.actionsRingSlots.length === 4
+                                Material.accent: actionsRingConfig.theme.accent
+                                onClicked: backend.setActionsRingSlotCount(4)
+                            }
+
+                            Button {
+                                text: s["ring.sectors_8"] || "8 Sectors"
+                                highlighted: backend.actionsRingSlots.length === 8
+                                Material.accent: actionsRingConfig.theme.accent
+                                onClicked: backend.setActionsRingSlotCount(8)
+                            }
+                        }
+                    }
+
+                    Text {
+                        text: s["ring.layout_desc"]
+                              || "Select the number of action sectors in the radial menu"
+                        font { family: uiState.fontFamily; pixelSize: 12 }
+                        color: actionsRingConfig.theme.textSecondary
+                        wrapMode: Text.WordWrap
+                        width: parent.width
+                    }
+                }
+            }
+
+            Item { width: 1; height: 16 }
+
             // ── Ring Slot Editor Card ────────────────────────────────
             Rectangle {
                 width: parent.width - 72
@@ -362,15 +438,19 @@ Item {
                     }
 
                     Repeater {
-                        model: 4
+                        model: backend.actionsRingSlots.length || 4
 
                         delegate: RowLayout {
                             width: slotsContent.width
                             spacing: 12
 
                             Text {
-                                text: (s["ring.slot_prefix"] || "Slot ") + (index + 1)
-                                Layout.preferredWidth: 60
+                                text: {
+                                    var dir = actionsRingConfig.getSectorDirectionName(index, backend.actionsRingSlots.length || 4)
+                                    var prefix = (s["ring.slot_prefix"] || "Slot ") + (index + 1)
+                                    return dir ? prefix + " (" + dir + ")" : prefix
+                                }
+                                Layout.preferredWidth: 120
                                 font {
                                     family: uiState.fontFamily
                                     pixelSize: 12


### PR DESCRIPTION
## Summary

This PR resolves a discrepancy in the **Actions Ring** settings page where only 4 slot dropdowns were rendered in the UI, even though the underlying radial geometry engine (`core/actions_ring.py`) and screen overlay (`ui/actions_ring_overlay.py`) dynamically support 4, 8, or any $N$ sectors.

### Problem
- `ActionsRingConfig.qml` hardcoded `Repeater { model: 4 }` and padded slots arrays to 4 with `"none"`.
- Users with existing 8-sector configurations (or those wanting 8 radial shortcuts like Logitech Options+) had slots 5–8 hidden in the settings UI.

### Solution & Key Changes
1. **4 vs 8 Sector Layout Switcher**:
   - Added a **Ring Layout** card in `ActionsRingConfig.qml` with quick preset buttons for **4 Sectors** and **8 Sectors**.
   - Added localization strings in English, Simplified Chinese (`zh_CN`), and Traditional Chinese (`zh_TW`).
2. **Dynamic Slot Repeater & Directional Hints**:
   - Replaced static `model: 4` with dynamic `model: backend.actionsRingSlots.length || 4`.
   - Added spatial direction labels to slot headers (e.g. `Slot 1 (Top)`, `Slot 2 (Top-Right)`, `Slot 3 (Right)`, etc.) so users can immediately tell where each slot sits around the radial dial.
3. **Safe Backend Resizing (`ui/backend.py`)**:
   - Added `actionsRingSlotCount` property and `setActionsRingSlotCount(count)` slot to safely expand or shrink slot arrays without losing existing configured shortcuts.
4. **Unit Tests (`tests/test_backend.py`)**:
   - Added unit tests covering dynamic expansion to 8 slots, preservation of existing mappings, and shrinking back to 4 slots.

### Testing
- Verified `tests/test_backend.py`, `tests/test_actions_ring.py`, `tests/test_config.py`, and `tests/test_locale_manager.py` all pass cleanly with 100% test pass rate.
